### PR TITLE
chore: more clean ups in the action

### DIFF
--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
       - run: yarn
 
       - name: Pack tarball
@@ -25,7 +25,7 @@ jobs:
       - name: Upload tarball to the release
         run: gh release upload ${GITHUB_REF_NAME} ./dist/${{ steps.tarball.outputs.filename }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Just to ensure the uploaded tarball is available.
       - run: sleep 10s
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-brew]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
           registry-url: "https://registry.npmjs.org"
           scope: "@knocklabs"
       - run: yarn


### PR DESCRIPTION
### Description
A few tweaks in the release action:
* Update `actions/checkout@v2` and `actions/setup-node@v2` to v3, currently we get warnings in the action runs.
* Instead of `lts/*` from #171, set the node version to `>=18.0.0` so it's more predictable. This is the LTS version that is ["current"](https://nodejs.dev/en/about/releases/), and the same config documented in the `setup-node` action [doc](https://github.com/actions/setup-node) for v3.
* Set `GITHUB_TOKEN` var instead of `GH_TOKEN`. Both should work, but the former is what is documented in their [Github Actions doc](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows). 