### PR TITLE
feat(KNO-4439): Add layout topics in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       },
       "translation": {
         "description": "Manage translation files."
+      },
+      "layout": {
+        "description": "Manage email layouts."
       }
     }
   },


### PR DESCRIPTION
### Description
Add missing layout topic, so the layout command description appears when doing `knock --help`

### Tasks
[KNO-4439](https://linear.app/knock/issue/KNO-4439/[control]-bump-cli-to-015-and-update-topics)

