### PR TITLE
feat(kno-3544): add workflow run command

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -1,0 +1,47 @@
+import { Flags } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { commaSeparatedStr, jsonStr } from "@/lib/helpers/flag";
+import { withSpinner } from "@/lib/helpers/request";
+import { indentString } from "@/lib/helpers/string";
+
+export default class WorkflowRun extends BaseCommand {
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment in which to run the workflow",
+    }),
+    recipients: commaSeparatedStr({
+      required: true,
+      aliases: ["recipient"],
+      summary:
+        "One or more recipient ids for this workflow run, separated by comma.",
+    }),
+    actor: Flags.string({ summary: "An actor id for the workflow run." }),
+    tenant: Flags.string({
+      summary: "A tenant id for the workflow run.",
+    }),
+    data: jsonStr({
+      summary: "A JSON string of the data for this workflow",
+    }),
+  };
+
+  static args = [{ name: "workflowKey", required: true }];
+
+  async run(): Promise<void> {
+    const { args, flags } = this.props;
+
+    const resp = await withSpinner<ApiV1.RehearseWorkflowResp>(
+      () => {
+        return this.apiV1.runWorkflow(this.props);
+      },
+      { action: "‣ Running" },
+    );
+
+    this.log(
+      `‣ Successfully ran \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment`,
+    );
+    this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`), 4);
+  }
+}

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -113,6 +113,21 @@ export default class ApiV1 {
     return this.put(`/workflows/${args.workflowKey}/activate`, {}, { params });
   }
 
+  async runWorkflow({
+    args,
+    flags,
+  }: Props): Promise<AxiosResponse<ActivateWorkflowResp>> {
+    const params = prune({
+      environment: flags.environment,
+      recipients: flags.recipients,
+      tenant: flags.tenant,
+      data: flags.data,
+      actor: flags.actor,
+    });
+
+    return this.put(`/workflows/${args.workflowKey}/run`, {}, { params });
+  }
+
   // By resources: Commits
 
   async commitAllChanges({
@@ -245,6 +260,11 @@ export type ValidateWorkflowResp = {
 
 export type ActivateWorkflowResp = {
   workflow?: Workflow.WorkflowData;
+  errors?: InputError[];
+};
+
+export type RehearseWorkflowResp = {
+  workflow_run_id?: string;
   errors?: InputError[];
 };
 

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -5,6 +5,8 @@ import * as fs from "fs-extra";
 
 import { DirContext } from "@/lib/helpers/fs";
 
+import { AnyObj } from "./object";
+
 /*
  * Takes a flag input of 'true' or 'false' as a string, then cast to a boolean
  * value when parsing.
@@ -34,5 +36,25 @@ export const dirPath = Flags.custom<DirContext>({
     }
 
     return { abspath, exists };
+  },
+});
+
+/*
+ * Takes a flag input that's supposed to be a JSON string and validates it.
+ */
+export const jsonStr = Flags.custom<AnyObj>({
+  parse: async (input: string) => {
+    try {
+      const data = JSON.parse(input);
+      return data;
+    } catch {
+      throw new Error(`${input} is not a valid JSON string.`);
+    }
+  },
+});
+
+export const commaSeparatedStr = Flags.custom<string[]>({
+  parse: async (input: string) => {
+    return input.split(",").filter((x) => x);
   },
 });

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -1,0 +1,99 @@
+import { test } from "@oclif/test";
+import enquirer from "enquirer";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+const setupWithStub = (attrs = {}) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(
+      KnockApiV1.prototype,
+      "runWorkflow",
+      sinon.stub().resolves(factory.resp(attrs)),
+    )
+    .stub(
+      enquirer.prototype,
+      "prompt",
+      sinon.stub().onFirstCall().resolves({ input: "y" }),
+    );
+
+describe("commands/workflow/run", () => {
+  describe("given no workflow key arg", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command(["workflow run"])
+      .exit(2)
+      .it("exists with status 2");
+  });
+
+  describe("given no recipients flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command(["workflow run", "workflow-x"])
+      .exit(2)
+      .it("exists with status 2");
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipient flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        "alice",
+      ])
+      .it("calls apiV1 runWorkflow with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.runWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                "api-origin": undefined,
+                environment: "staging",
+                recipients: ["alice"],
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipients flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        "alice,barry",
+      ])
+      .it("calls apiV1 runWorkflow with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.runWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                "api-origin": undefined,
+                environment: "staging",
+                recipients: ["alice", "barry"],
+              }),
+          ),
+        );
+      });
+  });
+});


### PR DESCRIPTION
### Description
Allows a user to run a workflow stored on Knock from the CLI; doesn't include functionality to run a local workflow.

### Tasks
[KNO-3544](https://linear.app/knock/issue/KNO-3544/[cli]-add-workflow-run-command-for-test-running-a-workflow-from-cli)
