### PR TITLE
feat(KNO-4367): Add pull email layout command

### DIFF
--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -42,6 +42,7 @@ export default class EmailLayoutPull extends BaseCommand<
     "layout-dir": CustomFlags.dirPath({
       summary: "The target directory path to pull all email layouts into.",
       dependsOn: ["all"],
+      aliases: ["email-layout-dir"],
     }),
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -4,9 +4,15 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { ApiError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object";
-import { formatErrorRespMessage, isSuccessResp, withSpinner } from "@/lib/helpers/request";
+import { MAX_PAGINATION_LIMIT, PageInfo } from "@/lib/helpers/page";
+import {
+  formatErrorRespMessage,
+  isSuccessResp,
+  withSpinner,
+} from "@/lib/helpers/request";
 import { promptToConfirm, spinner } from "@/lib/helpers/ux";
 import * as EmailLayout from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
@@ -15,8 +21,6 @@ import {
   ensureResourceDirForTarget,
   ResourceTarget,
 } from "@/lib/run-context";
-import { MAX_PAGINATION_LIMIT, PageInfo } from "@/lib/helpers/page";
-import { ApiError } from "@/lib/helpers/error";
 
 export default class EmailLayoutPull extends BaseCommand<
   typeof EmailLayoutPull
@@ -66,7 +70,6 @@ export default class EmailLayoutPull extends BaseCommand<
   }
 
   // Pull one email layout
-
   async pullOneEmailLayout(): Promise<void> {
     const { flags } = this.props;
 
@@ -98,7 +101,7 @@ export default class EmailLayoutPull extends BaseCommand<
     );
   }
 
-  // Pull all email layout
+  // Pull all email layouts
   async pullAllEmailLayouts(): Promise<void> {
     const { flags } = this.props;
 
@@ -137,7 +140,7 @@ export default class EmailLayoutPull extends BaseCommand<
       },
     });
 
-    const resp = await this.apiV1.listEmailLayouts<WithAnnotation>(props)
+    const resp = await this.apiV1.listEmailLayouts<WithAnnotation>(props);
     if (!isSuccessResp(resp)) {
       const message = formatErrorRespMessage(resp);
       this.error(new ApiError(message));

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -39,10 +39,10 @@ export default class EmailLayoutPull extends BaseCommand<
       summary:
         "Whether to pull all email layouts from the specified environment.",
     }),
-    "layout-dir": CustomFlags.dirPath({
+    "layouts-dir": CustomFlags.dirPath({
       summary: "The target directory path to pull all email layouts into.",
       dependsOn: ["all"],
-      aliases: ["email-layout-dir"],
+      aliases: ["email-layouts-dir"],
     }),
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
@@ -107,7 +107,7 @@ export default class EmailLayoutPull extends BaseCommand<
     const { flags } = this.props;
 
     const defaultToCwd = { abspath: this.runContext.cwd, exists: true };
-    const targetDirCtx = flags["layout-dir"] || defaultToCwd;
+    const targetDirCtx = flags["layouts-dir"] || defaultToCwd;
 
     const prompt = targetDirCtx.exists
       ? `Pull latest layouts into ${targetDirCtx.abspath}?\n  This will overwrite the contents of this directory.`

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -180,7 +180,7 @@ export default class EmailLayoutPull extends BaseCommand<
       const exists = await EmailLayout.isEmailLayoutDir(dirPath);
 
       return {
-        type: "email_layout",
+        type: "layout",
         key: emailLayoutKey,
         abspath: dirPath,
         exists,

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -17,8 +17,8 @@ import { promptToConfirm, spinner } from "@/lib/helpers/ux";
 import * as EmailLayout from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 import {
-  LayoutDirContext,
   ensureResourceDirForTarget,
+  LayoutDirContext,
   ResourceTarget,
 } from "@/lib/run-context";
 

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -177,10 +177,7 @@ export default class EmailLayoutPull extends BaseCommand<
     // new email layout directory in the cwd, or update it if there is one already.
     if (emailLayoutKey) {
       const dirPath = path.resolve(runCwd, emailLayoutKey);
-      const exists = await EmailLayout.isEmailLayoutDir(
-        dirPath,
-        `${emailLayoutKey}.json`,
-      );
+      const exists = await EmailLayout.isEmailLayoutDir(dirPath);
 
       return {
         type: "email_layout",

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -17,7 +17,7 @@ import { promptToConfirm, spinner } from "@/lib/helpers/ux";
 import * as EmailLayout from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 import {
-  EmailLayoutDirContext,
+  LayoutDirContext,
   ensureResourceDirForTarget,
   ResourceTarget,
 } from "@/lib/run-context";
@@ -155,7 +155,7 @@ export default class EmailLayoutPull extends BaseCommand<
       : emailLayouts;
   }
 
-  async getEmailLayoutDirContext(): Promise<EmailLayoutDirContext> {
+  async getEmailLayoutDirContext(): Promise<LayoutDirContext> {
     const { emailLayoutKey } = this.props.args;
     const { resourceDir, cwd: runCwd } = this.runContext;
 
@@ -170,7 +170,7 @@ export default class EmailLayoutPull extends BaseCommand<
       return ensureResourceDirForTarget(
         resourceDir,
         target,
-      ) as EmailLayoutDirContext;
+      ) as LayoutDirContext;
     }
 
     // Not inside any existing email layout directory, which means either create a

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -17,8 +17,8 @@ import { promptToConfirm, spinner } from "@/lib/helpers/ux";
 import * as EmailLayout from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 import {
-  ensureResourceDirForTarget,
   EmailLayoutDirContext,
+  ensureResourceDirForTarget,
   ResourceTarget,
 } from "@/lib/run-context";
 

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -19,6 +19,8 @@ import {
 export default class EmailLayoutPull extends BaseCommand<
   typeof EmailLayoutPull
 > {
+  static aliases = ["email-layout:pull", "email_layout:pull"];
+
   static summary =
     "Pull one or more email layouts from an environment into a local file system.";
 
@@ -31,11 +33,11 @@ export default class EmailLayoutPull extends BaseCommand<
       summary:
         "Whether to pull all email layouts from the specified environment.",
     }),
-    "email- layout - dir": CustomFlags.dirPath({
+    "layout-dir": CustomFlags.dirPath({
       summary: "The target directory path to pull all email layouts into.",
       dependsOn: ["all"],
     }),
-    "hide - uncommitted - changes": Flags.boolean({
+    "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
     force: Flags.boolean({
@@ -51,6 +53,7 @@ export default class EmailLayoutPull extends BaseCommand<
 
   async run(): Promise<void> {
     const { args, flags } = this.props;
+
     if (flags.all && args.emailLayoutKey) {
       return this.error(
         `emailLayoutKey arg \`${args.emailLayoutKey}\` cannot also be provided when using --all`,
@@ -63,6 +66,7 @@ export default class EmailLayoutPull extends BaseCommand<
   /*
    * Pull one email layout
    */
+
   async pullOneEmailLayout(): Promise<void> {
     const { flags } = this.props;
 
@@ -97,6 +101,7 @@ export default class EmailLayoutPull extends BaseCommand<
   async getEmailLayoutDirContext(): Promise<EmailLayoutDirContext> {
     const { emailLayoutKey } = this.props.args;
     const { resourceDir, cwd: runCwd } = this.runContext;
+
     // Inside an existing resource dir, use it if valid for the target email layout.
     if (resourceDir) {
       const target: ResourceTarget = {
@@ -104,6 +109,7 @@ export default class EmailLayoutPull extends BaseCommand<
         type: "email_layout",
         key: emailLayoutKey,
       };
+
       return ensureResourceDirForTarget(
         resourceDir,
         target,
@@ -114,16 +120,21 @@ export default class EmailLayoutPull extends BaseCommand<
     // new email layout directory in the cwd, or update it if there is one already.
     if (emailLayoutKey) {
       const dirPath = path.resolve(runCwd, emailLayoutKey);
-      const exists = await EmailLayout.isEmailLayoutDir(dirPath);
+      const exists = await EmailLayout.isEmailLayoutDir(
+        dirPath,
+        `${emailLayoutKey}.json`,
+      );
+      const abspath = path.resolve(dirPath, `${emailLayoutKey}.json`);
+
       return {
         type: "email_layout",
         key: emailLayoutKey,
-        abspath: dirPath,
+        abspath: abspath,
         exists,
       };
     }
 
     // Not in any email layout directory, nor a email layout key arg was given so error.
-    return this.error("Missing 1 required arg: emailLayoutKey");
+    return this.error("Missing 1 required arg:\nemailLayoutKey");
   }
 }

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -90,7 +90,7 @@ export default class EmailLayoutPull extends BaseCommand<
       },
     );
 
-    await EmailLayout.writeEmailLayoutFile(dirContext.abspath, resp.data);
+    await EmailLayout.writeWorkflowDirFromData(dirContext, resp.data);
 
     const action = dirContext.exists ? "updated" : "created";
     this.log(
@@ -124,12 +124,11 @@ export default class EmailLayoutPull extends BaseCommand<
         dirPath,
         `${emailLayoutKey}.json`,
       );
-      const abspath = path.resolve(dirPath, `${emailLayoutKey}.json`);
 
       return {
         type: "email_layout",
         key: emailLayoutKey,
-        abspath: abspath,
+        abspath: dirPath,
         exists,
       };
     }

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -163,7 +163,7 @@ export default class EmailLayoutPull extends BaseCommand<
     if (resourceDir) {
       const target: ResourceTarget = {
         commandId: BaseCommand.id,
-        type: "email_layout",
+        type: "layout",
         key: emailLayoutKey,
       };
 

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -18,7 +18,7 @@ import * as EmailLayout from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 import {
   ensureResourceDirForTarget,
-  LayoutDirContext,
+  EmailLayoutDirContext,
   ResourceTarget,
 } from "@/lib/run-context";
 
@@ -155,7 +155,7 @@ export default class EmailLayoutPull extends BaseCommand<
       : emailLayouts;
   }
 
-  async getEmailLayoutDirContext(): Promise<LayoutDirContext> {
+  async getEmailLayoutDirContext(): Promise<EmailLayoutDirContext> {
     const { emailLayoutKey } = this.props.args;
     const { resourceDir, cwd: runCwd } = this.runContext;
 
@@ -163,14 +163,14 @@ export default class EmailLayoutPull extends BaseCommand<
     if (resourceDir) {
       const target: ResourceTarget = {
         commandId: BaseCommand.id,
-        type: "layout",
+        type: "email_layout",
         key: emailLayoutKey,
       };
 
       return ensureResourceDirForTarget(
         resourceDir,
         target,
-      ) as LayoutDirContext;
+      ) as EmailLayoutDirContext;
     }
 
     // Not inside any existing email layout directory, which means either create a
@@ -180,7 +180,7 @@ export default class EmailLayoutPull extends BaseCommand<
       const exists = await EmailLayout.isEmailLayoutDir(dirPath);
 
       return {
-        type: "layout",
+        type: "email_layout",
         key: emailLayoutKey,
         abspath: dirPath,
         exists,

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -1,0 +1,129 @@
+import * as path from "node:path";
+
+import { Args, Flags } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import * as CustomFlags from "@/lib/helpers/flag";
+import { merge } from "@/lib/helpers/object";
+import { withSpinner } from "@/lib/helpers/request";
+import { promptToConfirm } from "@/lib/helpers/ux";
+import * as EmailLayout from "@/lib/marshal/email-layout";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+import {
+  EmailLayoutDirContext,
+  ensureResourceDirForTarget,
+  ResourceTarget,
+} from "@/lib/run-context";
+
+export default class EmailLayoutPull extends BaseCommand<
+  typeof EmailLayoutPull
+> {
+  static summary =
+    "Pull one or more email layouts from an environment into a local file system.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    all: Flags.boolean({
+      summary:
+        "Whether to pull all email layouts from the specified environment.",
+    }),
+    "email- layout - dir": CustomFlags.dirPath({
+      summary: "The target directory path to pull all email layouts into.",
+      dependsOn: ["all"],
+    }),
+    "hide - uncommitted - changes": Flags.boolean({
+      summary: "Hide any uncommitted changes.",
+    }),
+    force: Flags.boolean({
+      summary: "Remove the confirmation prompt.",
+    }),
+  };
+
+  static args = {
+    emailLayoutKey: Args.string({
+      required: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = this.props;
+    if (flags.all && args.emailLayoutKey) {
+      return this.error(
+        `emailLayoutKey arg \`${args.emailLayoutKey}\` cannot also be provided when using --all`,
+      );
+    }
+
+    return this.pullOneEmailLayout();
+  }
+
+  /*
+   * Pull one email layout
+   */
+  async pullOneEmailLayout(): Promise<void> {
+    const { flags } = this.props;
+
+    const dirContext = await this.getEmailLayoutDirContext();
+
+    if (dirContext.exists) {
+      this.log(`‣ Found \`${dirContext.key}\` at ${dirContext.abspath}`);
+    } else {
+      const prompt = `Create a new email layout directory \`${dirContext.key}\` at ${dirContext.abspath}?`;
+      const input = flags.force || (await promptToConfirm(prompt));
+      if (!input) return;
+    }
+
+    const resp = await withSpinner<ApiV1.GetEmailLayoutResp<WithAnnotation>>(
+      () => {
+        const props = merge(this.props, {
+          args: { emailLayoutKey: dirContext.key },
+          flags: { annotate: true },
+        });
+        return this.apiV1.getEmailLayout(props);
+      },
+    );
+
+    await EmailLayout.writeEmailLayoutFile(dirContext.abspath, resp.data);
+
+    const action = dirContext.exists ? "updated" : "created";
+    this.log(
+      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath}`,
+    );
+  }
+
+  async getEmailLayoutDirContext(): Promise<EmailLayoutDirContext> {
+    const { emailLayoutKey } = this.props.args;
+    const { resourceDir, cwd: runCwd } = this.runContext;
+    // Inside an existing resource dir, use it if valid for the target email layout.
+    if (resourceDir) {
+      const target: ResourceTarget = {
+        commandId: BaseCommand.id,
+        type: "email_layout",
+        key: emailLayoutKey,
+      };
+      return ensureResourceDirForTarget(
+        resourceDir,
+        target,
+      ) as EmailLayoutDirContext;
+    }
+
+    // Not inside any existing email layout directory, which means either create a
+    // new email layout directory in the cwd, or update it if there is one already.
+    if (emailLayoutKey) {
+      const dirPath = path.resolve(runCwd, emailLayoutKey);
+      const exists = await EmailLayout.isEmailLayoutDir(dirPath);
+      return {
+        type: "email_layout",
+        key: emailLayoutKey,
+        abspath: dirPath,
+        exists,
+      };
+    }
+
+    // Not in any email layout directory, nor a email layout key arg was given so error.
+    return this.error("Missing 1 required arg: emailLayoutKey");
+  }
+}

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -2,8 +2,6 @@ import * as path from "node:path";
 
 import * as fs from "fs-extra";
 
-export const EMAIL_LAYOUT_JSON = "email_layout.json";
-
 export type EmailLayoutFileContext = {
   key: string;
   abspath: string;
@@ -12,19 +10,24 @@ export type EmailLayoutFileContext = {
 
 /*
  * Evaluates whether the given directory path is an email layout directory, by
- * checking for the presence of email_layout.json file.
+ * checking for the presence of `${email_layout_key}.json` file.
  */
-export const isEmailLayoutDir = async (dirPath: string): Promise<boolean> =>
-  Boolean(await isEmailLayoutJson(dirPath));
+export const isEmailLayoutDir = async (
+  dirPath: string,
+  emailLayoutJson: string,
+): Promise<boolean> =>
+  Boolean(await isEmailLayoutJson(dirPath, emailLayoutJson));
 
 /*
- * Check for email_layout.json file and return the file path if present.
+ * Check for the existance of`${email_layout_key}.json` file in the directory.
  */
+
 export const isEmailLayoutJson = async (
   dirPath: string,
+  emailLayoutJson: string,
 ): Promise<string | undefined> => {
-  const workflowJsonPath = path.resolve(dirPath, EMAIL_LAYOUT_JSON);
+  const emailLayoutJsonPath = path.resolve(dirPath, emailLayoutJson);
 
-  const exists = await fs.pathExists(workflowJsonPath);
-  return exists ? workflowJsonPath : undefined;
+  const exists = await fs.pathExists(emailLayoutJsonPath);
+  return exists ? emailLayoutJsonPath : undefined;
 };

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -4,12 +4,6 @@ import * as fs from "fs-extra";
 
 export const LAYOUT_JSON = "layout.json";
 
-export type EmailLayoutFileContext = {
-  key: string;
-  abspath: string;
-  exists: boolean;
-};
-
 /*
  * Evaluates whether the given directory path is an email layout directory, by
  * checking for the presence of a `layout.json` file.

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -2,6 +2,8 @@ import * as path from "node:path";
 
 import * as fs from "fs-extra";
 
+export const LAYOUT_JSON = "layout.json";
+
 export type EmailLayoutFileContext = {
   key: string;
   abspath: string;
@@ -10,23 +12,19 @@ export type EmailLayoutFileContext = {
 
 /*
  * Evaluates whether the given directory path is an email layout directory, by
- * checking for the presence of `${email_layout_key}.json` file.
+ * checking for the presence of a `layout.json` file.
  */
-export const isEmailLayoutDir = async (
-  dirPath: string,
-  emailLayoutJson: string,
-): Promise<boolean> =>
-  Boolean(await isEmailLayoutJson(dirPath, emailLayoutJson));
+export const isEmailLayoutDir = async (dirPath: string): Promise<boolean> =>
+  Boolean(await isEmailLayoutJson(dirPath));
 
 /*
- * Check for the existance of`${email_layout_key}.json` file in the directory.
+ * Check for `layout.json` file and return the file path if present.
  */
 
 export const isEmailLayoutJson = async (
   dirPath: string,
-  emailLayoutJson: string,
 ): Promise<string | undefined> => {
-  const emailLayoutJsonPath = path.resolve(dirPath, emailLayoutJson);
+  const emailLayoutJsonPath = path.resolve(dirPath, LAYOUT_JSON);
 
   const exists = await fs.pathExists(emailLayoutJsonPath);
   return exists ? emailLayoutJsonPath : undefined;

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -20,7 +20,6 @@ export const isEmailLayoutDir = async (dirPath: string): Promise<boolean> =>
 /*
  * Check for `layout.json` file and return the file path if present.
  */
-
 export const isEmailLayoutJson = async (
   dirPath: string,
 ): Promise<string | undefined> => {

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -1,0 +1,30 @@
+import * as path from "node:path";
+
+import * as fs from "fs-extra";
+
+export const EMAIL_LAYOUT_JSON = "email_layout.json";
+
+export type EmailLayoutFileContext = {
+  key: string;
+  abspath: string;
+  exists: boolean;
+};
+
+/*
+ * Evaluates whether the given directory path is an email layout directory, by
+ * checking for the presence of email_layout.json file.
+ */
+export const isEmailLayoutDir = async (dirPath: string): Promise<boolean> =>
+  Boolean(await isEmailLayoutJson(dirPath));
+
+/*
+ * Check for email_layout.json file and return the file path if present.
+ */
+export const isEmailLayoutJson = async (
+  dirPath: string,
+): Promise<string | undefined> => {
+  const workflowJsonPath = path.resolve(dirPath, EMAIL_LAYOUT_JSON);
+
+  const exists = await fs.pathExists(workflowJsonPath);
+  return exists ? workflowJsonPath : undefined;
+};

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -15,12 +15,12 @@ export type EmailLayoutFileContext = {
  * checking for the presence of a `layout.json` file.
  */
 export const isEmailLayoutDir = async (dirPath: string): Promise<boolean> =>
-  Boolean(await isEmailLayoutJson(dirPath));
+  Boolean(await lsEmailLayoutJson(dirPath));
 
 /*
  * Check for `layout.json` file and return the file path if present.
  */
-export const isEmailLayoutJson = async (
+export const lsEmailLayoutJson = async (
   dirPath: string,
 ): Promise<string | undefined> => {
   const emailLayoutJsonPath = path.resolve(dirPath, LAYOUT_JSON);

--- a/src/lib/marshal/email-layout/index.ts
+++ b/src/lib/marshal/email-layout/index.ts
@@ -1,1 +1,3 @@
+export * from "./helpers";
 export * from "./types";
+export * from "./writer";

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -120,9 +120,7 @@ const validateExtractedFilePath = (
   const layoutJsonPath = path.resolve(emailLayoutDirCtx.abspath, LAYOUT_JSON);
   // Validate the file path format, and that it is unique per workflow.
   if (
-    !checkIfValidExtractedFilePathFormat(val, layoutJsonPath, {
-      withAbsolutePaths: true,
-    }) ||
+    !checkIfValidExtractedFilePathFormat(val, layoutJsonPath) ||
     typeof val !== "string"
   ) {
     const error = new JsonDataError(

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -109,9 +109,6 @@ const joinExtractedFiles = async (
 /*
  * Validate the extracted file path based on its format and uniqueness (but not
  * the presence).
- *
- * Note, the uniqueness check is based on reading from and writing to
- * uniqueFilePaths, which is MUTATED in place.
  */
 const validateExtractedFilePath = (
   val: unknown,

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -115,7 +115,7 @@ const validateExtractedFilePath = (
   emailLayoutDirCtx: EmailLayoutDirContext,
 ): JsonDataError | undefined => {
   const layoutJsonPath = path.resolve(emailLayoutDirCtx.abspath, LAYOUT_JSON);
-  // Validate the file path format, and that it is unique per workflow.
+  // Validate the file path format, and that it is unique per layout.
   if (
     !checkIfValidExtractedFilePathFormat(val, layoutJsonPath) ||
     typeof val !== "string"

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import * as fs from "fs-extra";
 import { hasIn, set } from "lodash";
 
@@ -80,8 +82,7 @@ const joinExtractedFiles = async (
     // Check if the extracted path found at the current field path is valid
     const invalidFilePathError = validateExtractedFilePath(
       relpath,
-      layoutDirCtx.abspath,
-      LAYOUT_JSON,
+      path.resolve(layoutDirCtx.abspath, LAYOUT_JSON),
       uniqueFilePaths,
       objPathToFieldStr,
     );

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import * as fs from "fs-extra";
 import { mapValues, set, unset } from "lodash";
 
@@ -5,12 +7,13 @@ import { JsonDataError } from "@/lib/helpers/error";
 import { ParseJsonResult, readJson } from "@/lib/helpers/json";
 import { AnyObj, omitDeep } from "@/lib/helpers/object";
 import {
+  checkIfValidExtractedFilePathFormat,
   FILEPATH_MARKED_RE,
   readExtractedFileSync,
 } from "@/lib/marshal/shared/helpers";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
-import { lsEmailLayoutJson } from "./helpers";
+import { LAYOUT_JSON, lsEmailLayoutJson } from "./helpers";
 
 type JoinExtractedFilesResult = [AnyObj, JsonDataError[]];
 
@@ -65,6 +68,23 @@ const joinExtractedFiles = async (
     // If not marked with the @suffix, there's nothing to do.
     if (!FILEPATH_MARKED_RE.test(key)) return;
 
+    const objPathStr = key.replace(FILEPATH_MARKED_RE, "");
+
+    // Check if the extracted path found at the current field path is valid
+    const invalidFilePathError = validateExtractedFilePath(
+      relpath,
+      layoutDirCtx,
+    );
+    if (invalidFilePathError) {
+      errors.push(invalidFilePathError);
+      // Wipe the invalid file path in the node so the final layout json
+      // object ends up with only valid file paths, this way layout writer
+      // can see only valid file paths and use those when pulling.
+      set(layoutJson, key, undefined);
+
+      return;
+    }
+
     // By this point we have a valid extracted file path, so attempt to read the file
     const [content, readExtractedFileError] = readExtractedFileSync(
       relpath,
@@ -78,11 +98,40 @@ const joinExtractedFiles = async (
       return;
     }
 
-    const objPathStr = key.replace(FILEPATH_MARKED_RE, "");
     // Inline the file content and remove the extracted file path
     set(layoutJson, objPathStr, content);
     unset(layoutJson, key);
   });
 
   return [layoutJson, errors];
+};
+
+/*
+ * Validate the extracted file path based on its format and uniqueness (but not
+ * the presence).
+ *
+ * Note, the uniqueness check is based on reading from and writing to
+ * uniqueFilePaths, which is MUTATED in place.
+ */
+const validateExtractedFilePath = (
+  val: unknown,
+  emailLayoutDirCtx: EmailLayoutDirContext,
+): JsonDataError | undefined => {
+  const layoutJsonPath = path.resolve(emailLayoutDirCtx.abspath, LAYOUT_JSON);
+  // Validate the file path format, and that it is unique per workflow.
+  if (
+    !checkIfValidExtractedFilePathFormat(val, layoutJsonPath, {
+      withAbsolutePaths: true,
+    }) ||
+    typeof val !== "string"
+  ) {
+    const error = new JsonDataError(
+      "must be a relative path string to a unique file within the directory",
+      String(val),
+    );
+
+    return error;
+  }
+
+  return undefined;
 };

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -1,0 +1,88 @@
+import * as fs from "fs-extra";
+import { mapValues, set, unset } from "lodash";
+
+import { JsonDataError } from "@/lib/helpers/error";
+import { ParseJsonResult, readJson } from "@/lib/helpers/json";
+import { AnyObj, omitDeep } from "@/lib/helpers/object";
+import {
+  FILEPATH_MARKED_RE,
+  readExtractedFileSync,
+} from "@/lib/marshal/shared/helpers";
+import { EmailLayoutDirContext } from "@/lib/run-context";
+
+import { lsEmailLayoutJson } from "./helpers";
+
+type JoinExtractedFilesResult = [AnyObj, JsonDataError[]];
+
+type ReadLayoutDirOpts = {
+  withExtractedFiles?: boolean;
+  withReadonlyField?: boolean;
+};
+
+/*
+ * The main read function that takes the layout directory context, then reads
+ * the layout json from the file system and returns the layout data obj.
+ */
+export const readEmailLayoutDir = async (
+  layoutDirCtx: EmailLayoutDirContext,
+  opts: ReadLayoutDirOpts = {},
+): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
+  const { abspath } = layoutDirCtx;
+  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+
+  const dirExists = await fs.pathExists(abspath);
+  if (!dirExists) throw new Error(`${abspath} does not exist`);
+
+  const layoutJsonPath = await lsEmailLayoutJson(abspath);
+
+  if (!layoutJsonPath) throw new Error(`${abspath} is not a layout directory`);
+
+  const result = await readJson(layoutJsonPath);
+  if (!result[0]) return result;
+
+  let [layoutJson] = result;
+
+  layoutJson = withReadonlyField
+    ? layoutJson
+    : omitDeep(layoutJson, ["__readonly"]);
+
+  return withExtractedFiles
+    ? joinExtractedFiles(layoutDirCtx, layoutJson)
+    : [layoutJson, []];
+};
+
+/*
+ * Given a layout json object, compiles all referenced extracted files from it
+ * and returns the updated object with the extracted content joined and inlined.
+ */
+const joinExtractedFiles = async (
+  layoutDirCtx: EmailLayoutDirContext,
+  layoutJson: AnyObj,
+): Promise<JoinExtractedFilesResult> => {
+  const errors: JsonDataError[] = [];
+
+  mapValues(layoutJson, (relpath: string, key: string) => {
+    // If not marked with the @suffix, there's nothing to do.
+    if (!FILEPATH_MARKED_RE.test(key)) return;
+
+    // By this point we have a valid extracted file path, so attempt to read the file
+    const [content, readExtractedFileError] = readExtractedFileSync(
+      relpath,
+      layoutDirCtx,
+      key,
+    );
+
+    if (readExtractedFileError) {
+      errors.push(readExtractedFileError);
+
+      return;
+    }
+
+    const objPathStr = key.replace(FILEPATH_MARKED_RE, "");
+    // Inline the file content and remove the extracted file path
+    set(layoutJson, objPathStr, content);
+    unset(layoutJson, key);
+  });
+
+  return [layoutJson, errors];
+};

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -37,7 +37,6 @@ export const readEmailLayoutDir = async (
   if (!dirExists) throw new Error(`${abspath} does not exist`);
 
   const layoutJsonPath = await lsEmailLayoutJson(abspath);
-
   if (!layoutJsonPath) throw new Error(`${abspath} is not a layout directory`);
 
   const result = await readJson(layoutJsonPath);

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -109,7 +109,7 @@ const joinExtractedFiles = async (
       return;
     }
 
-    // Inline the file content and remove the extracted file path
+    // Inline the file content and remove the extracted file path.
     set(layoutJson, objPathToFieldStr, relpath);
     set(layoutJson, inlinObjPathStr, content);
   });

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs-extra";
-import { set } from "lodash";
+import { hasIn, set } from "lodash";
 
 import { JsonDataError } from "@/lib/helpers/error";
 import { ParseJsonResult, readJson } from "@/lib/helpers/json";
@@ -59,6 +59,7 @@ const joinExtractedFiles = async (
   layoutDirCtx: EmailLayoutDirContext,
   layoutJson: AnyObj,
 ): Promise<JoinExtractedFilesResult> => {
+  // Tracks any errors encountered during traversal. Mutated in place.
   const errors: JsonDataError[] = [];
 
   // Tracks each new valid extracted file path seen (rebased to be relative to
@@ -72,6 +73,9 @@ const joinExtractedFiles = async (
 
     const objPathToFieldStr = ObjPath.stringify(parts);
     const inlinObjPathStr = objPathToFieldStr.replace(FILEPATH_MARKED_RE, "");
+
+    // If there is inlined content present already, then nothing more to do.
+    if (hasIn(layoutJson, inlinObjPathStr)) return;
 
     // Check if the extracted path found at the current field path is valid
     const invalidFilePathError = validateExtractedFilePath(

--- a/src/lib/marshal/email-layout/types.ts
+++ b/src/lib/marshal/email-layout/types.ts
@@ -7,6 +7,7 @@ export type EmailLayoutData<A extends MaybeWithAnnotation = unknown> = A & {
   html_layout: string;
   text_layout: string;
   footer_links?: Hyperlink[];
+  environment: string;
   updated_at: string;
   created_at: string;
 };

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -11,6 +11,7 @@ import { AnyObj, split } from "@/lib/helpers/object";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
 import { ExtractionSettings, WithAnnotation } from "../shared/types";
+import { LAYOUT_JSON } from "./helpers";
 import { EmailLayoutData } from "./types";
 
 export type EmailLayoutDirBundle = {
@@ -43,7 +44,7 @@ const compileExtractionSettings = (
   return map;
 };
 
-/* Sanitize the email latyout content into a format that's appropriate for reading
+/* Sanitize the email layout content into a format that's appropriate for reading
    and writing, by stripping out any annotation fields and handling readonly
    fields.
 */
@@ -79,7 +80,7 @@ export const writeEmailLayoutDirFromData = async (
     const promises = Object.entries(bundle).map(([relpath, fileContent]) => {
       const filePath = path.resolve(emailLayoutDirCtx.abspath, relpath);
 
-      return relpath === `${emailLayout.key}.json`
+      return relpath === LAYOUT_JSON
         ? fs.outputJson(filePath, fileContent, { spaces: DOUBLE_SPACES })
         : fs.outputFile(filePath, fileContent);
     });
@@ -130,13 +131,10 @@ const buildEmailLayoutDirBundle = (
     set(bundle, [relpath], data);
   }
 
-  // At this point the bundle contains all extractable files, so we finally add the email layout
+  // At this point the bundle contains all extractable files, so we finally add the layout
   // JSON realtive path + the file content.
-  return set(
-    bundle,
-    [`${emailLayout.key}.json`],
-    toEmailLayoutJson(emailLayout),
-  );
+
+  return set(bundle, [LAYOUT_JSON], toEmailLayoutJson(emailLayout));
 };
 
 // This bulk write function takes the fetched email layouts data KNOCK API and writes

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -103,8 +103,8 @@ export const writeEmailLayoutDirFromData = async (
 };
 
 /* For a given email layout payload, this function builds a "email layout directoy bundle".
-   This is an object which contains an `email_layout_key.json` file and all extractable fields.
-   Those extractable fields are extracted out and added to the bundle as separate files.
+   This is an object which contains all the relative paths and its file content.
+   It includes the extractable fields, which are extracted out and added to the bundle as separate files.
 */
 const buildEmailLayoutDirBundle = (
   emailLayout: EmailLayoutData<WithAnnotation>,
@@ -130,7 +130,8 @@ const buildEmailLayoutDirBundle = (
     set(bundle, [relpath], data);
   }
 
-  // At this point the bundle contains all extractable files, so we finally add the email layout JSON file.
+  // At this point the bundle contains all extractable files, so we finally add the email layout
+  // JSON realtive path + the file content.
   return set(
     bundle,
     [`${emailLayout.key}.json`],

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -130,13 +130,13 @@ const buildEmailLayoutDirBundle = (
   // Iterate through each extractable field, determine whether we need to
   // extract the field content, and if so, perform the
   // extraction.
-  for (const [objPath, extractionSettings] of compiledExtractionSettings) {
+  for (const [objPathParts, extractionSettings] of compiledExtractionSettings) {
     // If this layout doesn't have this field path, then we don't extract.
-    if (!has(mutRemoteEmailLayout, objPath)) continue;
+    if (!has(mutRemoteEmailLayout, objPathParts)) continue;
 
     // If the field at this path is extracted in the local layout, then
     // always extract; otherwise extract based on the field settings default.
-    const objPathStr = ObjPath.stringify(objPath);
+    const objPathStr = ObjPath.stringify(objPathParts);
 
     const extractedFilePath = get(
       localEmailLayout,
@@ -148,8 +148,8 @@ const buildEmailLayoutDirBundle = (
     if (!extractedFilePath && !extractByDefault) continue;
 
     // By this point, we have a field where we need to extract its content.
-    const data = get(mutRemoteEmailLayout, objPath);
-    const fileName = objPath.pop();
+    const data = get(mutRemoteEmailLayout, objPathParts);
+    const fileName = objPathParts.pop();
 
     // If we have an extracted file path from the local layout, we use that. In the other
     // case we use the default path.

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -8,7 +8,7 @@ import { DirContext } from "@/lib/helpers/fs";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import { ObjKeyOrArrayIdx, ObjPath, omitDeep } from "@/lib/helpers/object";
 import { AnyObj, split } from "@/lib/helpers/object";
-import { LayoutDirContext } from "@/lib/run-context";
+import { EmailLayoutDirContext } from "@/lib/run-context";
 
 import { ExtractionSettings, WithAnnotation } from "../shared/types";
 import { FILEPATH_MARKER } from "../workflow";
@@ -65,7 +65,7 @@ const toEmailLayoutJson = (
    Then writes them into a layout directory on a local file system.
 */
 export const writeEmailLayoutDirFromData = async (
-  emailLayoutDirCtx: LayoutDirContext,
+  emailLayoutDirCtx: EmailLayoutDirContext,
   emailLayout: EmailLayoutData<WithAnnotation>,
 ): Promise<void> => {
   const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
@@ -165,8 +165,8 @@ export const writeEmailLayoutIndexDir = async (
           emailLayout.key,
         );
 
-        const emailLayoutDirCtx: LayoutDirContext = {
-          type: "layout",
+        const emailLayoutDirCtx: EmailLayoutDirContext = {
+          type: "email_layout",
           key: emailLayout.key,
           abspath: emailLayoutDirPath,
           exists: false,

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -22,7 +22,7 @@ export type EmailLayoutDirBundle = {
 type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
 
 /* Traverse a given email layout data and compile extraction settings of every extractable
-   field into a sorted map.
+ * field into a sorted map.
 */
 const compileExtractionSettings = (
   emailLayout: EmailLayoutData<WithAnnotation>,
@@ -46,8 +46,8 @@ const compileExtractionSettings = (
 };
 
 /* Sanitize the email layout content into a format that's appropriate for reading
-   and writing, by stripping out any annotation fields and handling readonly
-   fields.
+ * and writing, by stripping out any annotation fields and handling readonly
+ * fields.
 */
 const toEmailLayoutJson = (
   emailLayout: EmailLayoutData<WithAnnotation>,
@@ -62,7 +62,7 @@ const toEmailLayoutJson = (
 };
 
 /* Builds an email layout dir bundle, which consist of the email layout JSON + the extractable files.
-   Then writes them into a layout directory on a local file system.
+ * Then writes them into a layout directory on a local file system.
 */
 export const writeEmailLayoutDirFromData = async (
   emailLayoutDirCtx: EmailLayoutDirContext,
@@ -105,8 +105,8 @@ export const writeEmailLayoutDirFromData = async (
 };
 
 /* For a given email layout payload, this function builds a "email layout directoy bundle".
-   This is an object which contains all the relative paths and its file content.
-   It includes the extractable fields, which are extracted out and added to the bundle as separate files.
+ * This is an object which contains all the relative paths and its file content.
+ * It includes the extractable fields, which are extracted out and added to the bundle as separate files.
 */
 const buildEmailLayoutDirBundle = (
   emailLayout: EmailLayoutData<WithAnnotation>,

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -72,7 +72,7 @@ export const writeEmailLayoutDirFromData = async (
   // If the layout directory exists on the file system (i.e. previously
   // pulled before), then read the layout file to use as a reference.
   const [localEmailLayout] = emailLayoutDirCtx.exists
-    ? await readEmailLayoutDir(emailLayoutDirCtx, { withExtractedFiles: true })
+    ? await readEmailLayoutDir(emailLayoutDirCtx)
     : [];
 
   const bundle = buildEmailLayoutDirBundle(remoteEmailLayout, localEmailLayout);
@@ -121,7 +121,6 @@ const buildEmailLayoutDirBundle = (
 ): EmailLayoutDirBundle => {
   const bundle: EmailLayoutDirBundle = {};
   const mutRemoteEmailLayout = cloneDeep(remoteEmailLayout);
-
   // A map of extraction settings of every field in the email layout
   const compiledExtractionSettings =
     compileExtractionSettings(mutRemoteEmailLayout);
@@ -141,6 +140,7 @@ const buildEmailLayoutDirBundle = (
       localEmailLayout,
       `${objPathStr}${FILEPATH_MARKER}`,
     );
+
     const { default: extractByDefault, file_ext: fileExt } = extractionSettings;
 
     if (!extractedFilePath && !extractByDefault) continue;

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -1,17 +1,152 @@
+import path from "node:path";
+
 import * as fs from "fs-extra";
+import { get, set, uniqueId } from "lodash";
 
+import { sandboxDir } from "@/lib/helpers/const";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
+import {
+  mapValuesDeep,
+  ObjKeyOrArrayIdx,
+  omitDeep,
+} from "@/lib/helpers/object";
+import { AnyObj, split } from "@/lib/helpers/object";
+import { EmailLayoutDirContext } from "@/lib/run-context";
 
+import { ExtractionSettings, WithAnnotation } from "../shared/types";
+import { FILEPATH_MARKED_RE } from "../workflow";
 import { EmailLayoutData } from "./types";
 
+export type EmailLayoutDirBundle = {
+  [relpath: string]: string;
+};
 /*
- * Write a single email layout file in a given path.
+ * Sanitize the email latyout content into a format that's appropriate for reading
+ * and writing, by stripping out any annotation fields and handling readonly
+ * fields.
  */
+type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
 
-export const writeEmailLayoutFile = async (
-  emailLayoutAbsPath: string,
-  emailLayout: EmailLayoutData,
-): Promise<void> =>
-  fs.outputJson(emailLayoutAbsPath, emailLayout, {
-    spaces: DOUBLE_SPACES,
-  });
+const compileExtractionSettings = (
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): CompiledExtractionSettings => {
+  const extractableFields = get(
+    emailLayout,
+    ["__annotation", "extractable_fields"],
+    {},
+  );
+  const map: CompiledExtractionSettings = new Map();
+
+  for (const [key] of Object.entries(emailLayout)) {
+    // If the field we are on is extractable, then add its extraction
+    // settings to the map with the current object path.
+    if (key in extractableFields) {
+      map.set([key], extractableFields[key]);
+    }
+  }
+
+  return map;
+};
+
+const toEmailLayoutJson = (
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): AnyObj => {
+  // Move read only field under the dedicated field "__readonly".
+  const readonlyFields = emailLayout.__annotation?.readonly_fields || [];
+  const [readonly, remainder] = split(emailLayout, readonlyFields);
+  const emailLayoutjson = { ...remainder, __readonly: readonly };
+
+  // Strip out all schema annotations, so not to expose them to end users.
+  return omitDeep(emailLayoutjson, ["__annotation"]);
+};
+
+// Builds an email layout dir bundle and writes it into a layout directory on local file system.
+export const writeWorkflowDirFromData = async (
+  emailLayoutDirCtx: EmailLayoutDirContext,
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): Promise<void> => {
+  const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
+
+  const bundle = buildEmailLayoutDirBundle(emailLayout);
+  try {
+    // We store a backup in case there's an error.
+    if (emailLayoutDirCtx.exists) {
+      await fs.copy(emailLayoutDirCtx.abspath, backupDirPath);
+      await fs.emptyDir(emailLayoutDirCtx.abspath);
+    }
+
+    const promises = Object.entries(bundle).map(([relpath, fileContent]) => {
+      const filePath = path.resolve(emailLayoutDirCtx.abspath, relpath);
+
+      return relpath === `${emailLayout.key}.json`
+        ? fs.outputJson(filePath, fileContent, { spaces: DOUBLE_SPACES })
+        : fs.outputFile(filePath, fileContent);
+    });
+    await Promise.all(promises);
+  } catch (error) {
+    // In case of any error, wipe the target directory that is likely in a bad
+    // state then restore the backup if one existed before.
+    if (emailLayoutDirCtx.exists) {
+      await fs.emptyDir(emailLayoutDirCtx.abspath);
+      await fs.copy(backupDirPath, emailLayoutDirCtx.abspath);
+    } else {
+      await fs.remove(emailLayoutDirCtx.abspath);
+    }
+
+    throw error;
+  } finally {
+    // Always clean up the backup directory in the temp sandbox.
+    await fs.remove(backupDirPath);
+  }
+};
+
+// For a given email layout payload, this function builds an "layout directoy bundle".
+// This is an object which contains an `email_layout_key.json` file and all extractable fields.
+// Those extractable fields are extracted out and added to the bundle as separate files.
+const buildEmailLayoutDirBundle = (
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): EmailLayoutDirBundle => {
+  const bundle: EmailLayoutDirBundle = {};
+
+  // A compiled map of extraction settings of every field in the email layout
+  const compiledExtractionSettings = compileExtractionSettings(emailLayout);
+
+  // Iterate through each extractable field, determine whether we need to
+  // extract the field content, and if so, perform the
+  // extraction.
+  for (const [objPathParts, extractionSettings] of compiledExtractionSettings) {
+    const { default: extractByDefault, file_ext: fileExt } = extractionSettings;
+    if (!extractByDefault) continue;
+    // Extract the field and its content
+    let data = get(emailLayout, objPathParts);
+    const relpath = formatExtractedFilePath(objPathParts, fileExt);
+
+    data = mapValuesDeep(data, (value, key) => {
+      if (!FILEPATH_MARKED_RE.test(key)) return value;
+
+      const rebaseRootDir = path.dirname(relpath);
+      const rebasedFilePath = path.relative(rebaseRootDir, value);
+
+      return rebasedFilePath;
+    });
+
+    set(bundle, [relpath], data);
+  }
+
+  // At this point the bundles contains all extractable fields, so we finally add the email layout JSON file.
+  return set(
+    bundle,
+    [`${emailLayout.key}.json`],
+    toEmailLayoutJson(emailLayout),
+  );
+};
+
+const formatExtractedFilePath = (
+  objPathParts: ObjKeyOrArrayIdx[],
+  fileExt: string,
+): string => {
+  const fileName = objPathParts.pop();
+  const paths = [`${fileName}.${fileExt}`];
+
+  return path.join(...paths).toLowerCase();
+};

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -24,6 +24,8 @@ type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
 
 /* Traverse a given email layout data and compile extraction settings of every extractable
  * field into a sorted map.
+ * 
+ * NOTE: Currently we do NOT support content extraction at nested levels for email layouts. 
  */
 const compileExtractionSettings = (
   emailLayout: EmailLayoutData<WithAnnotation>,

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -72,7 +72,7 @@ export const writeEmailLayoutDirFromData = async (
   // If the layout directory exists on the file system (i.e. previously
   // pulled before), then read the layout file to use as a reference.
   const [localEmailLayout] = emailLayoutDirCtx.exists
-    ? await readEmailLayoutDir(emailLayoutDirCtx)
+    ? await readEmailLayoutDir(emailLayoutDirCtx, { withExtractedFiles: true })
     : [];
 
   const bundle = buildEmailLayoutDirBundle(remoteEmailLayout, localEmailLayout);

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -24,8 +24,8 @@ type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
 
 /* Traverse a given email layout data and compile extraction settings of every extractable
  * field into a sorted map.
- * 
- * NOTE: Currently we do NOT support content extraction at nested levels for email layouts. 
+ *
+ * NOTE: Currently we do NOT support content extraction at nested levels for email layouts.
  */
 const compileExtractionSettings = (
   emailLayout: EmailLayoutData<WithAnnotation>,

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -8,10 +8,10 @@ import { DirContext } from "@/lib/helpers/fs";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import { ObjKeyOrArrayIdx, ObjPath, omitDeep } from "@/lib/helpers/object";
 import { AnyObj, split } from "@/lib/helpers/object";
+import { FILEPATH_MARKER } from "@/lib/marshal/shared/helpers";
+import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
-import { ExtractionSettings, WithAnnotation } from "../shared/types";
-import { FILEPATH_MARKER } from "../workflow";
 import { LAYOUT_JSON } from "./helpers";
 import { EmailLayoutData } from "./types";
 
@@ -23,7 +23,7 @@ type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
 
 /* Traverse a given email layout data and compile extraction settings of every extractable
  * field into a sorted map.
-*/
+ */
 const compileExtractionSettings = (
   emailLayout: EmailLayoutData<WithAnnotation>,
 ): CompiledExtractionSettings => {
@@ -48,7 +48,7 @@ const compileExtractionSettings = (
 /* Sanitize the email layout content into a format that's appropriate for reading
  * and writing, by stripping out any annotation fields and handling readonly
  * fields.
-*/
+ */
 const toEmailLayoutJson = (
   emailLayout: EmailLayoutData<WithAnnotation>,
 ): AnyObj => {
@@ -63,7 +63,7 @@ const toEmailLayoutJson = (
 
 /* Builds an email layout dir bundle, which consist of the email layout JSON + the extractable files.
  * Then writes them into a layout directory on a local file system.
-*/
+ */
 export const writeEmailLayoutDirFromData = async (
   emailLayoutDirCtx: EmailLayoutDirContext,
   emailLayout: EmailLayoutData<WithAnnotation>,
@@ -107,7 +107,7 @@ export const writeEmailLayoutDirFromData = async (
 /* For a given email layout payload, this function builds a "email layout directoy bundle".
  * This is an object which contains all the relative paths and its file content.
  * It includes the extractable fields, which are extracted out and added to the bundle as separate files.
-*/
+ */
 const buildEmailLayoutDirBundle = (
   emailLayout: EmailLayoutData<WithAnnotation>,
 ): EmailLayoutDirBundle => {

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -8,7 +8,7 @@ import { DirContext } from "@/lib/helpers/fs";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import { ObjKeyOrArrayIdx, omitDeep } from "@/lib/helpers/object";
 import { AnyObj, split } from "@/lib/helpers/object";
-import { EmailLayoutDirContext } from "@/lib/run-context";
+import { LayoutDirContext } from "@/lib/run-context";
 
 import { ExtractionSettings, WithAnnotation } from "../shared/types";
 import { LAYOUT_JSON } from "./helpers";
@@ -64,7 +64,7 @@ const toEmailLayoutJson = (
    Then writes them into a layout directory on a local file system.
 */
 export const writeEmailLayoutDirFromData = async (
-  emailLayoutDirCtx: EmailLayoutDirContext,
+  emailLayoutDirCtx: LayoutDirContext,
   emailLayout: EmailLayoutData<WithAnnotation>,
 ): Promise<void> => {
   const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
@@ -158,8 +158,8 @@ export const writeEmailLayoutIndexDir = async (
           emailLayout.key,
         );
 
-        const emailLayoutDirCtx: EmailLayoutDirContext = {
-          type: "email_layout",
+        const emailLayoutDirCtx: LayoutDirContext = {
+          type: "layout",
           key: emailLayout.key,
           abspath: emailLayoutDirPath,
           exists: false,

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
 import * as fs from "fs-extra";
-import { cloneDeep, get, set, uniqueId, unset } from "lodash";
+import { cloneDeep, get, has, set, uniqueId, unset } from "lodash";
 
 import { sandboxDir } from "@/lib/helpers/const";
 import { DirContext } from "@/lib/helpers/fs";
@@ -129,6 +129,9 @@ const buildEmailLayoutDirBundle = (
   // extract the field content, and if so, perform the
   // extraction.
   for (const [objPath, extractionSettings] of compiledExtractionSettings) {
+    // If this layout doesn't have this field path, then we don't extract.
+    if (!has(remoteEmailLayout, objPath)) continue;
+
     // If the field at this path is extracted in the local layout, then
     // always extract; otherwise extract based on the field settings default.
     const objPathStr = ObjPath.stringify(objPath);

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
 import * as fs from "fs-extra";
-import { get, set, uniqueId, unset } from "lodash";
+import { cloneDeep, get, set, uniqueId, unset } from "lodash";
 
 import { sandboxDir } from "@/lib/helpers/const";
 import { DirContext } from "@/lib/helpers/fs";
@@ -75,7 +75,8 @@ export const writeEmailLayoutDirFromData = async (
     ? await readEmailLayoutDir(emailLayoutDirCtx)
     : [];
 
-  const bundle = buildEmailLayoutDirBundle(remoteEmailLayout, localEmailLayout);
+  const mutRemoteEmailLayout = cloneDeep(remoteEmailLayout);
+  const bundle = buildEmailLayoutDirBundle(mutRemoteEmailLayout, localEmailLayout);
 
   const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
   try {

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -5,12 +5,13 @@ import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import { EmailLayoutData } from "./types";
 
 /*
- * Write a single email layout file.
+ * Write a single email layout file in a given path.
  */
+
 export const writeEmailLayoutFile = async (
-  emailLayoutFilePath: string,
+  emailLayoutAbsPath: string,
   emailLayout: EmailLayoutData,
 ): Promise<void> =>
-  fs.outputJson(emailLayoutFilePath, JSON.parse(emailLayout.html_layout), {
+  fs.outputJson(emailLayoutAbsPath, emailLayout, {
     spaces: DOUBLE_SPACES,
   });

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -1,0 +1,16 @@
+import * as fs from "fs-extra";
+
+import { DOUBLE_SPACES } from "@/lib/helpers/json";
+
+import { EmailLayoutData } from "./types";
+
+/*
+ * Write a single email layout file.
+ */
+export const writeEmailLayoutFile = async (
+  emailLayoutFilePath: string,
+  emailLayout: EmailLayoutData,
+): Promise<void> =>
+  fs.outputJson(emailLayoutFilePath, JSON.parse(emailLayout.html_layout), {
+    spaces: DOUBLE_SPACES,
+  });

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -86,19 +86,15 @@ export const readExtractedFileSync = (
  * Note, the uniqueness check is based on reading from and writing to
  * uniqueFilePaths, which is MUTATED in place.
  */
-
-/* eslint-disable max-params */
 export const validateExtractedFilePath = (
   val: unknown,
   sourceFileAbspath: string,
-  sourceJson: string,
   uniqueFilePaths: Record<string, boolean>,
   objPathToFieldStr: string,
 ): JsonDataError | undefined => {
-  const jsonPath = path.resolve(sourceFileAbspath, sourceJson);
   // Validate the file path format, and that it is unique per entity.
   if (
-    !checkIfValidExtractedFilePathFormat(val, jsonPath) ||
+    !checkIfValidExtractedFilePathFormat(val, sourceFileAbspath) ||
     typeof val !== "string" ||
     val in uniqueFilePaths
   ) {

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -98,7 +98,6 @@ export const readExtractedFileSync = (
  * Note: does not validate the presence of the file nor the uniqueness of the
  * file path.
  */
-
 export const checkIfValidExtractedFilePathFormat = (
   relpath: unknown,
   sourceFileAbspath: string,

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -97,26 +97,13 @@ export const readExtractedFileSync = (
  *
  * Note: does not validate the presence of the file nor the uniqueness of the
  * file path.
- *
- * Options:
- * - withAbsolutePaths: it will return non absoulte paths as valid.
- *   For example:
- *     html_layout@: "html_layout.html"
- *
  */
-type CheckValidExtractedFilePathOptions = {
-  withAbsolutePaths?: boolean;
-};
 
 export const checkIfValidExtractedFilePathFormat = (
   relpath: unknown,
   sourceFileAbspath: string,
-  opts: CheckValidExtractedFilePathOptions = {},
 ): boolean => {
-  const { withAbsolutePaths = false } = opts;
   if (typeof relpath !== "string") return false;
-  // If the option for allowing absolute paths was passed, and the path is indeed absolute, then it's valid.
-  if (withAbsolutePaths && !path.isAbsolute(relpath)) return true;
 
   if (path.isAbsolute(relpath)) return false;
 

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -1,0 +1,80 @@
+import * as path from "node:path";
+
+import * as fs from "fs-extra";
+
+import { formatErrors, JsonDataError } from "@/lib/helpers/error";
+import { ParsedJson, parseJson } from "@/lib/helpers/json";
+import { validateLiquidSyntax } from "@/lib/helpers/liquid";
+import { VISUAL_BLOCKS_JSON } from "@/lib/marshal/workflow";
+import { EmailLayoutDirContext, WorkflowDirContext } from "@/lib/run-context";
+
+// Mark any template fields we are extracting out with this suffix as a rule,
+// so we can reliably interpret the field value.
+export const FILEPATH_MARKER = "@";
+export const FILEPATH_MARKED_RE = new RegExp(`${FILEPATH_MARKER}$`);
+
+/*
+ * Read the file at the given path if it exists, validate the content as
+ * applicable, and return the content string or an error.
+ */
+type ExtractedFileContent = string | ParsedJson;
+type ReadExtractedFileResult =
+  | [undefined, JsonDataError]
+  | [ExtractedFileContent, undefined];
+
+// The following files are exepected to have valid json content, and should be
+// decoded and joined into the main JSON file.
+const DECODABLE_JSON_FILES = new Set([VISUAL_BLOCKS_JSON]);
+
+export const readExtractedFileSync = (
+  relpath: string,
+  dirCtx: WorkflowDirContext | EmailLayoutDirContext,
+  objPathToFieldStr = "",
+): ReadExtractedFileResult => {
+  // Check if the file actually exists at the given file path.
+  const abspath = path.resolve(dirCtx.abspath, relpath);
+  const exists = fs.pathExistsSync(abspath);
+  if (!exists) {
+    const error = new JsonDataError(
+      "must be a relative path string to a file that exists",
+      objPathToFieldStr,
+    );
+    return [undefined, error];
+  }
+
+  // Read the file and check for valid liquid syntax given it is supported
+  // across all message templates and file extensions.
+  const contentStr = fs.readFileSync(abspath, "utf8");
+  const liquidParseError = validateLiquidSyntax(contentStr);
+
+  if (liquidParseError) {
+    const error = new JsonDataError(
+      `points to a file that contains invalid liquid syntax (${relpath})\n\n` +
+        formatErrors([liquidParseError], { indentBy: 2 }),
+      objPathToFieldStr,
+    );
+
+    return [undefined, error];
+  }
+
+  // If the file is expected to contain decodable json, then parse the contentStr
+  // as such.
+  const fileName = path.basename(abspath.toLowerCase());
+  const decodable = DECODABLE_JSON_FILES.has(fileName);
+
+  const [content, jsonParseErrors] = decodable
+    ? parseJson(contentStr)
+    : [contentStr, []];
+
+  if (jsonParseErrors.length > 0) {
+    const error = new JsonDataError(
+      `points to a file with invalid content (${relpath})\n\n` +
+        formatErrors(jsonParseErrors, { indentBy: 2 }),
+      objPathToFieldStr,
+    );
+
+    return [undefined, error];
+  }
+
+  return [content!, undefined];
+};

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -80,6 +80,43 @@ export const readExtractedFileSync = (
 };
 
 /*
+ * Validate the extracted file path based on its format and uniqueness (but not
+ * the presence).
+ *
+ * Note, the uniqueness check is based on reading from and writing to
+ * uniqueFilePaths, which is MUTATED in place.
+ */
+
+/* eslint-disable max-params */
+export const validateExtractedFilePath = (
+  val: unknown,
+  sourceFileAbspath: string,
+  sourceJson: string,
+  uniqueFilePaths: Record<string, boolean>,
+  objPathToFieldStr: string,
+): JsonDataError | undefined => {
+  const jsonPath = path.resolve(sourceFileAbspath, sourceJson);
+  // Validate the file path format, and that it is unique per entity.
+  if (
+    !checkIfValidExtractedFilePathFormat(val, jsonPath) ||
+    typeof val !== "string" ||
+    val in uniqueFilePaths
+  ) {
+    const error = new JsonDataError(
+      "must be a relative path string to a unique file within the directory",
+      objPathToFieldStr,
+    );
+
+    return error;
+  }
+
+  // Keep track of all the valid extracted file paths that have been seen, so
+  // we can validate each file path's uniqueness as we traverse.
+  uniqueFilePaths[val] = true;
+  return undefined;
+};
+
+/*
  * Validate the file path format of an extracted field. The file path must be:
  *
  * 1) Expressed as a relative path.

--- a/src/lib/marshal/workflow/generator.ts
+++ b/src/lib/marshal/workflow/generator.ts
@@ -2,9 +2,10 @@ import * as path from "node:path";
 
 import { assign, get, zip } from "lodash";
 
+import { FILEPATH_MARKER } from "@/lib/marshal/shared/helpers";
 import { WorkflowDirContext } from "@/lib/run-context";
 
-import { FILEPATH_MARKER, WORKFLOW_JSON } from "./helpers";
+import { WORKFLOW_JSON } from "./helpers";
 import { StepType, WorkflowStepData } from "./types";
 import { WorkflowDirBundle, writeWorkflowDirFromBundle } from "./writer";
 

--- a/src/lib/marshal/workflow/helpers.ts
+++ b/src/lib/marshal/workflow/helpers.ts
@@ -16,12 +16,6 @@ export const VISUAL_BLOCKS_JSON = "visual_blocks.json";
 export const workflowJsonPath = (workflowDirCtx: WorkflowDirContext): string =>
   path.resolve(workflowDirCtx.abspath, WORKFLOW_JSON);
 
-// Mark any template fields we are extracting out with this suffix as a rule,
-// so we can reliably interpret the field value.
-// TODO: Move this up to a top level directory when re-used for other resources.
-export const FILEPATH_MARKER = "@";
-export const FILEPATH_MARKED_RE = new RegExp(`${FILEPATH_MARKER}$`);
-
 /*
  * Validates a string input for a workflow key, and returns an error reason
  * if invalid.

--- a/src/lib/marshal/workflow/reader.ts
+++ b/src/lib/marshal/workflow/reader.ts
@@ -5,13 +5,7 @@ import * as fs from "fs-extra";
 import { hasIn, set } from "lodash";
 
 import { formatErrors, JsonDataError, SourceError } from "@/lib/helpers/error";
-import {
-  ParsedJson,
-  parseJson,
-  ParseJsonResult,
-  readJson,
-} from "@/lib/helpers/json";
-import { validateLiquidSyntax } from "@/lib/helpers/liquid";
+import { ParseJsonResult, readJson } from "@/lib/helpers/json";
 import {
   AnyObj,
   getLastFound,
@@ -19,13 +13,15 @@ import {
   ObjPath,
   omitDeep,
 } from "@/lib/helpers/object";
+import {
+  FILEPATH_MARKED_RE,
+  readExtractedFileSync,
+} from "@/lib/marshal/shared/helpers";
 import { WorkflowDirContext } from "@/lib/run-context";
 
 import {
-  FILEPATH_MARKED_RE,
   isWorkflowDir,
   lsWorkflowJson,
-  VISUAL_BLOCKS_JSON,
   WORKFLOW_JSON,
   WorkflowCommandTarget,
 } from "./helpers";
@@ -38,10 +34,6 @@ export type WorkflowDirData = WorkflowDirContext & {
 // For now we support up to two levels of content extraction in workflow.json.
 // (e.g. workflow.json, then visual_blocks.json)
 const MAX_EXTRACTION_LEVEL = 2;
-
-// The following files are exepected to have valid json content, and should be
-// decoded and joined into the main workflow.json.
-const DECODABLE_JSON_FILES = new Set([VISUAL_BLOCKS_JSON]);
 
 /*
  * Validate the file path format of an extracted field. The file path must be:
@@ -109,68 +101,6 @@ const validateExtractedFilePath = (
   uniqueFilePaths[val] = true;
 
   return undefined;
-};
-
-/*
- * Read the file at the given path if it exists, validate the content as
- * applicable, and return the content string or an error.
- */
-type ExtractedFileContent = string | ParsedJson;
-type ReadExtractedFileResult =
-  | [undefined, JsonDataError]
-  | [ExtractedFileContent, undefined];
-
-const readExtractedFileSync = (
-  relpath: string,
-  workflowDirCtx: WorkflowDirContext,
-  objPathToFieldStr = "",
-): ReadExtractedFileResult => {
-  // Check if the file actually exists at the given file path.
-  const abspath = path.resolve(workflowDirCtx.abspath, relpath);
-  const exists = fs.pathExistsSync(abspath);
-  if (!exists) {
-    const error = new JsonDataError(
-      "must be a relative path string to a file that exists",
-      objPathToFieldStr,
-    );
-    return [undefined, error];
-  }
-
-  // Read the file and check for valid liquid syntax given it is supported
-  // across all message templates and file extensions.
-  const contentStr = fs.readFileSync(abspath, "utf8");
-  const liquidParseError = validateLiquidSyntax(contentStr);
-
-  if (liquidParseError) {
-    const error = new JsonDataError(
-      `points to a file that contains invalid liquid syntax (${relpath})\n\n` +
-        formatErrors([liquidParseError], { indentBy: 2 }),
-      objPathToFieldStr,
-    );
-
-    return [undefined, error];
-  }
-
-  // If the file is expected to contain decodable json, then parse the contentStr
-  // as such.
-  const fileName = path.basename(abspath.toLowerCase());
-  const decodable = DECODABLE_JSON_FILES.has(fileName);
-
-  const [content, jsonParseErrors] = decodable
-    ? parseJson(contentStr)
-    : [contentStr, []];
-
-  if (jsonParseErrors.length > 0) {
-    const error = new JsonDataError(
-      `points to a file with invalid content (${relpath})\n\n` +
-        formatErrors(jsonParseErrors, { indentBy: 2 }),
-      objPathToFieldStr,
-    );
-
-    return [undefined, error];
-  }
-
-  return [content!, undefined];
 };
 
 /*
@@ -424,4 +354,4 @@ export const readAllForCommandTarget = async (
 };
 
 // Exported for tests.
-export { checkIfValidExtractedFilePathFormat, readExtractedFileSync };
+export { checkIfValidExtractedFilePathFormat };

--- a/src/lib/marshal/workflow/reader.ts
+++ b/src/lib/marshal/workflow/reader.ts
@@ -113,8 +113,7 @@ const joinExtractedFiles = async (
 
       const invalidFilePathError = validateExtractedFilePath(
         rebasedFilePath,
-        workflowDirCtx.abspath,
-        WORKFLOW_JSON,
+        path.resolve(workflowDirCtx.abspath, WORKFLOW_JSON),
         uniqueFilePaths,
         objPathToFieldStr,
       );

--- a/src/lib/marshal/workflow/writer.ts
+++ b/src/lib/marshal/workflow/writer.ts
@@ -22,15 +22,14 @@ import {
   omitDeep,
   split,
 } from "@/lib/helpers/object";
-import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
-import { WorkflowDirContext } from "@/lib/run-context";
-
 import {
   FILEPATH_MARKED_RE,
   FILEPATH_MARKER,
-  isWorkflowDir,
-  WORKFLOW_JSON,
-} from "./helpers";
+} from "@/lib/marshal/shared/helpers";
+import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
+import { WorkflowDirContext } from "@/lib/run-context";
+
+import { isWorkflowDir, WORKFLOW_JSON } from "./helpers";
 import { readWorkflowDir } from "./reader";
 import { StepType, WorkflowData, WorkflowStepData } from "./types";
 

--- a/src/lib/run-context/loader.ts
+++ b/src/lib/run-context/loader.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 
 import * as Translation from "@/lib/marshal/translation";
 import * as Workflow from "@/lib/marshal/workflow";
+import * as EmailLayout from "@/lib/marshal/email-layout";
 
 import { RunContext } from "./types";
 
@@ -32,6 +33,17 @@ const evaluateRecursively = async (
   if (!ctx.resourceDir && isTranslationDir) {
     ctx.resourceDir = {
       type: "translation",
+      key: path.basename(currDir),
+      abspath: currDir,
+      exists: true,
+    };
+  }
+
+  // Check if we are inside a layout directory, and if so update the context.
+  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir)
+  if (!ctx.resourceDir && isLayoutDir) {
+    ctx.resourceDir = {
+      type: "layout",
       key: path.basename(currDir),
       abspath: currDir,
       exists: true,

--- a/src/lib/run-context/loader.ts
+++ b/src/lib/run-context/loader.ts
@@ -30,7 +30,7 @@ const evaluateRecursively = async (
   const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
   if (!ctx.resourceDir && isLayoutDir) {
     ctx.resourceDir = {
-      type: "layout",
+      type: "email_layout",
       key: path.basename(currDir),
       abspath: currDir,
       exists: true,

--- a/src/lib/run-context/loader.ts
+++ b/src/lib/run-context/loader.ts
@@ -5,9 +5,9 @@
  */
 import * as path from "node:path";
 
+import * as EmailLayout from "@/lib/marshal/email-layout";
 import * as Translation from "@/lib/marshal/translation";
 import * as Workflow from "@/lib/marshal/workflow";
-import * as EmailLayout from "@/lib/marshal/email-layout";
 
 import { RunContext } from "./types";
 
@@ -40,7 +40,7 @@ const evaluateRecursively = async (
   }
 
   // Check if we are inside a layout directory, and if so update the context.
-  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir)
+  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
   if (!ctx.resourceDir && isLayoutDir) {
     ctx.resourceDir = {
       type: "layout",

--- a/src/lib/run-context/loader.ts
+++ b/src/lib/run-context/loader.ts
@@ -27,8 +27,8 @@ const evaluateRecursively = async (
   }
 
   // Check if we are inside a layout directory, and if so update the context.
-  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
-  if (!ctx.resourceDir && isLayoutDir) {
+  const isEmailLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
+  if (!ctx.resourceDir && isEmailLayoutDir) {
     ctx.resourceDir = {
       type: "email_layout",
       key: path.basename(currDir),

--- a/src/lib/run-context/loader.ts
+++ b/src/lib/run-context/loader.ts
@@ -26,6 +26,17 @@ const evaluateRecursively = async (
     };
   }
 
+  // Check if we are inside a layout directory, and if so update the context.
+  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
+  if (!ctx.resourceDir && isLayoutDir) {
+    ctx.resourceDir = {
+      type: "layout",
+      key: path.basename(currDir),
+      abspath: currDir,
+      exists: true,
+    };
+  }
+
   // NOTE: Must keep this check as last in the order of directory-type checks
   // since the `isTranslationDir` only checks that the directory name is a
   // valid locale name.
@@ -33,17 +44,6 @@ const evaluateRecursively = async (
   if (!ctx.resourceDir && isTranslationDir) {
     ctx.resourceDir = {
       type: "translation",
-      key: path.basename(currDir),
-      abspath: currDir,
-      exists: true,
-    };
-  }
-
-  // Check if we are inside a layout directory, and if so update the context.
-  const isLayoutDir = await EmailLayout.isEmailLayoutDir(currDir);
-  if (!ctx.resourceDir && isLayoutDir) {
-    ctx.resourceDir = {
-      type: "layout",
       key: path.basename(currDir),
       abspath: currDir,
       exists: true,

--- a/src/lib/run-context/types.ts
+++ b/src/lib/run-context/types.ts
@@ -16,11 +16,7 @@ export type T = RunContext;
  * Resource directory context
  */
 
-export type ResourceType =
-  | "workflow"
-  | "layout"
-  | "translation"
-  | "email_layout";
+export type ResourceType = "workflow" | "layout" | "translation";
 
 type ResourceDirContextBase = DirContext & {
   type: ResourceType;
@@ -39,15 +35,10 @@ export type TranslationDirContext = ResourceDirContextBase & {
   type: "translation";
 };
 
-export type EmailLayoutDirContext = ResourceDirContextBase & {
-  type: "email_layout";
-};
-
 export type ResourceDirContext =
   | WorkflowDirContext
   | LayoutDirContext
-  | TranslationDirContext
-  | EmailLayoutDirContext;
+  | TranslationDirContext;
 
 export type ResourceTarget = {
   commandId: string;

--- a/src/lib/run-context/types.ts
+++ b/src/lib/run-context/types.ts
@@ -27,7 +27,7 @@ export type WorkflowDirContext = ResourceDirContextBase & {
   type: "workflow";
 };
 
-type LayoutDirContext = ResourceDirContextBase & {
+export type LayoutDirContext = ResourceDirContextBase & {
   type: "layout";
 };
 

--- a/src/lib/run-context/types.ts
+++ b/src/lib/run-context/types.ts
@@ -16,7 +16,11 @@ export type T = RunContext;
  * Resource directory context
  */
 
-export type ResourceType = "workflow" | "layout" | "translation";
+export type ResourceType =
+  | "workflow"
+  | "layout"
+  | "translation"
+  | "email_layout";
 
 type ResourceDirContextBase = DirContext & {
   type: ResourceType;
@@ -35,10 +39,15 @@ export type TranslationDirContext = ResourceDirContextBase & {
   type: "translation";
 };
 
+export type EmailLayoutDirContext = ResourceDirContextBase & {
+  type: "email_layout";
+};
+
 export type ResourceDirContext =
   | WorkflowDirContext
   | LayoutDirContext
-  | TranslationDirContext;
+  | TranslationDirContext
+  | EmailLayoutDirContext;
 
 export type ResourceTarget = {
   commandId: string;

--- a/src/lib/run-context/types.ts
+++ b/src/lib/run-context/types.ts
@@ -16,7 +16,7 @@ export type T = RunContext;
  * Resource directory context
  */
 
-export type ResourceType = "workflow" | "layout" | "translation";
+export type ResourceType = "workflow" | "email_layout" | "translation";
 
 type ResourceDirContextBase = DirContext & {
   type: ResourceType;
@@ -27,8 +27,8 @@ export type WorkflowDirContext = ResourceDirContextBase & {
   type: "workflow";
 };
 
-export type LayoutDirContext = ResourceDirContextBase & {
-  type: "layout";
+export type EmailLayoutDirContext = ResourceDirContextBase & {
+  type: "email_layout";
 };
 
 export type TranslationDirContext = ResourceDirContextBase & {
@@ -37,7 +37,7 @@ export type TranslationDirContext = ResourceDirContextBase & {
 
 export type ResourceDirContext =
   | WorkflowDirContext
-  | LayoutDirContext
+  | EmailLayoutDirContext
   | TranslationDirContext;
 
 export type ResourceTarget = {

--- a/test/commands/layout/pull.test.ts
+++ b/test/commands/layout/pull.test.ts
@@ -133,7 +133,7 @@ describe("commands/layout/pull", () => {
       .stdout()
       .command(["layout pull", "--all", "--layouts-dir", "./layouts"])
       .it(
-        "writes a layout dir to the file system (+ the layout JSON file), with individual layouts dirs inside",
+        "writes a layout dir to the file system, with individual layouts dirs inside (plus a layout JSON file)",
         () => {
           const path1 = path.resolve(
             sandboxDir,

--- a/test/commands/layout/pull.test.ts
+++ b/test/commands/layout/pull.test.ts
@@ -42,7 +42,9 @@ const setupWithListLayoutsStub = (
       sinon.stub().resolves(
         factory.resp({
           data: {
-            entries: manyLayoutsAttrs.map((attrs) => factory.emailLayout(attrs)),
+            entries: manyLayoutsAttrs.map((attrs) =>
+              factory.emailLayout(attrs),
+            ),
             page_info: factory.pageInfo(),
           },
         }),
@@ -127,18 +129,34 @@ describe("commands/layout/pull", () => {
       { key: "default" },
       { key: "messages" },
       { key: "transactional" },
-    ).stdout()
+    )
+      .stdout()
       .command(["layout pull", "--all", "--layouts-dir", "./layouts"])
       .it(
         "writes a layout dir to the file system (+ the layout JSON file), with individual layouts dirs inside",
         () => {
-          const path1 = path.resolve(sandboxDir, "layouts", "default", "default.json");
+          const path1 = path.resolve(
+            sandboxDir,
+            "layouts",
+            "default",
+            "default.json",
+          );
           expect(fs.pathExistsSync(path1)).to.equal(true);
 
-          const path2 = path.resolve(sandboxDir, "layouts", "messages", "messages.json");
+          const path2 = path.resolve(
+            sandboxDir,
+            "layouts",
+            "messages",
+            "messages.json",
+          );
           expect(fs.pathExistsSync(path2)).to.equal(true);
 
-          const path3 = path.resolve(sandboxDir, "layouts", "transactional", "transactional.json");
+          const path3 = path.resolve(
+            sandboxDir,
+            "layouts",
+            "transactional",
+            "transactional.json",
+          );
           expect(fs.pathExistsSync(path3)).to.equal(true);
         },
       );
@@ -154,5 +172,4 @@ describe("commands/layout/pull", () => {
       )
       .it("throws an error");
   });
-
 });

--- a/test/commands/layout/pull.test.ts
+++ b/test/commands/layout/pull.test.ts
@@ -93,7 +93,7 @@ describe("commands/layout/pull", () => {
       .command(["layout pull", "messages"])
       .it("writes an email layout dir to the file system", () => {
         const exists = fs.pathExistsSync(
-          path.resolve(sandboxDir, "messages", "messages.json"),
+          path.resolve(sandboxDir, "messages", "layout.json"),
         );
 
         expect(exists).to.equal(true);
@@ -139,7 +139,7 @@ describe("commands/layout/pull", () => {
             sandboxDir,
             "layouts",
             "default",
-            "default.json",
+            "layout.json",
           );
           expect(fs.pathExistsSync(path1)).to.equal(true);
 
@@ -147,7 +147,7 @@ describe("commands/layout/pull", () => {
             sandboxDir,
             "layouts",
             "messages",
-            "messages.json",
+            "layout.json",
           );
           expect(fs.pathExistsSync(path2)).to.equal(true);
 
@@ -155,7 +155,7 @@ describe("commands/layout/pull", () => {
             sandboxDir,
             "layouts",
             "transactional",
-            "transactional.json",
+            "layout.json",
           );
           expect(fs.pathExistsSync(path3)).to.equal(true);
         },

--- a/test/commands/layout/pull.test.ts
+++ b/test/commands/layout/pull.test.ts
@@ -1,0 +1,158 @@
+import * as path from "node:path";
+
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import * as fs from "fs-extra";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+import { sandboxDir } from "@/lib/helpers/const";
+import { EmailLayoutData } from "@/lib/marshal/email-layout";
+
+const currCwd = process.cwd();
+
+const setupWithGetLayoutStub = (emailLayoutAttrs = {}) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(
+      KnockApiV1.prototype,
+      "getEmailLayout",
+      sinon.stub().resolves(
+        factory.resp({
+          data: factory.emailLayout(emailLayoutAttrs),
+        }),
+      ),
+    )
+    .stub(
+      enquirer.prototype,
+      "prompt",
+      sinon.stub().onFirstCall().resolves({ input: "y" }),
+    );
+
+const setupWithListLayoutsStub = (
+  ...manyLayoutsAttrs: Partial<EmailLayoutData>[]
+) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(
+      KnockApiV1.prototype,
+      "listEmailLayouts",
+      sinon.stub().resolves(
+        factory.resp({
+          data: {
+            entries: manyLayoutsAttrs.map((attrs) => factory.emailLayout(attrs)),
+            page_info: factory.pageInfo(),
+          },
+        }),
+      ),
+    )
+    .stub(
+      enquirer.prototype,
+      "prompt",
+      sinon.stub().onFirstCall().resolves({ input: "y" }),
+    );
+
+describe("commands/layout/pull", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+    process.chdir(sandboxDir);
+  });
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  describe("given an email layout key arg", () => {
+    setupWithGetLayoutStub({ key: "default" })
+      .stdout()
+      .command(["layout pull", "default"])
+      .it("calls apiV1 getEmailLayout with an annotate param", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getEmailLayout as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                emailLayoutKey: "default",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                annotate: true,
+              }),
+          ),
+        );
+      });
+
+    setupWithGetLayoutStub({ key: "messages" })
+      .stdout()
+      .command(["layout pull", "messages"])
+      .it("writes an email layout dir to the file system", () => {
+        const exists = fs.pathExistsSync(
+          path.resolve(sandboxDir, "messages", "messages.json"),
+        );
+
+        expect(exists).to.equal(true);
+      });
+  });
+
+  describe("given a --all flag", () => {
+    setupWithListLayoutsStub({ key: "messages" }, { key: "transactional" })
+      .stdout()
+      .command(["layout pull", "--all", "--layouts-dir", "./layouts"])
+      .it("calls apiV1 listEmailLayouts with an annotate param", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listEmailLayouts as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                all: true,
+                "layouts-dir": {
+                  abspath: path.resolve(sandboxDir, "layouts"),
+                  exists: false,
+                },
+                "service-token": "valid-token",
+                environment: "development",
+                annotate: true,
+                limit: 100,
+              }),
+          ),
+        );
+      });
+
+    setupWithListLayoutsStub(
+      { key: "default" },
+      { key: "messages" },
+      { key: "transactional" },
+    ).stdout()
+      .command(["layout pull", "--all", "--layouts-dir", "./layouts"])
+      .it(
+        "writes a layout dir to the file system (+ the layout JSON file), with individual layouts dirs inside",
+        () => {
+          const path1 = path.resolve(sandboxDir, "layouts", "default", "default.json");
+          expect(fs.pathExistsSync(path1)).to.equal(true);
+
+          const path2 = path.resolve(sandboxDir, "layouts", "messages", "messages.json");
+          expect(fs.pathExistsSync(path2)).to.equal(true);
+
+          const path3 = path.resolve(sandboxDir, "layouts", "transactional", "transactional.json");
+          expect(fs.pathExistsSync(path3)).to.equal(true);
+        },
+      );
+  });
+
+  describe("given both an email layout key arg and a --all flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .command(["layout pull", "default", "--all"])
+      .catch(
+        "emailLayoutKey arg `default` cannot also be provided when using --all",
+      )
+      .it("throws an error");
+  });
+
+});

--- a/test/lib/marshal/layout/reader.test.ts
+++ b/test/lib/marshal/layout/reader.test.ts
@@ -32,7 +32,6 @@ describe("lib/marshal/layout/reader", () => {
         const result = checkIfValidExtractedFilePathFormat(
           abspath,
           emailLayoutDirCtx.abspath,
-          { withAbsolutePaths: true },
         );
 
         expect(result).to.equal(true);

--- a/test/lib/marshal/layout/reader.test.ts
+++ b/test/lib/marshal/layout/reader.test.ts
@@ -4,13 +4,12 @@ import { expect } from "@oclif/test";
 import * as fs from "fs-extra";
 import { get } from "lodash";
 
-import { xpath } from "@/../test/support";
 import { sandboxDir } from "@/lib/helpers/const";
 import { JsonDataError } from "@/lib/helpers/error";
 import { LAYOUT_JSON } from "@/lib/marshal/email-layout";
+import { readEmailLayoutDir } from "@/lib/marshal/email-layout/reader";
 import { readExtractedFileSync } from "@/lib/marshal/shared/helpers";
 import { EmailLayoutDirContext } from "@/lib/run-context";
-import { readEmailLayoutDir } from "@/lib/marshal/email-layout/reader";
 
 const currCwd = process.cwd();
 
@@ -129,14 +128,15 @@ describe("lib/marshal/layout/reader", () => {
       fs.removeSync(sandboxDir);
     });
 
-
     describe("by default without any opts", () => {
       it("reads layout.json without the readonly field and extracted files joined", async () => {
         const [layout] = await readEmailLayoutDir(emailLayoutDirCtx);
 
         expect(get(layout, ["name"])).to.equal("Transactional");
         expect(get(layout, ["html_layout@"])).to.equal("html_layout.html");
-        expect(get(layout, ["text_layout@"])).to.equal("text-layout-examples/text_layout.txt");
+        expect(get(layout, ["text_layout@"])).to.equal(
+          "text-layout-examples/text_layout.txt",
+        );
       });
     });
 
@@ -148,13 +148,15 @@ describe("lib/marshal/layout/reader", () => {
 
         expect(get(layout, ["name"])).to.equal("Transactional");
         expect(get(layout, ["html_layout@"])).to.equal("html_layout.html");
-        expect(get(layout, ["text_layout@"])).to.equal("text-layout-examples/text_layout.txt");
+        expect(get(layout, ["text_layout@"])).to.equal(
+          "text-layout-examples/text_layout.txt",
+        );
 
         expect(get(layout, ["__readonly"])).to.eql({
           key: "transactional",
           environment: "development",
           created_at: "2023-09-18T18:32:18.398053Z",
-          updated_at: "2023-10-02T19:24:48.714630Z"
+          updated_at: "2023-10-02T19:24:48.714630Z",
         });
       });
 
@@ -167,13 +169,14 @@ describe("lib/marshal/layout/reader", () => {
           expect(get(layout, ["name"])).to.equal("Transactional");
 
           // HTML layout content should be inlined into layout data
-          expect(get(layout, ["html_layout"])).to.contain("<html><body><p> example </p></body></html>");
+          expect(get(layout, ["html_layout"])).to.contain(
+            "<html><body><p> example </p></body></html>",
+          );
 
           // Text layout content should be inlined into layout data
           expect(get(layout, ["text_layout"])).to.contains("foo {{content}}");
         });
       });
-
     });
   });
 });

--- a/test/lib/marshal/layout/reader.test.ts
+++ b/test/lib/marshal/layout/reader.test.ts
@@ -8,12 +8,68 @@ import { sandboxDir } from "@/lib/helpers/const";
 import { JsonDataError } from "@/lib/helpers/error";
 import { LAYOUT_JSON } from "@/lib/marshal/email-layout";
 import { readEmailLayoutDir } from "@/lib/marshal/email-layout/reader";
-import { readExtractedFileSync } from "@/lib/marshal/shared/helpers";
+import {
+  checkIfValidExtractedFilePathFormat,
+  readExtractedFileSync,
+} from "@/lib/marshal/shared/helpers";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
 const currCwd = process.cwd();
 
 describe("lib/marshal/layout/reader", () => {
+  describe("checkIfValidExtractedFilePathFormat", () => {
+    const emailLayoutDirCtx = {
+      type: "email_layout",
+      key: "transactional",
+      abspath: "/layouts/transactional",
+      exists: true,
+    } as EmailLayoutDirContext;
+
+    describe("given an absolute path", () => {
+      it("returns true as it's valid", () => {
+        const abspath = "html_layout.html";
+
+        const result = checkIfValidExtractedFilePathFormat(
+          abspath,
+          emailLayoutDirCtx.abspath,
+          { withAbsolutePaths: true },
+        );
+
+        expect(result).to.equal(true);
+      });
+    });
+
+    describe("given an relative path that resolves outside the layouts dir", () => {
+      it("returns false as it is invalid", () => {
+        const relpath = "../foo";
+
+        const result = checkIfValidExtractedFilePathFormat(
+          relpath,
+          emailLayoutDirCtx.abspath,
+        );
+
+        expect(result).to.equal(false);
+      });
+    });
+
+    describe("given an relative path that resolves inside the layout dir", () => {
+      it("returns true as it is valid", () => {
+        const relpath1 = "text-layouts/text_layout.txt";
+        const result1 = checkIfValidExtractedFilePathFormat(
+          relpath1,
+          emailLayoutDirCtx.abspath,
+        );
+        expect(result1).to.equal(true);
+
+        const relpath2 = "./text-layouts/text_layout.txt";
+        const result2 = checkIfValidExtractedFilePathFormat(
+          relpath2,
+          emailLayoutDirCtx.abspath,
+        );
+        expect(result2).to.equal(true);
+      });
+    });
+  });
   describe("readExtractedFileSync", () => {
     const emailLayoutDirCtx: EmailLayoutDirContext = {
       type: "email_layout",

--- a/test/lib/marshal/layout/reader.test.ts
+++ b/test/lib/marshal/layout/reader.test.ts
@@ -1,0 +1,179 @@
+import * as path from "node:path";
+
+import { expect } from "@oclif/test";
+import * as fs from "fs-extra";
+import { get } from "lodash";
+
+import { xpath } from "@/../test/support";
+import { sandboxDir } from "@/lib/helpers/const";
+import { JsonDataError } from "@/lib/helpers/error";
+import { LAYOUT_JSON } from "@/lib/marshal/email-layout";
+import { readExtractedFileSync } from "@/lib/marshal/shared/helpers";
+import { EmailLayoutDirContext } from "@/lib/run-context";
+import { readEmailLayoutDir } from "@/lib/marshal/email-layout/reader";
+
+const currCwd = process.cwd();
+
+describe("lib/marshal/layout/reader", () => {
+  describe("readExtractedFileSync", () => {
+    const emailLayoutDirCtx: EmailLayoutDirContext = {
+      type: "email_layout",
+      key: "transactional",
+      abspath: path.resolve(sandboxDir, "transactional"),
+      exists: true,
+    };
+
+    beforeEach(() => {
+      fs.removeSync(sandboxDir);
+      fs.ensureDir(emailLayoutDirCtx.abspath);
+    });
+    after(() => fs.removeSync(sandboxDir));
+
+    describe("given a valid liquid text layout", () => {
+      it("returns the read text layout content without errors", async () => {
+        const fileContent = `
+          {{ vars.app_name }} ({{ vars.app_url }})
+          <p>
+          Hello {{ recipient.name }}
+          </p>
+       `.trimStart();
+
+        const filePath = path.resolve(emailLayoutDirCtx.abspath, "sample.txt");
+        fs.outputFileSync(filePath, fileContent);
+
+        const [readContent, error] = readExtractedFileSync(
+          "sample.txt",
+          emailLayoutDirCtx,
+        );
+
+        expect(readContent).to.be.a("string");
+        expect(error).to.equal(undefined);
+      });
+    });
+
+    describe("given an invalid liquid text layout", () => {
+      it("returns the read text layout content with errors", async () => {
+        const fileContent = `
+          {{ vars.app_name }} ({{ vars.app_url }})
+          <p>
+          Hello {{ recipient.name 
+          </p>
+       `.trimStart();
+
+        const filePath = path.resolve(emailLayoutDirCtx.abspath, "sample.txt");
+        fs.outputFileSync(filePath, fileContent);
+
+        const [readContent, error] = readExtractedFileSync(
+          "sample.txt",
+          emailLayoutDirCtx,
+        );
+
+        expect(readContent).to.equal(undefined);
+        expect(error).to.be.an.instanceof(JsonDataError);
+      });
+    });
+  });
+
+  describe("readEmailLayoutDir", () => {
+    const sampleEmailLayoutJson = {
+      name: "Transactional",
+      "html_layout@": "html_layout.html",
+      "text_layout@": "text-layout-examples/text_layout.txt",
+      __readonly: {
+        key: "transactional",
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+        updated_at: "2023-10-02T19:24:48.714630Z",
+      },
+    };
+
+    const emailLayoutDirPath = path.join(
+      sandboxDir,
+      "layouts",
+      "transactional",
+    );
+
+    const emailLayoutDirCtx: EmailLayoutDirContext = {
+      type: "email_layout",
+      key: "transactional",
+      abspath: emailLayoutDirPath,
+      exists: true,
+    };
+
+    before(() => {
+      fs.removeSync(sandboxDir);
+
+      // Set up a sample layout directory
+      fs.outputJsonSync(
+        path.join(emailLayoutDirPath, LAYOUT_JSON),
+        sampleEmailLayoutJson,
+      );
+
+      fs.outputJsonSync(
+        path.join(emailLayoutDirPath, "html_layout.html"),
+        "<html><body><p> example </p></body></html>",
+      );
+
+      fs.outputJsonSync(
+        path.join(
+          emailLayoutDirPath,
+          "text-layout-examples",
+          "text_layout.txt",
+        ),
+        "foo {{content}}",
+      );
+    });
+
+    after(() => {
+      process.chdir(currCwd);
+      fs.removeSync(sandboxDir);
+    });
+
+
+    describe("by default without any opts", () => {
+      it("reads layout.json without the readonly field and extracted files joined", async () => {
+        const [layout] = await readEmailLayoutDir(emailLayoutDirCtx);
+
+        expect(get(layout, ["name"])).to.equal("Transactional");
+        expect(get(layout, ["html_layout@"])).to.equal("html_layout.html");
+        expect(get(layout, ["text_layout@"])).to.equal("text-layout-examples/text_layout.txt");
+      });
+    });
+
+    describe("with the withReadonlyField opt of true", () => {
+      it("reads layout.json with the readonly field", async () => {
+        const [layout] = await readEmailLayoutDir(emailLayoutDirCtx, {
+          withReadonlyField: true,
+        });
+
+        expect(get(layout, ["name"])).to.equal("Transactional");
+        expect(get(layout, ["html_layout@"])).to.equal("html_layout.html");
+        expect(get(layout, ["text_layout@"])).to.equal("text-layout-examples/text_layout.txt");
+
+        expect(get(layout, ["__readonly"])).to.eql({
+          key: "transactional",
+          environment: "development",
+          created_at: "2023-09-18T18:32:18.398053Z",
+          updated_at: "2023-10-02T19:24:48.714630Z"
+        });
+      });
+
+      describe("with the withExtractedFiles opt of true", () => {
+        it("reads layout.json with the extracted fields inlined", async () => {
+          const [layout] = await readEmailLayoutDir(emailLayoutDirCtx, {
+            withExtractedFiles: true,
+          });
+
+          expect(get(layout, ["name"])).to.equal("Transactional");
+
+          // HTML layout content should be inlined into layout data
+          expect(get(layout, ["html_layout"])).to.contain("<html><body><p> example </p></body></html>");
+
+          // Text layout content should be inlined into layout data
+          expect(get(layout, ["text_layout"])).to.contains("foo {{content}}");
+        });
+      });
+
+    });
+  });
+});

--- a/test/lib/marshal/layout/writer.test.ts
+++ b/test/lib/marshal/layout/writer.test.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+
+import { expect } from "chai";
+import * as fs from "fs-extra";
+import { get } from "lodash";
+
+import { sandboxDir } from "@/lib/helpers/const";
+import {
+  buildEmailLayoutDirBundle,
+  EmailLayoutData,
+  LAYOUT_JSON,
+  pruneLayoutsIndexDir,
+  toEmailLayoutJson,
+} from "@/lib/marshal/email-layout";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+const annotation = {
+  extractable_fields: {
+    html_layout: { default: true, file_ext: "html" },
+    text_layout: { default: true, file_ext: "txt" },
+  },
+  readonly_fields: ["key", "environment", "created_at", "updated_at"],
+};
+
+const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
+  key: "default",
+  name: "Default",
+  html_layout: "<html><body><p> Example content </html></body><p>",
+  text_layout: "Text {{content}}",
+  footer_links: [{ text: "Link 1", url: "https://example.com" }],
+  environment: "development",
+  updated_at: "2023-10-02T19:24:48.714630Z",
+  created_at: "2023-09-18T18:32:18.398053Z",
+  __annotation: annotation,
+};
+
+describe("lib/marshal/layout/writer", () => {
+  describe("toEmailLayoutJson", () => {
+    it("moves over layout's readonly fields under __readonly field", () => {
+      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
+
+      expect(layoutJson.key).to.equal(undefined);
+      expect(layoutJson.environment).to.equal(undefined);
+      expect(layoutJson.created_at).to.equal(undefined);
+      expect(layoutJson.updated_at).to.equal(undefined);
+
+      expect(layoutJson.__readonly).to.eql({
+        key: "default",
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+        updated_at: "2023-10-02T19:24:48.714630Z",
+      });
+    });
+
+    it("removes all __annotation fields", () => {
+      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
+
+      expect(get(layoutJson, "__annotation")).to.equal(undefined);
+    });
+  });
+
+  describe("pruneLayoutsIndexDir", () => {
+    const remoteEmailLayouts: EmailLayoutData<WithAnnotation>[] = [
+      {
+        key: "foo",
+        name: "Foo",
+        html_layout: "<html><body><p> Example content </html></body><p>",
+        text_layout: "Text {{content}}",
+        footer_links: [],
+        environment: "development",
+        updated_at: "2023-10-02T19:24:48.714630Z",
+        created_at: "2023-09-18T18:32:18.398053Z",
+        __annotation: annotation,
+      },
+    ];
+
+    const layoutsIndexDir = path.resolve(sandboxDir, "layouts");
+
+    beforeEach(() => {
+      fs.removeSync(sandboxDir);
+      fs.ensureDirSync(layoutsIndexDir);
+    });
+
+    after(() => {
+      fs.removeSync(sandboxDir);
+    });
+
+    describe("given a file in the layouts index dir", () => {
+      it("removes the file", async () => {
+        const filePath = path.resolve(layoutsIndexDir, "foo");
+        fs.ensureFileSync(filePath);
+
+        const indexDirCtx = { abspath: layoutsIndexDir, exists: true };
+        await pruneLayoutsIndexDir(indexDirCtx, remoteEmailLayouts);
+
+        expect(fs.pathExistsSync(filePath)).to.equal(false);
+      });
+    });
+
+    describe("given a non layout directory in the layouts index dir", () => {
+      it("removes the directory", async () => {
+        const dirPath = path.resolve(layoutsIndexDir, "foo");
+        fs.ensureDirSync(dirPath);
+
+        const indexDirCtx = { abspath: layoutsIndexDir, exists: true };
+        await pruneLayoutsIndexDir(indexDirCtx, remoteEmailLayouts);
+
+        expect(fs.pathExistsSync(dirPath)).to.equal(false);
+      });
+    });
+
+    describe("given a layout directory not found in remote layouts", () => {
+      it("removes the layout directory", async () => {
+        const layoutJsonPath = path.resolve(
+          layoutsIndexDir,
+          "bar",
+          LAYOUT_JSON,
+        );
+        fs.ensureFileSync(layoutJsonPath);
+
+        const indexDirCtx = { abspath: layoutsIndexDir, exists: true };
+        await pruneLayoutsIndexDir(indexDirCtx, remoteEmailLayouts);
+
+        expect(fs.pathExistsSync(layoutJsonPath)).to.equal(false);
+      });
+    });
+
+    describe("given a layout directory found in remote layouts", () => {
+      it("retains the layout directory", async () => {
+        const layoutJsonPath = path.resolve(
+          layoutsIndexDir,
+          "foo",
+          LAYOUT_JSON,
+        );
+        fs.ensureFileSync(layoutJsonPath);
+
+        const indexDirCtx = { abspath: layoutsIndexDir, exists: true };
+        await pruneLayoutsIndexDir(indexDirCtx, remoteEmailLayouts);
+
+        expect(fs.pathExistsSync(layoutJsonPath)).to.equal(true);
+      });
+    });
+  });
+
+  describe("buildEmailLayoutDirBundle", () => {
+    describe("given a fetched layout that has not been pulled before", () => {
+      const result = buildEmailLayoutDirBundle(remoteEmailLayout);
+
+      expect(result).to.eql({
+        "html_layout.html": "<html><body><p> Example content </html></body><p>",
+        "text_layout.txt": "Text {{content}}",
+        "layout.json": {
+          name: "Default",
+          footer_links: [{ text: "Link 1", url: "https://example.com" }],
+          "html_layout@": "html_layout.html",
+          "text_layout@": "text_layout.txt",
+          __readonly: {
+            key: "default",
+            environment: "development",
+            created_at: "2023-09-18T18:32:18.398053Z",
+            updated_at: "2023-10-02T19:24:48.714630Z",
+          },
+        },
+      });
+    });
+
+    describe("given a fetched layout with a local version available", () => {
+      it("returns a dir bundle based on a local version and default extract settings", () => {
+        const localEmailLayout = {
+          name: "default",
+          "html_layout@": "foo/bar/layout.html",
+          "text_layout@": "text_layout.txt",
+        };
+
+        const result = buildEmailLayoutDirBundle(
+          remoteEmailLayout,
+          localEmailLayout,
+        );
+
+        expect(result).to.eql({
+          "foo/bar/layout.html":
+            "<html><body><p> Example content </html></body><p>",
+          "text_layout.txt": "Text {{content}}",
+          "layout.json": {
+            name: "Default",
+            footer_links: [{ text: "Link 1", url: "https://example.com" }],
+            "html_layout@": "foo/bar/layout.html",
+            "text_layout@": "text_layout.txt",
+            __readonly: {
+              key: "default",
+              environment: "development",
+              created_at: "2023-09-18T18:32:18.398053Z",
+              updated_at: "2023-10-02T19:24:48.714630Z",
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/test/lib/marshal/workflow/reader.test.ts
+++ b/test/lib/marshal/workflow/reader.test.ts
@@ -7,9 +7,11 @@ import { get } from "lodash";
 import { xpath } from "@/../test/support";
 import { sandboxDir } from "@/lib/helpers/const";
 import { JsonDataError } from "@/lib/helpers/error";
-import { readExtractedFileSync } from "@/lib/marshal/shared/helpers";
 import {
   checkIfValidExtractedFilePathFormat,
+  readExtractedFileSync,
+} from "@/lib/marshal/shared/helpers";
+import {
   readWorkflowDir,
   VISUAL_BLOCKS_JSON,
   WORKFLOW_JSON,

--- a/test/lib/marshal/workflow/reader.test.ts
+++ b/test/lib/marshal/workflow/reader.test.ts
@@ -7,9 +7,9 @@ import { get } from "lodash";
 import { xpath } from "@/../test/support";
 import { sandboxDir } from "@/lib/helpers/const";
 import { JsonDataError } from "@/lib/helpers/error";
+import { readExtractedFileSync } from "@/lib/marshal/shared/helpers";
 import {
   checkIfValidExtractedFilePathFormat,
-  readExtractedFileSync,
   readWorkflowDir,
   VISUAL_BLOCKS_JSON,
   WORKFLOW_JSON,


### PR DESCRIPTION
### Description
Adds a `layout pull` command for pulling a given email layout into a directory. It also allows to pull all email layouts from a given environment using the `--all` flag along with the `--layout-dir`.

It allows the following flags:
* --environment
* --all
* --layout-dir 
* --hide-uncommitted-changes
* --force


This PR also abstract some logic we use for reading external field contents. Before we used this logic when pulling `workflows`, but now we use the same logic for pulling `layouts`. 


### Tasks
[KNO-4367](https://linear.app/knock/issue/KNO-4367/[cli]-add-pull-email-layout-command)

### Video
https://www.loom.com/share/d0035467d1cf48a999536b466d5dd1df



