### PR TITLE
feat(kno-4256): show number of changed and unchanged translations on push

### DIFF
--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -271,6 +271,7 @@ export type ListTranslationResp = PaginatedResp<Translation.TranslationData>;
 export type GetTranslationResp = Translation.TranslationData;
 
 export type UpsertTranslationResp = {
+  had_changes: boolean;
   translation?: Translation.TranslationData;
   errors?: InputError[];
 };

--- a/test/commands/translation/push.test.ts
+++ b/test/commands/translation/push.test.ts
@@ -41,7 +41,7 @@ describe("commands/translation/push", () => {
       process.chdir(translationsDir);
     });
 
-    setupWithStub()
+    setupWithStub({ data: { had_changes: true } })
       .stdout()
       .command(["translation push", "admin.en"])
       .it("calls apiV1 upsertTranslation with expected props", () => {
@@ -62,7 +62,7 @@ describe("commands/translation/push", () => {
         );
       });
 
-    setupWithStub()
+    setupWithStub({ data: { had_changes: true } })
       .stdout()
       .command([
         "translation push",
@@ -214,7 +214,7 @@ describe("commands/translation/push", () => {
       process.chdir(sandboxDir);
     });
 
-    setupWithStub()
+    setupWithStub({ data: { had_changes: true } })
       .stdout()
       .command([
         "translation push",


### PR DESCRIPTION
### Description
Relies on https://github.com/knocklabs/control/pull/2399 to be approved.

Given that the API will return `had_changes`: `boolean` for every translation pushed up, surfaces a message to the user about how many successfully updated.

### Tasks
[KNO-4256](https://linear.app/knock/issue/KNO-4256/surface-message-in-cli-about-which-translations-were-updated)

### TO DO
- [x] Fix tests

### Screenshots
![image](https://github.com/knocklabs/knock-cli/assets/24256463/02e9d0f3-d856-4445-af7b-536cb9b04305)

