### PR TITLE
feat(KNO-3908): Allow rehearsing workflows using recipients/actors as maps

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
-import { jsonStr } from "@/lib/helpers/flag";
+import { commaSeparatedJsonStr, jsonStr } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
 
@@ -14,16 +14,14 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       default: "development",
       summary: "The environment in which to run the workflow",
     }),
-    recipients: Flags.string({
+    recipients: commaSeparatedJsonStr({
       required: true,
       aliases: ["recipient"],
       summary:
-        "One or more recipient ids for this workflow run, separated by comma.",
-      multiple: true,
-      delimiter: ",",
+        "A string containing mutiple JSON strings with the id (and an optional collection) for the recipients, separated by commas",
     }),
-    actor: Flags.string({
-      summary: "An actor id for the workflow run.",
+    actor: jsonStr({
+      summary: "A JSON string containing the id (and an optional collection) for the actor",
     }),
     tenant: Flags.string({
       summary: "A tenant id for the workflow run.",

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -25,8 +25,7 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
         "One or more recipient ids or JSON recipient objects for this workflow run, separated by comma.",
     }),
     actor: stringOrJsonString({
-      summary:
-        "An actor id or JSON object for the workflow run.",
+      summary: "An actor id or JSON object for the workflow run.",
     }),
     tenant: Flags.string({
       summary: "A tenant id for the workflow run.",

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -4,7 +4,7 @@ import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
 import {
   jsonStr,
-  stringOrJsonString,
+  maybeJsonStr,
   stringOrJsonStringList,
 } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
@@ -24,7 +24,7 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       summary:
         "One or more recipient ids or JSON recipient objects for this workflow run, separated by comma.",
     }),
-    actor: stringOrJsonString({
+    actor: maybeJsonStr({
       summary: "An actor id or JSON object for the workflow run.",
     }),
     tenant: Flags.string({

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -2,11 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
-import {
-  jsonStr,
-  maybeJsonStr,
-  maybeJsonStrAsList,
-} from "@/lib/helpers/flag";
+import { jsonStr, maybeJsonStr, maybeJsonStrAsList } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
 
@@ -22,10 +18,11 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       required: true,
       aliases: ["recipient"],
       summary:
-        "One or more recipient ids or JSON recipient objects for this workflow run, separated by comma.",
+        "One or more recipient user ids separated by comma, or a JSON string containing one or more recipient object references for this workflow run.",
     }),
     actor: maybeJsonStr({
-      summary: "An actor id or JSON object for the workflow run.",
+      summary:
+        "An actor id, or a JSON string of an actor object reference for the workflow run.",
     }),
     tenant: Flags.string({
       summary: "A tenant id for the workflow run.",

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -22,11 +22,11 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       required: true,
       aliases: ["recipient"],
       summary:
-        "A string containing mutiple JSON strings with the id (and an optional collection) for the recipients, separated by commas",
+        "One or more recipient ids or JSON recipient objects for this workflow run, separated by comma.",
     }),
     actor: stringOrJsonString({
       summary:
-        "A JSON string containing the id (and an optional collection) for the actor",
+        "An actor id or JSON object for the workflow run.",
     }),
     tenant: Flags.string({
       summary: "A tenant id for the workflow run.",

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -2,7 +2,11 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
-import { commaSeparatedJsonStr, jsonStr } from "@/lib/helpers/flag";
+import {
+  jsonStr,
+  stringOrJsonString,
+  stringOrJsonStringList,
+} from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
 
@@ -14,13 +18,13 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       default: "development",
       summary: "The environment in which to run the workflow",
     }),
-    recipients: commaSeparatedJsonStr({
+    recipients: stringOrJsonStringList({
       required: true,
       aliases: ["recipient"],
       summary:
         "A string containing mutiple JSON strings with the id (and an optional collection) for the recipients, separated by commas",
     }),
-    actor: jsonStr({
+    actor: stringOrJsonString({
       summary:
         "A JSON string containing the id (and an optional collection) for the actor",
     }),

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -21,7 +21,8 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
         "A string containing mutiple JSON strings with the id (and an optional collection) for the recipients, separated by commas",
     }),
     actor: jsonStr({
-      summary: "A JSON string containing the id (and an optional collection) for the actor",
+      summary:
+        "A JSON string containing the id (and an optional collection) for the actor",
     }),
     tenant: Flags.string({
       summary: "A tenant id for the workflow run.",

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -5,7 +5,7 @@ import BaseCommand from "@/lib/base-command";
 import {
   jsonStr,
   maybeJsonStr,
-  stringOrJsonStringList,
+  maybeJsonStrAsList,
 } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
@@ -18,7 +18,7 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       default: "development",
       summary: "The environment in which to run the workflow",
     }),
-    recipients: stringOrJsonStringList({
+    recipients: maybeJsonStrAsList({
       required: true,
       aliases: ["recipient"],
       summary:

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -115,13 +115,14 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ActivateWorkflowResp>> {
     const params = prune({
       environment: flags.environment,
+    });
+    const data = prune({
       recipients: flags.recipients,
       tenant: flags.tenant,
       data: flags.data,
       actor: flags.actor,
     });
-
-    return this.put(`/workflows/${args.workflowKey}/run`, {}, { params });
+    return this.put(`/workflows/${args.workflowKey}/run`, data, { params });
   }
 
   // By resources: Commits

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -57,7 +57,7 @@ export const jsonStr = Flags.custom<AnyObj>({
  * Takes a flag input that's supposed to be a string containing multiple JSON string
    and validates it.
  */
-export const commaSeparatedJsonStr = Flags.custom<string[]>({
+export const commaSeparatedJsonStr = Flags.custom<string>({
   parse: async (input: string) => {
     try {
       const jsonList = [];
@@ -80,7 +80,7 @@ export const commaSeparatedJsonStr = Flags.custom<string[]>({
         startIndex = endIndex + 1;
       }
 
-      return jsonList;
+      return JSON.stringify(jsonList);
     } catch (error_) {
       const error =
         error_ instanceof SyntaxError

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -64,27 +64,29 @@ export const commaSeparatedJsonStr = Flags.custom<string[]>({
       let startIndex = 0;
 
       while (startIndex < input.length) {
-        let endIndex = input.indexOf('}', startIndex);
+        let endIndex = input.indexOf("}", startIndex);
         if (endIndex === -1) {
-          throw new Error();
+          throw new SyntaxError("missing `}`");
         }
 
         // Adjust the end index to include the closing brace
         endIndex += 1;
 
-        const jsonObjectString = input.substring(startIndex, endIndex);
+        const jsonObjectString = input.slice(startIndex, endIndex);
         const jsonObject = JSON.parse(jsonObjectString);
         jsonList.push(jsonObject);
 
         // Move the start index to the next JSON string
         startIndex = endIndex + 1;
       }
+
       return jsonList;
-
-    } catch {
-      throw new Error(`${input} is not a valid JSON string.`);
+    } catch (error_) {
+      const error =
+        error_ instanceof SyntaxError
+          ? new Error(`${input} is not a valid JSON string, ${error_.message}`)
+          : new Error(`${input} is not a valid JSON string.`);
+      throw error;
     }
-
-  }
-
+  },
 });

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -5,6 +5,7 @@ import * as fs from "fs-extra";
 
 import { DirContext } from "@/lib/helpers/fs";
 
+import { tryJsonParse } from "./json";
 import { AnyObj } from "./object";
 
 /*
@@ -58,12 +59,7 @@ export const jsonStr = Flags.custom<AnyObj>({
  */
 export const maybeJsonStr = Flags.custom<AnyObj | string>({
   parse: async (input: string) => {
-    try {
-      const data = JSON.parse(input);
-      return data;
-    } catch {
-      return input;
-    }
+    return tryJsonParse(input);
   },
 });
 
@@ -91,5 +87,3 @@ export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
     }
   },
 });
-
-

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -81,7 +81,6 @@ export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
 /*
  * Takes a flag input that's supposed to be a string or a JSON string.
  */
-
 export const stringOrJsonString = Flags.custom<AnyObj>({
   parse: async (input: string) => {
     try {

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -56,7 +56,7 @@ export const jsonStr = Flags.custom<AnyObj>({
 /*
  * Takes a flag input that's supposed to be a string containing one of the following options:
   1) An ID
-  2) A list with multiple ID's separated by comma.
+  2) Multiple ID's separated by comma.
   3) A JSON string.
   4) A list with multiple JSON string separated by comma.
   5) A list with multiple JSON string + ID's, separated by comma.

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -80,7 +80,7 @@ export const commaSeparatedJsonStr = Flags.custom<string>({
         startIndex = endIndex + 1;
       }
 
-      return JSON.stringify(jsonList);
+      return jsonList;
     } catch (error_) {
       const error =
         error_ instanceof SyntaxError

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -61,7 +61,7 @@ export const jsonStr = Flags.custom<AnyObj>({
   4) A list with multiple JSON string separated by comma.
   5) A list with multiple JSON string + ID's, separated by comma.
 
-  Note: It Will always return a list.
+  Note: It will always return a list.
  */
 export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
   parse: async (input: string) => {

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -54,39 +54,41 @@ export const jsonStr = Flags.custom<AnyObj>({
 });
 
 /*
- * Takes a flag input that's supposed to be a string containing multiple JSON string
-   and validates it.
+ * Takes a flag input that's supposed to be a string containing one of the following options:
+  1) An ID
+  2) A list with multiple ID's separated by comma.
+  3) A JSON string.
+  4) A list with multiple JSON string separated by comma.
+  5) A list with multiple JSON string + ID's, separated by comma.
+
+  Note: It Will always return a list.
  */
-export const commaSeparatedJsonStr = Flags.custom<string>({
+export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
   parse: async (input: string) => {
     try {
-      const jsonList = [];
-      let startIndex = 0;
-
-      while (startIndex < input.length) {
-        let endIndex = input.indexOf("}", startIndex);
-        if (endIndex === -1) {
-          throw new SyntaxError("missing `}`");
-        }
-
-        // Adjust the end index to include the closing brace
-        endIndex += 1;
-
-        const jsonObjectString = input.slice(startIndex, endIndex);
-        const jsonObject = JSON.parse(jsonObjectString);
-        jsonList.push(jsonObject);
-
-        // Move the start index to the next JSON string
-        startIndex = endIndex + 1;
+      const data = JSON.parse(input);
+      if (!Array.isArray(data)) {
+        return [data];
       }
 
-      return jsonList;
-    } catch (error_) {
-      const error =
-        error_ instanceof SyntaxError
-          ? new Error(`${input} is not a valid JSON string, ${error_.message}`)
-          : new Error(`${input} is not a valid JSON string.`);
-      throw error;
+      return data;
+    } catch {
+      return input.split(",");
+    }
+  },
+});
+
+/*
+ * Takes a flag input that's supposed to be a string or a JSON string.
+ */
+
+export const stringOrJsonString = Flags.custom<AnyObj>({
+  parse: async (input: string) => {
+    try {
+      const data = JSON.parse(input);
+      return data;
+    } catch {
+      return input;
     }
   },
 });

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -73,7 +73,7 @@ export const maybeJsonStr = Flags.custom<AnyObj | string>({
 
   Note: It will always return a list.
  */
-export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
+export const maybeJsonStrAsList = Flags.custom<AnyObj[]>({
   parse: async (input: string) => {
     try {
       const data = JSON.parse(input);

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -54,6 +54,20 @@ export const jsonStr = Flags.custom<AnyObj>({
 });
 
 /*
+ * Takes a flag input that's supposed to be a string or a JSON string.
+ */
+export const maybeJsonStr = Flags.custom<AnyObj | string>({
+  parse: async (input: string) => {
+    try {
+      const data = JSON.parse(input);
+      return data;
+    } catch {
+      return input;
+    }
+  },
+});
+
+/*
  * Takes a flag input that's supposed to be a string containing one of the following options:
   1) An ID
   2) Multiple ID's separated by comma.
@@ -78,16 +92,4 @@ export const stringOrJsonStringList = Flags.custom<AnyObj[]>({
   },
 });
 
-/*
- * Takes a flag input that's supposed to be a string or a JSON string.
- */
-export const stringOrJsonString = Flags.custom<AnyObj>({
-  parse: async (input: string) => {
-    try {
-      const data = JSON.parse(input);
-      return data;
-    } catch {
-      return input;
-    }
-  },
-});
+

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -70,15 +70,9 @@ export const maybeJsonStr = Flags.custom<AnyObj | string>({
  */
 export const maybeJsonStrAsList = Flags.custom<AnyObj[] | string[]>({
   parse: async (input: string) => {
-    try {
-      const data = JSON.parse(input);
-      if (!Array.isArray(data)) {
-        return [data];
-      }
-
-      return data;
-    } catch {
-      return input.split(",");
-    }
+    const data = tryJsonParse(input);
+    if (typeof data === "string") return data.split(",");
+    if (Array.isArray(data)) return data;
+    return [data];
   },
 });

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -55,7 +55,8 @@ export const jsonStr = Flags.custom<AnyObj>({
 });
 
 /*
- * Takes a flag input that's supposed to be a string or a JSON string.
+ * Takes a flag input that can be a valid json or an arbitrary string,
+ * tries parsing it before returning it.
  */
 export const maybeJsonStr = Flags.custom<AnyObj | string>({
   parse: async (input: string) => {
@@ -64,14 +65,8 @@ export const maybeJsonStr = Flags.custom<AnyObj | string>({
 });
 
 /*
- * Takes a flag input that's supposed to be a string containing one of the following options:
-  1) An ID
-  2) Multiple ID's separated by comma.
-  3) A JSON string.
-  4) A list with multiple JSON string separated by comma.
-  5) A list with multiple JSON string + ID's, separated by comma.
-
-  Note: It will always return a list.
+ * Takes a flag input that can be a valid json or an arbitrary comma separate-able string,
+ * tries parsing the string then always returns the result as a list.
  */
 export const maybeJsonStrAsList = Flags.custom<AnyObj[]>({
   parse: async (input: string) => {

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -68,7 +68,7 @@ export const maybeJsonStr = Flags.custom<AnyObj | string>({
  * Takes a flag input that can be a valid json or an arbitrary comma separate-able string,
  * tries parsing the string then always returns the result as a list.
  */
-export const maybeJsonStrAsList = Flags.custom<AnyObj[]>({
+export const maybeJsonStrAsList = Flags.custom<AnyObj[] | string[]>({
   parse: async (input: string) => {
     try {
       const data = JSON.parse(input);

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -52,3 +52,39 @@ export const jsonStr = Flags.custom<AnyObj>({
     }
   },
 });
+
+/*
+ * Takes a flag input that's supposed to be a string containing multiple JSON string
+   and validates it.
+ */
+export const commaSeparatedJsonStr = Flags.custom<string[]>({
+  parse: async (input: string) => {
+    try {
+      const jsonList = [];
+      let startIndex = 0;
+
+      while (startIndex < input.length) {
+        let endIndex = input.indexOf('}', startIndex);
+        if (endIndex === -1) {
+          throw new Error();
+        }
+
+        // Adjust the end index to include the closing brace
+        endIndex += 1;
+
+        const jsonObjectString = input.substring(startIndex, endIndex);
+        const jsonObject = JSON.parse(jsonObjectString);
+        jsonList.push(jsonObject);
+
+        // Move the start index to the next JSON string
+        startIndex = endIndex + 1;
+      }
+      return jsonList;
+
+    } catch {
+      throw new Error(`${input} is not a valid JSON string.`);
+    }
+
+  }
+
+});

--- a/src/lib/helpers/json.ts
+++ b/src/lib/helpers/json.ts
@@ -33,9 +33,9 @@ export const parseJson = (json: string): ParseJsonResult => {
 };
 
 /*
-* Tries to parse a json string and returns the parsed JSON object if successful,
-  otherwise returns the original string.
-*/
+ * Tries to parse a json string and returns the parsed JSON object if successful,
+ * otherwise returns the original string.
+ */
 type MaybeParseJsonResult = ParsedJson | string;
 export const tryJsonParse = (maybeJson: string): MaybeParseJsonResult => {
   try {

--- a/src/lib/helpers/json.ts
+++ b/src/lib/helpers/json.ts
@@ -33,6 +33,20 @@ export const parseJson = (json: string): ParseJsonResult => {
 };
 
 /*
+* Tries to parse a json string and returns the parsed JSON object if successful,
+  otherwise returns the original string.
+*/
+type MaybeParseJsonResult = ParsedJson | string;
+export const tryJsonParse = (maybeJson: string): MaybeParseJsonResult => {
+  try {
+    const data = JSON.parse(maybeJson);
+    return data;
+  } catch {
+    return maybeJson;
+  }
+};
+
+/*
  * Reads a JSON file and then parses it into an object.
  *
  * Like the `readJson` method of `fs-extra`, but parse with jsonlint instead

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -46,7 +46,7 @@ describe("commands/workflow/run", () => {
         "--environment",
         "staging",
         "--recipient",
-        "alice",
+        '{"id": "alice"}',
       ])
       .it("calls apiV1 runWorkflow with expected props", () => {
         sinon.assert.calledWith(
@@ -80,7 +80,7 @@ describe("commands/workflow/run", () => {
         "--environment",
         "staging",
         "--recipient",
-        "alice,barry",
+        '{"id": "alice"}, {"id": "object", "collection": "projects-1"}',
       ])
       .it("calls apiV1 runWorkflow with expected props", () => {
         sinon.assert.calledWith(

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -46,29 +46,135 @@ describe("commands/workflow/run", () => {
         "--environment",
         "staging",
         "--recipient",
-        '{"id": "alice"}',
+        "user1",
       ])
-      .it("calls apiV1 runWorkflow with expected props", () => {
-        sinon.assert.calledWith(
-          KnockApiV1.prototype.runWorkflow as any,
-          sinon.match(
-            ({ args, flags }) =>
-              isEqual(args, {
-                workflowKey: "workflow-x",
-              }) &&
-              isEqual(flags, {
-                "service-token": "valid-token",
-                "api-origin": undefined,
-                environment: "staging",
-                recipients: JSON.stringify([
-                  {
-                    id: "alice",
-                  },
-                ]),
-              }),
-          ),
-        );
-      });
+      .it(
+        "calls apiV1 runWorkflow with expected props (recipient as a string)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: ["user1"],
+                }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipient flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        "alice,barry",
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected props (recipient as a list of string)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: ["alice", "barry"],
+                }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipient flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        '{"id": "user1"}',
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected props (recipient as a JSON",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: [{ id: "user1" }],
+                }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipient flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        '[{"id": "alice"}, {"id": "object-1", "collection": "project-1"}]',
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected props (recipient as a list of JSON)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: [
+                    {
+                      id: "alice",
+                    },
+                    {
+                      id: "object-1",
+                      collection: "project-1",
+                    },
+                  ],
+                }),
+            ),
+          );
+        },
+      );
   });
 
   describe("given the workflow key arg, the environment flag and the recipients flag", () => {
@@ -80,32 +186,103 @@ describe("commands/workflow/run", () => {
         "--environment",
         "staging",
         "--recipient",
-        '{"id": "alice"}, {"id": "object", "collection": "projects-1"}',
+        '["alice",{"id": "object-1", "collection": "projects"}, {"id": "bruce"}]',
       ])
-      .it("calls apiV1 runWorkflow with expected props", () => {
-        sinon.assert.calledWith(
-          KnockApiV1.prototype.runWorkflow as any,
-          sinon.match(
-            ({ args, flags }) =>
-              isEqual(args, {
-                workflowKey: "workflow-x",
-              }) &&
-              isEqual(flags, {
-                "service-token": "valid-token",
-                "api-origin": undefined,
-                environment: "staging",
-                recipients: JSON.stringify([
-                  {
-                    id: "alice",
-                  },
-                  {
-                    id: "object",
-                    collection: "projects-1",
-                  },
-                ]),
-              }),
-          ),
-        );
-      });
+      .it(
+        "calls apiV1 runWorkflow with expected props, (recipient as a list containing JSON + ID's)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: [
+                    "alice",
+                    { id: "object-1", collection: "projects" },
+                    { id: "bruce" },
+                  ],
+                }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipients flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        "alice",
+        "--actor",
+        "bruce",
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected props, (actor as a string)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: ["alice"],
+                  actor: "bruce",
+                }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given the workflow key arg, the environment flag and the recipients flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--recipient",
+        "alice",
+        "--actor",
+        '{"id": "object-1", "collection": "projects"}',
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected props, (actor as a JSON)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  "api-origin": undefined,
+                  environment: "staging",
+                  recipients: ["alice"],
+                  actor: { id: "object-1", collection: "projects" },
+                }),
+            ),
+          );
+        },
+      );
   });
 });

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -60,7 +60,11 @@ describe("commands/workflow/run", () => {
                 "service-token": "valid-token",
                 "api-origin": undefined,
                 environment: "staging",
-                recipients: ["alice"],
+                recipients: [
+                  {
+                    "id": "alice",
+                  }
+                ],
               }),
           ),
         );
@@ -90,7 +94,15 @@ describe("commands/workflow/run", () => {
                 "service-token": "valid-token",
                 "api-origin": undefined,
                 environment: "staging",
-                recipients: ["alice", "barry"],
+                recipients: [
+                  {
+                    "id": "alice",
+                  },
+                  {
+                    "id": "object",
+                    "collection": "projects-1"
+                  }
+                ],
               }),
           ),
         );

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -62,8 +62,8 @@ describe("commands/workflow/run", () => {
                 environment: "staging",
                 recipients: [
                   {
-                    "id": "alice",
-                  }
+                    id: "alice",
+                  },
                 ],
               }),
           ),
@@ -96,12 +96,12 @@ describe("commands/workflow/run", () => {
                 environment: "staging",
                 recipients: [
                   {
-                    "id": "alice",
+                    id: "alice",
                   },
                   {
-                    "id": "object",
-                    "collection": "projects-1"
-                  }
+                    id: "object",
+                    collection: "projects-1",
+                  },
                 ],
               }),
           ),

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -60,11 +60,11 @@ describe("commands/workflow/run", () => {
                 "service-token": "valid-token",
                 "api-origin": undefined,
                 environment: "staging",
-                recipients: [
+                recipients: JSON.stringify([
                   {
                     id: "alice",
                   },
-                ],
+                ]),
               }),
           ),
         );
@@ -94,7 +94,7 @@ describe("commands/workflow/run", () => {
                 "service-token": "valid-token",
                 "api-origin": undefined,
                 environment: "staging",
-                recipients: [
+                recipients: JSON.stringify([
                   {
                     id: "alice",
                   },
@@ -102,7 +102,7 @@ describe("commands/workflow/run", () => {
                     id: "object",
                     collection: "projects-1",
                   },
-                ],
+                ]),
               }),
           ),
         );

--- a/test/lib/marshal/workflow/generator.test.ts
+++ b/test/lib/marshal/workflow/generator.test.ts
@@ -140,6 +140,7 @@ describe("lib/marshal/workflow/generator", () => {
                     unit: "seconds",
                     value: 30,
                   },
+                  batch_window_type: "sliding",
                 },
               },
               {


### PR DESCRIPTION
### Description
The recipient list will start receiving a string containing multiple JSON strings separated by commas. These JSON strings must contain an `id` and can have an optional `collection`, so users can use objects as the recipients/actor.

The same for the actor, this will now receive a JSON string with the required data.

Backend changes: https://github.com/knocklabs/control/pull/2218

### Tasks
[KNO-3908](https://linear.app/knock/issue/KNO-3908/[cli]-rehearse-workflows-using-objects)


