### PR TITLE
feat(kno-3983): add batch window extension limit to summary

### DIFF
--- a/src/lib/marshal/workflow/helpers.ts
+++ b/src/lib/marshal/workflow/helpers.ts
@@ -97,6 +97,7 @@ const batchStepSummaryLines = (step: WorkflowStepData) => {
     batch_key,
     batch_window_type,
     batch_window: duration,
+    batch_window_extension_limit,
     batch_until_field_path: field_path,
     batch_order,
   } = step.settings;
@@ -106,6 +107,8 @@ const batchStepSummaryLines = (step: WorkflowStepData) => {
     duration && `Batch window: ${duration.value} ${duration.unit}`,
     field_path && `Batch window: "${field_path}"`,
     `Batch window type: ${batch_window_type}`,
+    batch_window_extension_limit &&
+      `Batch window extension limit: ${batch_window_extension_limit.value} ${batch_window_extension_limit.unit}`,
     `Batch order: ${batch_order}`,
   ];
 };

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -49,6 +49,7 @@ type BatchStepSettings = {
   batch_window?: Duration;
   batch_window_type: "fixed" | "sliding";
   batch_order: "asc" | "desc";
+  batch_window_extension_limit?: Duration;
 };
 
 type BatchStepData = WorkflowStepBase & {


### PR DESCRIPTION
### Description
Display batch window extension limit on batch step summary

### Tasks
[KNO-3983](https://linear.app/knock/issue/KNO-3983/[cli]-add-batch-extension-limit-to-summary)