### PR TITLE
feat(KNO-3495): Allow the usage of steps without a template in CLI

### DIFF
--- a/src/lib/marshal/workflow/reader.ts
+++ b/src/lib/marshal/workflow/reader.ts
@@ -199,68 +199,68 @@ const compileTemplateFiles = async (
       continue;
     }
 
-  if(step.template !== undefined){
-    if (!isPlainObject(step.template)) {
-      errors.push(
-        new JsonDataError(
-          "must be a template object",
-          objPath.to("template").str,
-        ),
-      );
-      continue;
-    }
-
-    // 3. For a given template, look for any extracted template content, read
-    // the extracted template files, then inline the content.
-    objPath.push("template");
-
-    for (const [field, val] of Object.entries(step.template)) {
-      if (field.startsWith("settings")) continue;
-      if (!FILEPATH_MARKED_RE.test(field)) continue;
-
-      const pathToFieldStr = objPath.to(field).str;
-
-      // eslint-disable-next-line no-await-in-loop
-      const [content, error] = await maybeReadTemplateFile(
-        val,
-        workflowDirCtx,
-        extractedFilePaths,
-        pathToFieldStr,
-      );
-      if (error) {
-        errors.push(error);
+    if (step.template !== undefined) {
+      if (!isPlainObject(step.template)) {
+        errors.push(
+          new JsonDataError(
+            "must be a template object",
+            objPath.to("template").str,
+          ),
+        );
         continue;
       }
 
-      const inlinePathStr = pathToFieldStr.replace(FILEPATH_MARKED_RE, "");
-      set(workflowJson, inlinePathStr, content);
-    }
+      // 3. For a given template, look for any extracted template content, read
+      // the extracted template files, then inline the content.
+      objPath.push("template");
 
-    if (!step.template.settings) continue;
-    objPath.push("settings");
+      for (const [field, val] of Object.entries(step.template)) {
+        if (field.startsWith("settings")) continue;
+        if (!FILEPATH_MARKED_RE.test(field)) continue;
 
-    for (const [field, val] of Object.entries(step.template.settings)) {
-      if (!FILEPATH_MARKED_RE.test(field)) continue;
+        const pathToFieldStr = objPath.to(field).str;
 
-      const pathToFieldStr = objPath.to(field).str;
+        // eslint-disable-next-line no-await-in-loop
+        const [content, error] = await maybeReadTemplateFile(
+          val,
+          workflowDirCtx,
+          extractedFilePaths,
+          pathToFieldStr,
+        );
+        if (error) {
+          errors.push(error);
+          continue;
+        }
 
-      // eslint-disable-next-line no-await-in-loop
-      const [content, error] = await maybeReadTemplateFile(
-        val,
-        workflowDirCtx,
-        extractedFilePaths,
-        pathToFieldStr,
-      );
-      if (error) {
-        errors.push(error);
-        continue;
+        const inlinePathStr = pathToFieldStr.replace(FILEPATH_MARKED_RE, "");
+        set(workflowJson, inlinePathStr, content);
       }
 
-      const inlinePathStr = pathToFieldStr.replace(FILEPATH_MARKED_RE, "");
-      set(workflowJson, inlinePathStr, content);
+      if (!step.template.settings) continue;
+      objPath.push("settings");
+
+      for (const [field, val] of Object.entries(step.template.settings)) {
+        if (!FILEPATH_MARKED_RE.test(field)) continue;
+
+        const pathToFieldStr = objPath.to(field).str;
+
+        // eslint-disable-next-line no-await-in-loop
+        const [content, error] = await maybeReadTemplateFile(
+          val,
+          workflowDirCtx,
+          extractedFilePaths,
+          pathToFieldStr,
+        );
+        if (error) {
+          errors.push(error);
+          continue;
+        }
+
+        const inlinePathStr = pathToFieldStr.replace(FILEPATH_MARKED_RE, "");
+        set(workflowJson, inlinePathStr, content);
+      }
     }
   }
-}
 
   return [workflowJson, errors];
 };


### PR DESCRIPTION
### Description
HTTP webhook steps uses the `channel_setting_overrides` of the channel as the `template`. This means it's now possible to have steps without a `template`, so we need to do some minor changes in order to support this.

### Tasks
[KNO-3495](https://linear.app/knock/issue/KNO-3495/[cli]-allow-creating-steps-without-a-template-in-the-payload)

### Screenshots
Example of a payload using two webhook channel steps, with and without a template.

![Screen Shot 2023-04-24 at 11 06 36](https://user-images.githubusercontent.com/67347884/234021424-50b809ab-cd3b-4511-a9d1-6146ab4ed99b.png)

