### PR TITLE
feat(KNO-4537): Add "knock commit list" command in cli

### DIFF
--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -88,7 +88,8 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       },
       commit_message: {
         header: "Commit message",
-        get: (entry) => entry.commit_message?.trim(),
+        get: (entry) =>
+          entry.commit_message ? entry.commit_message.trim() : "",
       },
       created_at: {
         header: "Created at",

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -54,7 +54,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
 
     let qualifier = "";
 
-    if (promoted) {
+    if (promoted === true) {
       qualifier = "(showing only promoted)";
     }
 

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -13,20 +13,20 @@ import {
 import { withSpinner } from "@/lib/helpers/request";
 import { formatCommitAuthor, formatCommitTarget } from "@/lib/marshal/commit";
 
-export default class CommitList extends BaseCommand<typeof CommitList>{
-  static summary = "Display all commit for an environment"
+export default class CommitList extends BaseCommand<typeof CommitList> {
+  static summary = "Display all commit for an environment";
 
   static flags = {
     environment: Flags.string({
       default: "development",
       summary: "The environment to use.",
     }),
-    "promoted": Flags.boolean({
+    promoted: Flags.boolean({
       summary: "Show only promoted or unpromoted changes.",
-      allowNo: true
+      allowNo: true,
     }),
     ...pageFlags,
-  }
+  };
 
   static enableJsonFlag = true;
 
@@ -39,9 +39,7 @@ export default class CommitList extends BaseCommand<typeof CommitList>{
     this.render(resp.data);
   }
 
-  async request(
-    pageParams = {},
-  ): Promise<AxiosResponse<ApiV1.ListCommitResp>> {
+  async request(pageParams = {}): Promise<AxiosResponse<ApiV1.ListCommitResp>> {
     const props = merge(this.props, { flags: { ...pageParams } });
 
     return withSpinner<ApiV1.ListCommitResp>(() =>
@@ -51,17 +49,16 @@ export default class CommitList extends BaseCommand<typeof CommitList>{
 
   async render(data: ApiV1.ListCommitResp): Promise<void> {
     const { entries } = data;
-    const { environment: env, "promoted": promoted } =
-      this.props.flags;
+    const { environment: env, promoted } = this.props.flags;
 
-    let qualifier = ""
+    let qualifier = "";
 
     if (env === "development" && promoted) {
-      qualifier = "(showing promoted)"
+      qualifier = "(showing promoted)";
     }
 
-    if (env === "development" && promoted == false) {
-      qualifier == "(showing unpromoted)"
+    if (env === "development" && promoted === false) {
+      qualifier === "(showing unpromoted)";
     }
 
     this.log(
@@ -69,8 +66,8 @@ export default class CommitList extends BaseCommand<typeof CommitList>{
     );
 
     /*
-    * Commits table
-    */
+     * Commits table
+     */
 
     ux.table(entries, {
       id: {
@@ -78,11 +75,11 @@ export default class CommitList extends BaseCommand<typeof CommitList>{
       },
       target: {
         header: "Target",
-        get: (entry) => formatCommitTarget(entry)
+        get: (entry) => formatCommitTarget(entry),
       },
       author: {
         header: "Author",
-        get: (entry) => formatCommitAuthor(entry)
+        get: (entry) => formatCommitAuthor(entry),
       },
       commit_message: {
         header: "Commit message",
@@ -101,8 +98,8 @@ export default class CommitList extends BaseCommand<typeof CommitList>{
       const { page_info } = data;
 
       const pageAction = await maybePromptPageAction(page_info);
-      const pageParams = pageAction && paramsForPageAction(pageAction, page_info);
-
+      const pageParams =
+        pageAction && paramsForPageAction(pageAction, page_info);
 
       if (pageParams) {
         this.log("\n");

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -88,7 +88,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       },
       commit_message: {
         header: "Commit message",
-        get: (entry) => entry.commit_message?.trim()
+        get: (entry) => entry.commit_message?.trim(),
       },
       created_at: {
         header: "Created at",

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -22,7 +22,8 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       summary: "The environment to use.",
     }),
     promoted: Flags.boolean({
-      summary: "Show only promoted or unpromoted changes between the given environment and the subsequent environment.",
+      summary:
+        "Show only promoted or unpromoted changes between the given environment and the subsequent environment.",
       allowNo: true,
     }),
     ...pageFlags,
@@ -53,12 +54,12 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
 
     let qualifier = "";
 
-    if (env === "development" && promoted) {
-      qualifier = "(showing promoted)";
+    if (promoted) {
+      qualifier = "(showing only promoted)";
     }
 
-    if (env === "development" && promoted === false) {
-      qualifier = "(showing unpromoted)";
+    if (promoted === false) {
+      qualifier = "(showing only unpromoted)";
     }
 
     this.log(

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -94,19 +94,16 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
   }
 
   async prompt(data: ApiV1.ListCommitResp): Promise<void> {
-    if (data.page_info) {
-      const { page_info } = data;
+    const { page_info } = data;
 
-      const pageAction = await maybePromptPageAction(page_info);
-      const pageParams =
-        pageAction && paramsForPageAction(pageAction, page_info);
+    const pageAction = await maybePromptPageAction(page_info);
+    const pageParams = pageAction && paramsForPageAction(pageAction, page_info);
 
-      if (pageParams) {
-        this.log("\n");
+    if (pageParams) {
+      this.log("\n");
 
-        const resp = await this.request(pageParams);
-        return this.render(resp.data);
-      }
+      const resp = await this.request(pageParams);
+      return this.render(resp.data);
     }
   }
 }

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -1,0 +1,115 @@
+import { Flags, ux } from "@oclif/core";
+import { AxiosResponse } from "axios";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatDate } from "@/lib/helpers/date";
+import { merge } from "@/lib/helpers/object";
+import {
+  maybePromptPageAction,
+  pageFlags,
+  paramsForPageAction,
+} from "@/lib/helpers/page";
+import { withSpinner } from "@/lib/helpers/request";
+import { formatCommitAuthor, formatCommitTarget } from "@/lib/marshal/commit";
+
+export default class CommitList extends BaseCommand<typeof CommitList>{
+  static summary = "Display all commit for an environment"
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    "promoted": Flags.boolean({
+      summary: "Show only promoted or unpromoted changes.",
+      allowNo: true
+    }),
+    ...pageFlags,
+  }
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.ListCommitResp | void> {
+    const resp = await this.request();
+
+    const { flags } = this.props;
+    if (flags.json) return resp.data;
+
+    this.render(resp.data);
+  }
+
+  async request(
+    pageParams = {},
+  ): Promise<AxiosResponse<ApiV1.ListCommitResp>> {
+    const props = merge(this.props, { flags: { ...pageParams } });
+
+    return withSpinner<ApiV1.ListCommitResp>(() =>
+      this.apiV1.listCommits(props),
+    );
+  }
+
+  async render(data: ApiV1.ListCommitResp): Promise<void> {
+    const { entries } = data;
+    const { environment: env, "promoted": promoted } =
+      this.props.flags;
+
+    let qualifier = ""
+
+    if (env === "development" && promoted) {
+      qualifier = "(showing promoted)"
+    }
+
+    if (env === "development" && promoted == false) {
+      qualifier == "(showing unpromoted)"
+    }
+
+    this.log(
+      `‣ Showing ${entries.length} commits in \`${env}\` environment ${qualifier}\n`,
+    );
+
+    /*
+    * Commits table
+    */
+
+    ux.table(entries, {
+      id: {
+        header: "ID",
+      },
+      target: {
+        header: "Target",
+        get: (entry) => formatCommitTarget(entry)
+      },
+      author: {
+        header: "Author",
+        get: (entry) => formatCommitAuthor(entry)
+      },
+      commit_message: {
+        header: "Commit message",
+      },
+      created_at: {
+        header: "Created at",
+        get: (entry) => formatDate(entry.created_at),
+      },
+    });
+
+    return this.prompt(data);
+  }
+
+  async prompt(data: ApiV1.ListCommitResp): Promise<void> {
+    if (data.page_info) {
+      const { page_info } = data;
+
+      const pageAction = await maybePromptPageAction(page_info);
+      const pageParams = pageAction && paramsForPageAction(pageAction, page_info);
+
+
+      if (pageParams) {
+        this.log("\n");
+
+        const resp = await this.request(pageParams);
+        return this.render(resp.data);
+      }
+    }
+  }
+}

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -88,6 +88,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       },
       commit_message: {
         header: "Commit message",
+        get: (entry) => entry.commit_message?.trim()
       },
       created_at: {
         header: "Created at",

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -58,7 +58,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
     }
 
     if (env === "development" && promoted === false) {
-      qualifier === "(showing unpromoted)";
+      qualifier = "(showing unpromoted)";
     }
 
     this.log(

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -14,7 +14,7 @@ import { withSpinner } from "@/lib/helpers/request";
 import { formatCommitAuthor, formatCommitResource } from "@/lib/marshal/commit";
 
 export default class CommitList extends BaseCommand<typeof CommitList> {
-  static summary = "Display all commit for an environment";
+  static summary = "Display all commits in an environment";
 
   static flags = {
     environment: Flags.string({
@@ -22,7 +22,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       summary: "The environment to use.",
     }),
     promoted: Flags.boolean({
-      summary: "Show only promoted or unpromoted changes.",
+      summary: "Show only promoted or unpromoted changes between the given environment and the subsequent environment.",
       allowNo: true,
     }),
     ...pageFlags,

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -11,7 +11,7 @@ import {
   paramsForPageAction,
 } from "@/lib/helpers/page";
 import { withSpinner } from "@/lib/helpers/request";
-import { formatCommitAuthor, formatCommitResource } from "@/lib/marshal/commit";
+import { formatCommitAuthor } from "@/lib/marshal/commit";
 
 export default class CommitList extends BaseCommand<typeof CommitList> {
   static summary = "Display all commits in an environment";
@@ -75,7 +75,11 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       },
       resource: {
         header: "Resource",
-        get: (entry) => formatCommitResource(entry),
+        get: (entry) => entry.resource.type,
+      },
+      identifier: {
+        header: "Identifier",
+        get: (entry) => entry.resource.identifier,
       },
       author: {
         header: "Author",

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -11,7 +11,7 @@ import {
   paramsForPageAction,
 } from "@/lib/helpers/page";
 import { withSpinner } from "@/lib/helpers/request";
-import { formatCommitAuthor, formatCommitTarget } from "@/lib/marshal/commit";
+import { formatCommitAuthor, formatCommitResource } from "@/lib/marshal/commit";
 
 export default class CommitList extends BaseCommand<typeof CommitList> {
   static summary = "Display all commit for an environment";
@@ -73,9 +73,9 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       id: {
         header: "ID",
       },
-      target: {
-        header: "Target",
-        get: (entry) => formatCommitTarget(entry),
+      resource: {
+        header: "Resource",
+        get: (entry) => formatCommitResource(entry),
       },
       author: {
         header: "Author",

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -5,11 +5,11 @@ import { BFlags, Props } from "@/lib/base-command";
 import { InputError } from "@/lib/helpers/error";
 import { prune } from "@/lib/helpers/object";
 import { PaginatedResp, toPageParams } from "@/lib/helpers/page";
+import * as Commit from "@/lib/marshal/commit";
 import * as EmailLayout from "@/lib/marshal/email-layout";
 import { MaybeWithAnnotation } from "@/lib/marshal/shared/types";
 import * as Translation from "@/lib/marshal/translation";
 import * as Workflow from "@/lib/marshal/workflow";
-import * as Commit from "@/lib/marshal/commit";
 
 const DEFAULT_ORIGIN = "https://control.knock.app";
 const API_VERSION = "v1";
@@ -129,12 +129,10 @@ export default class ApiV1 {
 
   // By resources: Commits
 
-  async listCommits({
-    flags,
-  }: Props): Promise<AxiosResponse<ListCommitResp>> {
+  async listCommits({ flags }: Props): Promise<AxiosResponse<ListCommitResp>> {
     const params = prune({
       environment: flags.environment,
-      promoted: flags["promoted"],
+      promoted: flags.promoted,
       ...toPageParams(flags),
     });
 
@@ -367,7 +365,7 @@ export type ValidateEmailLayoutResp = {
   errors?: InputError[];
 };
 
-export type ListCommitResp = PaginatedResp<Commit.CommitData>
+export type ListCommitResp = PaginatedResp<Commit.CommitData>;
 
 export type CommitAllChangesResp = {
   result?: "success";

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -9,6 +9,7 @@ import * as EmailLayout from "@/lib/marshal/email-layout";
 import { MaybeWithAnnotation } from "@/lib/marshal/shared/types";
 import * as Translation from "@/lib/marshal/translation";
 import * as Workflow from "@/lib/marshal/workflow";
+import * as Commit from "@/lib/marshal/commit";
 
 const DEFAULT_ORIGIN = "https://control.knock.app";
 const API_VERSION = "v1";
@@ -127,6 +128,18 @@ export default class ApiV1 {
   }
 
   // By resources: Commits
+
+  async listCommits({
+    flags,
+  }: Props): Promise<AxiosResponse<ListCommitResp>> {
+    const params = prune({
+      environment: flags.environment,
+      promoted: flags["promoted"],
+      ...toPageParams(flags),
+    });
+
+    return this.get("/commits", { params });
+  }
 
   async commitAllChanges({
     flags,
@@ -353,6 +366,8 @@ export type ValidateEmailLayoutResp = {
   email_layout?: EmailLayout.EmailLayoutData;
   errors?: InputError[];
 };
+
+export type ListCommitResp = PaginatedResp<Commit.CommitData>
 
 export type CommitAllChangesResp = {
   result?: "success";

--- a/src/lib/marshal/commit/helpers.ts
+++ b/src/lib/marshal/commit/helpers.ts
@@ -11,5 +11,5 @@ export function formatCommitAuthor(commit: CommitData): string {
   const email = commit.author.email;
   const name = commit.author.name;
 
-  return name ? `${name} - ${email}` : email;
+  return name ? `${name} <${email}>` : `<${email}>`;
 }

--- a/src/lib/marshal/commit/helpers.ts
+++ b/src/lib/marshal/commit/helpers.ts
@@ -1,0 +1,15 @@
+import { CommitData } from "./types";
+
+export function formatCommitTarget(commit: CommitData): string {
+  const target = commit.target.type
+  const identifier = commit.target.identifier;
+
+  return `${target} - ${identifier}`
+}
+
+export function formatCommitAuthor(commit: CommitData): string {
+  const email = commit.author.email;
+  const name = commit.author.name;
+
+  return name ? `${name} - ${email}` : email
+}

--- a/src/lib/marshal/commit/helpers.ts
+++ b/src/lib/marshal/commit/helpers.ts
@@ -1,12 +1,5 @@
 import { CommitData } from "./types";
 
-export function formatCommitResource(commit: CommitData): string {
-  const type = commit.resource.type;
-  const identifier = commit.resource.identifier;
-
-  return `${type} - ${identifier}`;
-}
-
 export function formatCommitAuthor(commit: CommitData): string {
   const email = commit.author.email;
   const name = commit.author.name;

--- a/src/lib/marshal/commit/helpers.ts
+++ b/src/lib/marshal/commit/helpers.ts
@@ -1,10 +1,10 @@
 import { CommitData } from "./types";
 
-export function formatCommitTarget(commit: CommitData): string {
-  const target = commit.target.type;
-  const identifier = commit.target.identifier;
+export function formatCommitResource(commit: CommitData): string {
+  const type = commit.resource.type;
+  const identifier = commit.resource.identifier;
 
-  return `${target} - ${identifier}`;
+  return `${type} - ${identifier}`;
 }
 
 export function formatCommitAuthor(commit: CommitData): string {

--- a/src/lib/marshal/commit/helpers.ts
+++ b/src/lib/marshal/commit/helpers.ts
@@ -1,15 +1,15 @@
 import { CommitData } from "./types";
 
 export function formatCommitTarget(commit: CommitData): string {
-  const target = commit.target.type
+  const target = commit.target.type;
   const identifier = commit.target.identifier;
 
-  return `${target} - ${identifier}`
+  return `${target} - ${identifier}`;
 }
 
 export function formatCommitAuthor(commit: CommitData): string {
   const email = commit.author.email;
   const name = commit.author.name;
 
-  return name ? `${name} - ${email}` : email
+  return name ? `${name} - ${email}` : email;
 }

--- a/src/lib/marshal/commit/index.ts
+++ b/src/lib/marshal/commit/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/lib/marshal/commit/index.ts
+++ b/src/lib/marshal/commit/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./helpers"

--- a/src/lib/marshal/commit/index.ts
+++ b/src/lib/marshal/commit/index.ts
@@ -1,2 +1,2 @@
+export * from "./helpers";
 export * from "./types";
-export * from "./helpers"

--- a/src/lib/marshal/commit/types.ts
+++ b/src/lib/marshal/commit/types.ts
@@ -1,0 +1,10 @@
+// Commit payload data from the API.
+export type CommitData = {
+  id: string;
+  action: string;
+  author: { name?: string, email: string };
+  commit_message?: string;
+  created_at: string;
+  environment: string;
+  target: string;
+}

--- a/src/lib/marshal/commit/types.ts
+++ b/src/lib/marshal/commit/types.ts
@@ -1,9 +1,9 @@
 // Commit payload data from the API.
 export type CommitData = {
   id: string;
-  target: { type: string, identifier: string };
-  author: { name?: string, email: string };
+  target: { type: string; identifier: string };
+  author: { name?: string; email: string };
   commit_message?: string;
   created_at: string;
   environment: string;
-}
+};

--- a/src/lib/marshal/commit/types.ts
+++ b/src/lib/marshal/commit/types.ts
@@ -1,10 +1,9 @@
 // Commit payload data from the API.
 export type CommitData = {
   id: string;
-  action: string;
+  target: { type: string, identifier: string };
   author: { name?: string, email: string };
   commit_message?: string;
   created_at: string;
   environment: string;
-  target: string;
 }

--- a/src/lib/marshal/commit/types.ts
+++ b/src/lib/marshal/commit/types.ts
@@ -1,7 +1,7 @@
 // Commit payload data from the API.
 export type CommitData = {
   id: string;
-  target: { type: string; identifier: string };
+  resource: { type: string; identifier: string };
   author: { name?: string; email: string };
   commit_message?: string;
   created_at: string;

--- a/test/commands/commit/list.test.ts
+++ b/test/commands/commit/list.test.ts
@@ -1,0 +1,202 @@
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/commit/list", () => {
+  const emptyCommitListResp = factory.resp({
+    data: {
+      page_info: factory.pageInfo(),
+      entries: [],
+    },
+  });
+
+  describe("given no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "listCommits",
+        sinon.stub().resolves(emptyCommitListResp),
+      )
+      .stdout()
+      .command(["commit list"])
+      .it("calls apiV1 listCommits with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listCommits as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "listCommits",
+        sinon.stub().resolves(emptyCommitListResp),
+      )
+      .stdout()
+      .command([
+        "commit list",
+        "--no-promoted",
+        "--environment",
+        "staging",
+        "--limit",
+        "5",
+        "--after",
+        "xyz",
+        "--json",
+      ])
+      .it("calls apiV1 listCommits with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listCommits as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                promoted: false,
+                environment: "staging",
+                limit: 5,
+                after: "xyz",
+                json: true,
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a list of commit in response", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "listCommits",
+        sinon.stub().resolves(
+          factory.resp({
+            data: {
+              page_info: factory.pageInfo(),
+              entries: [
+                factory.commit({ id: "commit-1" }),
+                factory.commit({ id: "commit-2" }),
+                factory.commit({ id: "commit-3" }),
+              ],
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["commit list"])
+      .it("displays the list of commits", (ctx) => {
+        expect(ctx.stdout).to.contain("Showing 3 commits in");
+        expect(ctx.stdout).to.contain("commit-1");
+        expect(ctx.stdout).to.contain("commit-2");
+        expect(ctx.stdout).to.contain("commit-3");
+        expect(ctx.stdout).to.not.contain("commit-4");
+      });
+  });
+
+  describe("given the first page of paginated commits in resp", () => {
+    const paginatedCommitsResp = factory.resp({
+      data: {
+        page_info: factory.pageInfo({
+          after: "xyz",
+        }),
+        entries: [
+          factory.commit({ id: "commit-1" }),
+          factory.commit({ id: "commit-2" }),
+          factory.commit({ id: "commit-3" }),
+        ],
+      },
+    });
+
+    describe("plus a next page action from the prompt input", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(
+          KnockApiV1.prototype,
+          "listCommits",
+          sinon.stub().resolves(paginatedCommitsResp),
+        )
+        .stub(
+          enquirer.prototype,
+          "prompt",
+          sinon
+            .stub()
+            .onFirstCall()
+            .resolves({ input: "n" })
+            .onSecondCall()
+            .resolves({ input: "" }),
+        )
+        .stdout()
+        .command(["commit list"])
+        .it(
+          "calls apiV1 listCommits for the second time with page params",
+          () => {
+            const listCommitsFn = KnockApiV1.prototype.listCommits as any;
+
+            sinon.assert.calledTwice(listCommitsFn);
+
+            // First call without page params.
+            sinon.assert.calledWith(
+              listCommitsFn.firstCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                  }),
+              ),
+            );
+
+            // Second call with page params to fetch the next page.
+            sinon.assert.calledWith(
+              listCommitsFn.secondCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                    after: "xyz",
+                  }),
+              ),
+            );
+          },
+        );
+    });
+
+    describe("plus a previous page action input from the prompt", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(
+          KnockApiV1.prototype,
+          "listCommits",
+          sinon.stub().resolves(paginatedCommitsResp),
+        )
+        .stub(
+          enquirer.prototype,
+          "prompt",
+          sinon.stub().onFirstCall().resolves({ input: "p" }),
+        )
+        .stdout()
+        .command(["commit list"])
+        .it("calls apiV1 listCommits once for the initial page only", () => {
+          sinon.assert.calledOnce(KnockApiV1.prototype.listCommits as any);
+        });
+    });
+  });
+});

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -223,8 +223,8 @@ describe("lib/api-v1", () => {
       sinon.assert.calledWith(stub, "/v1/commits", { params });
 
       stub.restore();
-    })
-  })
+    });
+  });
 
   describe("commitAllChanges", () => {
     it("makes a PUT request to /v1/commits with supported params", async () => {

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -190,6 +190,42 @@ describe("lib/api-v1", () => {
     });
   });
 
+  describe("listCommits", () => {
+    it("makes a GET request to /v1/commits with supported params", async () => {
+      const apiV1 = new KnockApiV1(factory.gFlags(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "get").returns(
+        Promise.resolve({
+          status: 200,
+          data: {
+            entries: [],
+            page_info: factory.pageInfo(),
+          },
+        }),
+      );
+
+      const flags = {
+        environment: "development",
+        promoted: true,
+        after: "foo",
+        limit: 3,
+        ...factory.gFlags(),
+      };
+      await apiV1.listCommits(factory.props({ flags }));
+
+      const params = {
+        environment: "development",
+        promoted: true,
+        after: "foo",
+        limit: 3,
+      };
+
+      sinon.assert.calledWith(stub, "/v1/commits", { params });
+
+      stub.restore();
+    })
+  })
+
   describe("commitAllChanges", () => {
     it("makes a PUT request to /v1/commits with supported params", async () => {
       const apiV1 = new KnockApiV1(factory.gFlags(), dummyConfig);

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { AxiosResponse, InternalAxiosRequestConfig } from "axios";
 
 import { BFlags, Props } from "@/lib/base-command";
@@ -147,7 +149,7 @@ export const emailLayout = (
 
 export const commit = (attrs: Partial<CommitData> = {}): CommitData => {
   return {
-    id: "commit-id-example",
+    id: randomUUID(),
     resource: { type: "workflow", identifier: "new-comment" },
     author: {
       email: "john.doe@example.com",

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -2,6 +2,7 @@ import { AxiosResponse, InternalAxiosRequestConfig } from "axios";
 
 import { BFlags, Props } from "@/lib/base-command";
 import { PageInfo } from "@/lib/helpers/page";
+import { CommitData } from "@/lib/marshal/commit";
 import { EmailLayoutData } from "@/lib/marshal/email-layout";
 import { TranslationData } from "@/lib/marshal/translation";
 import {
@@ -16,7 +17,7 @@ import { sequence } from "./helpers";
 export const gFlags = (attrs: Partial<BFlags> = {}): BFlags => {
   return {
     "service-token": "valid-token",
-
+    "api-origin": undefined,
     json: undefined,
     ...attrs,
   };
@@ -133,13 +134,28 @@ export const emailLayout = (
 ): EmailLayoutData => {
   return {
     key: "transactional",
-    key: "Transactional",
     name: "Transactional",
     html_layout: "<html><body> Content </body></html>",
     text_layout: "Text content",
     footer_links: [{ text: "Link1", url: "https://exampleUrl.com" }],
+    environment: "development",
     created_at: "2022-12-31T12:00:00.000000Z",
     updated_at: "2022-12-31T12:00:00.000000Z",
+    ...attrs,
+  };
+};
+
+export const commit = (attrs: Partial<CommitData> = {}): CommitData => {
+  return {
+    id: "commit-id-example",
+    target: { type: "workflow", identifier: "new-comment" },
+    author: {
+      email: "john.doe@example.com",
+      name: "John Doe",
+    },
+    commit_message: "This is a commit message",
+    created_at: "2022-12-31T12:00:00.000000Z",
+    environment: "development",
     ...attrs,
   };
 };

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -148,7 +148,7 @@ export const emailLayout = (
 export const commit = (attrs: Partial<CommitData> = {}): CommitData => {
   return {
     id: "commit-id-example",
-    target: { type: "workflow", identifier: "new-comment" },
+    resource: { type: "workflow", identifier: "new-comment" },
     author: {
       email: "john.doe@example.com",
       name: "John Doe",


### PR DESCRIPTION
### Description
Adds support for using `knock commit list` command, which lists all commits for a given environment.
Allowed flags:
--promoted (or --no-promoted): Shows all promoted/unpromoted commits for a given environment.
--environment
--json
--limit
--after
--before

### Tasks
[KNO-4537](https://linear.app/knock/issue/KNO-4537/[cli]-add-knock-commit-list-command-in-cli)

### Screenshots

