### PR TITLE
fix: typo in the workflow run output

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -51,6 +51,6 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
     this.log(
       `‣ Successfully ran \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment`,
     );
-    this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`), 4);
+    this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`, 4));
   }
 }


### PR DESCRIPTION
### Description
Fixed the dangling `4` in the workflow run output message. 


### Screenshots
![CleanShot 2023-06-02 at 15 09 05@2x](https://github.com/knocklabs/knock-cli/assets/4471723/0abf8154-099c-4b51-8563-f9b453409f07)

