### PR TITLE
feat(kno-3591): run a local workflow

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -1,10 +1,14 @@
-import { Args, Flags } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatErrors } from "@/lib/helpers/error";
 import { jsonStr } from "@/lib/helpers/flag";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
+import * as Workflow from "@/lib/marshal/workflow";
+import { CommandTargetProps } from "@/lib/marshal/workflow";
 
 export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
   static summary =
@@ -15,13 +19,11 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       default: "development",
       summary: "The environment in which to run the workflow",
     }),
-    recipients: Flags.string({
+    recipients: CustomFlags.commaSeparatedStr({
       required: true,
       aliases: ["recipient"],
       summary:
         "One or more recipient ids for this workflow run, separated by comma.",
-      multiple: true,
-      delimiter: ",",
     }),
     actor: Flags.string({
       summary: "An actor id for the workflow run.",
@@ -31,6 +33,10 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
     }),
     data: jsonStr({
       summary: "A JSON string of the data for this workflow",
+    }),
+    local: Flags.boolean({
+      default: false,
+      summary: "Whether to use the local file version of this workflow",
     }),
   };
 
@@ -43,14 +49,45 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
   async run(): Promise<void> {
     const { args, flags } = this.props;
 
+    const workflow = flags.local ? await this.getWorkflowInput() : undefined;
+
     const resp = await withSpinner<ApiV1.RehearseWorkflowResp>(
-      () => this.apiV1.runWorkflow(this.props),
+      () => this.apiV1.runWorkflow(this.props, workflow),
       { action: "‣ Running" },
     );
 
     this.log(
       `‣ Successfully ran \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment`,
     );
-    this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`), 4);
+    this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`, 2));
+  }
+
+  async getWorkflowInput(): Promise<Workflow.WorkflowInput | undefined> {
+    const target = await Workflow.ensureValidCommandTarget(
+      this.props as CommandTargetProps,
+      this.runContext,
+    );
+
+    const { type: targetType, context: targetCtx } = target;
+
+    if (targetType !== "workflowDir") {
+      throw new Error(`Unsupported command target: ${target}`);
+    }
+
+    if (!targetCtx.exists) {
+      return ux.error(
+        `Cannot locate a workflow directory at \`${targetCtx.abspath}\``,
+      );
+    }
+
+    const [workflow, readErrors] = await Workflow.readWorkflowDir(targetCtx, {
+      withExtractedFiles: true,
+    });
+
+    if (readErrors.length > 0) {
+      return this.error(formatErrors(readErrors));
+    }
+
+    return workflow as Workflow.WorkflowInput;
   }
 }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -109,10 +109,10 @@ export default class ApiV1 {
     return this.put(`/workflows/${args.workflowKey}/activate`, {}, { params });
   }
 
-  async runWorkflow({
-    args,
-    flags,
-  }: Props): Promise<AxiosResponse<ActivateWorkflowResp>> {
+  async runWorkflow(
+    { args, flags }: Props,
+    workflow?: Workflow.WorkflowInput,
+  ): Promise<AxiosResponse<ActivateWorkflowResp>> {
     const params = prune({
       environment: flags.environment,
       recipients: flags.recipients,
@@ -121,7 +121,11 @@ export default class ApiV1 {
       actor: flags.actor,
     });
 
-    return this.put(`/workflows/${args.workflowKey}/run`, {}, { params });
+    return this.put(
+      `/workflows/${args.workflowKey}/run`,
+      { workflow },
+      { params },
+    );
   }
 
   // By resources: Commits

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -52,3 +52,12 @@ export const jsonStr = Flags.custom<AnyObj>({
     }
   },
 });
+
+/**
+ * Takes a string separated by commas and turns it into an array
+ */
+export const commaSeparatedStr = Flags.custom<string[]>({
+  parse: async (input: string) => {
+    return input.split(",").filter((x) => x);
+  },
+});

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -52,12 +52,3 @@ export const jsonStr = Flags.custom<AnyObj>({
     }
   },
 });
-
-/**
- * Takes a string separated by commas and turns it into an array
- */
-export const commaSeparatedStr = Flags.custom<string[]>({
-  parse: async (input: string) => {
-    return input.split(",").filter((x) => x);
-  },
-});

--- a/src/lib/marshal/workflow/helpers.ts
+++ b/src/lib/marshal/workflow/helpers.ts
@@ -166,10 +166,10 @@ export const formatStatus = (workflow: WorkflowData): string => {
  * Validate the provided args and flags with the current run context, to first
  * ensure the invoked command makes sense, and return the target context.
  */
-type CommandTargetProps = {
+export type CommandTargetProps = {
   flags: {
-    all: boolean | undefined;
-    "workflows-dir": DirContext | undefined;
+    all?: boolean | undefined;
+    "workflows-dir"?: DirContext | undefined;
   };
   args: {
     workflowKey: string | undefined;

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -148,7 +148,9 @@ describe("commands/workflow/run", () => {
                 local: true,
               }),
           ),
-          sinon.match((workflow) => isEqual(workflow, { name: "New comment" })),
+          sinon.match((workflow) =>
+            isEqual(workflow, { name: "New comment", key: "new-comment" }),
+          ),
         );
       });
   });


### PR DESCRIPTION
### Description
Run a local workflow rather than a remote workflow.

### Todos
- [ ] cut a new release of the CLI before we merge this
- [ ] handle the workflow logs in control before merging this

### Tasks
[KNO-3591](https://linear.app/knock/issue/KNO-3591/[cli]-run-a-local-workflow-rather-than-a-remote-one)
