### PR TITLE
chore: rename "if else" step to "branch" step

### DIFF
--- a/src/commands/workflow/get.ts
+++ b/src/commands/workflow/get.ts
@@ -161,7 +161,7 @@ export default class WorkflowGet extends BaseCommand<typeof WorkflowGet> {
       conditions: {
         header: "Conditions",
         get: (step) => {
-          if (step.type === Workflow.StepType.IfElse) return "-";
+          if (step.type === Workflow.StepType.Branch) return "-";
           if (!step.conditions) return "-";
 
           return Conditions.formatConditions(step.conditions);
@@ -169,11 +169,11 @@ export default class WorkflowGet extends BaseCommand<typeof WorkflowGet> {
       },
     });
 
-    const hasTopLevelIfElseStep = workflow.steps.some(
-      (step) => step.type === Workflow.StepType.IfElse,
+    const hasTopLevelBranchStep = workflow.steps.some(
+      (step) => step.type === Workflow.StepType.Branch,
     );
 
-    const dashboardLinkMessage = hasTopLevelIfElseStep
+    const dashboardLinkMessage = hasTopLevelBranchStep
       ? `\n‣ This workflow has branches with nested steps, view the full workflow tree in the Knock Dashboard:`
       : `\n‣ View the full workflow in the Knock Dashboard:`;
 

--- a/src/lib/marshal/workflow/helpers.ts
+++ b/src/lib/marshal/workflow/helpers.ts
@@ -131,8 +131,8 @@ const throttleStepSummaryLines = (step: WorkflowStepData) => {
   ];
 };
 
-const ifElseStepSummaryLines = (step: WorkflowStepData) => {
-  if (step.type !== StepType.IfElse) return [];
+const branchStepSummaryLines = (step: WorkflowStepData) => {
+  if (step.type !== StepType.Branch) return [];
 
   let stepsCount = 0;
 
@@ -182,7 +182,7 @@ export const formatStepSummary = (step: WorkflowStepData): string => {
     ...batchStepSummaryLines(step),
     ...delayStepSummaryLines(step),
     ...httpFetchStepSummaryLines(step),
-    ...ifElseStepSummaryLines(step),
+    ...branchStepSummaryLines(step),
     ...throttleStepSummaryLines(step),
 
     // Extra line between step rows to make it easier on the eye.
@@ -297,7 +297,7 @@ const doCountSteps = (steps: WorkflowStepData[]): number => {
   for (const step of steps) {
     count += 1;
 
-    if (step.type === StepType.IfElse) {
+    if (step.type === StepType.Branch) {
       for (const branch of step.branches) {
         count += doCountSteps(branch.steps);
       }

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -13,7 +13,7 @@ export enum StepType {
   Batch = "batch",
   Delay = "delay",
   HttpFetch = "http_fetch",
-  IfElse = "if_else",
+  Branch = "branch",
   Throttle = "throttle",
 }
 
@@ -99,7 +99,7 @@ type HttpFetchStepData = WorkflowStepBase & {
   settings: HttpFetchStepSettings;
 };
 
-/* If-else step */
+/* Branch step */
 
 type WorkflowBranch<A extends MaybeWithAnnotation = unknown> = {
   name: string;
@@ -108,11 +108,11 @@ type WorkflowBranch<A extends MaybeWithAnnotation = unknown> = {
   steps: WorkflowStepData<A>[];
 };
 
-type IfElseStepData<A extends MaybeWithAnnotation = unknown> = Omit<
+type BranchStepData<A extends MaybeWithAnnotation = unknown> = Omit<
   WorkflowStepBase,
   "conditions"
 > & {
-  type: StepType.IfElse;
+  type: StepType.Branch;
   branches: WorkflowBranch<A>[];
 };
 
@@ -123,7 +123,7 @@ export type WorkflowStepData<A extends MaybeWithAnnotation = unknown> =
   | BatchStepData
   | DelayStepData
   | HttpFetchStepData
-  | IfElseStepData<A>
+  | BranchStepData<A>
   | ThrottleStepData;
 
 export type WorkflowData<A extends MaybeWithAnnotation = unknown> = A & {

--- a/src/lib/marshal/workflow/writer.ts
+++ b/src/lib/marshal/workflow/writer.ts
@@ -229,7 +229,7 @@ const keyLocalWorkflowStepsByRef = (
 
     result[step.ref] = step;
 
-    if (step.type === StepType.IfElse && Array.isArray(step.branches)) {
+    if (step.type === StepType.Branch && Array.isArray(step.branches)) {
       for (const branch of step.branches) {
         if (!isPlainObject(branch)) continue;
 
@@ -322,7 +322,7 @@ const recursivelyBuildWorkflowDirBundle = (
     }
 
     // Lastly, recurse thru any branches that exist in the workflow tree
-    if (step.type === StepType.IfElse) {
+    if (step.type === StepType.Branch) {
       for (const branch of step.branches) {
         recursivelyBuildWorkflowDirBundle(
           bundle,

--- a/test/lib/marshal/workflow/writer.test.ts
+++ b/test/lib/marshal/workflow/writer.test.ts
@@ -75,8 +75,8 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
       },
     },
     {
-      ref: "if_else_1",
-      type: StepType.IfElse,
+      ref: "branch_1",
+      type: StepType.Branch,
       branches: [
         {
           name: "Branch 1",
@@ -84,7 +84,7 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
           conditions: {
             all: [
               {
-                variable: "data.if_else_1_enabled",
+                variable: "data.branch_1_enabled",
                 operator: "equal_to",
                 argument: "true",
               },
@@ -404,8 +404,8 @@ describe("lib/marshal/workflow/writer", () => {
                 },
               },
               {
-                ref: "if_else_1",
-                type: StepType.IfElse,
+                ref: "branch_1",
+                type: StepType.Branch,
                 branches: [
                   {
                     name: "Branch 1",
@@ -413,7 +413,7 @@ describe("lib/marshal/workflow/writer", () => {
                     conditions: {
                       all: [
                         {
-                          variable: "data.if_else_1_enabled",
+                          variable: "data.branch_1_enabled",
                           operator: "equal_to",
                           argument: "true",
                         },
@@ -541,8 +541,8 @@ describe("lib/marshal/workflow/writer", () => {
                 },
               },
               {
-                ref: "if_else_1",
-                type: StepType.IfElse,
+                ref: "branch_1",
+                type: StepType.Branch,
                 branches: [
                   {
                     name: "Branch 1",
@@ -550,7 +550,7 @@ describe("lib/marshal/workflow/writer", () => {
                     conditions: {
                       all: [
                         {
-                          variable: "data.if_else_1_enabled",
+                          variable: "data.branch_1_enabled",
                           operator: "equal_to",
                           argument: "true",
                         },


### PR DESCRIPTION
### Description
Based on the live discussion last week, we are renaming "if-else" step to "branch" step.

This PR only contains diffs from searching and replacing of `if-else`s or `if_else`s with `branch`s.

### Tasks
[KNO-4102](https://linear.app/knock/issue/KNO-4102/[control]-rename-if-else-step-to-branch-step-everywhere)
