### PR TITLE
chore: update node version in actions

### DIFF
--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.4.x"
+          node-version: lts/*
       - run: yarn
 
       - name: Pack tarball
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.4.x"
+          node-version: lts/*
           registry-url: "https://registry.npmjs.org"
           scope: "@knocklabs"
       - run: yarn


### PR DESCRIPTION
### Description
I think probably use the latest LTS version instead, which is what we have in the `on-pr-open` action.