### PR TITLE
feat(KNO-4622) Add "knock commit get" command

### DIFF
--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -6,14 +6,14 @@ import { formatDate } from "@/lib/helpers/date";
 import { withSpinner } from "@/lib/helpers/request";
 import { formatCommitAuthor } from "@/lib/marshal/commit";
 
-export default class CommitGet extends BaseCommand<typeof CommitGet>{
-  static summary = "Display a single commit based on an ID"
+export default class CommitGet extends BaseCommand<typeof CommitGet> {
+  static summary = "Display a single commit based on an ID";
 
   static args = {
     id: Args.string({
-      required: true
-    })
-  }
+      required: true,
+    }),
+  };
 
   static enableJsonFlag = true;
 
@@ -21,23 +21,21 @@ export default class CommitGet extends BaseCommand<typeof CommitGet>{
     const { flags } = this.props;
 
     const resp = await withSpinner<ApiV1.GetCommitResp>(() =>
-      this.apiV1.getCommit(this.props)
+      this.apiV1.getCommit(this.props),
     );
 
     if (flags.json) return resp.data;
     this.render(resp.data);
-
   }
 
   render(commit: ApiV1.GetCommitResp): void {
-
     this.log(
       `‣ Showing commit \`${commit.id}\` in \`${commit.environment}\` environment`,
     );
 
     /*
-    * Commit table
-    */
+     * Commit table
+     */
 
     const rows = [
       {
@@ -62,7 +60,7 @@ export default class CommitGet extends BaseCommand<typeof CommitGet>{
       },
       {
         key: "Created at",
-        value: formatDate(commit.created_at)
+        value: formatDate(commit.created_at),
       },
     ];
 

--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -31,17 +31,18 @@ export default class CommitGet extends BaseCommand<typeof CommitGet>{
 
   render(commit: ApiV1.GetCommitResp): void {
 
+    this.log(
+      `‣ Showing commit \`${commit.id}\` in \`${commit.environment}\` environment`,
+    );
+
     /*
     * Commit table
     */
+
     const rows = [
       {
         key: "ID",
         value: commit.id,
-      },
-      {
-        key: "Environment",
-        value: commit.environment,
       },
       {
         key: "Resource",

--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -7,7 +7,7 @@ import { withSpinner } from "@/lib/helpers/request";
 import { formatCommitAuthor } from "@/lib/marshal/commit";
 
 export default class CommitGet extends BaseCommand<typeof CommitGet> {
-  static summary = "Display a single commit based on an ID";
+  static summary = "Display a single commit";
 
   static args = {
     id: Args.string({
@@ -76,7 +76,7 @@ export default class CommitGet extends BaseCommand<typeof CommitGet> {
     this.log("");
 
     if (commit.commit_message) {
-      ux.info(commit.commit_message);
+      this.log(commit.commit_message);
       this.log("");
     }
   }

--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -1,0 +1,83 @@
+import { Args, ux } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatDate } from "@/lib/helpers/date";
+import { withSpinner } from "@/lib/helpers/request";
+import { formatCommitAuthor } from "@/lib/marshal/commit";
+
+export default class CommitGet extends BaseCommand<typeof CommitGet>{
+  static summary = "Display a single commit based on an ID"
+
+  static args = {
+    id: Args.string({
+      required: true
+    })
+  }
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.GetCommitResp | void> {
+    const { flags } = this.props;
+
+    const resp = await withSpinner<ApiV1.GetCommitResp>(() =>
+      this.apiV1.getCommit(this.props)
+    );
+
+    if (flags.json) return resp.data;
+    this.render(resp.data);
+
+  }
+
+  render(commit: ApiV1.GetCommitResp): void {
+
+    /*
+    * Commit table
+    */
+    const rows = [
+      {
+        key: "ID",
+        value: commit.id,
+      },
+      {
+        key: "Environment",
+        value: commit.environment,
+      },
+      {
+        key: "Resource",
+        value: commit.resource.type,
+      },
+      {
+        key: "Identifier",
+        value: commit.resource.identifier,
+      },
+      {
+        key: "Author",
+        value: formatCommitAuthor(commit),
+      },
+      {
+        key: "Commit message",
+        value: commit.commit_message ? commit.commit_message.trim() : "",
+      },
+      {
+        key: "Created at",
+        value: formatDate(commit.created_at)
+      },
+    ];
+
+    this.log("");
+
+    ux.table(rows, {
+      key: {
+        header: "Commit",
+        minWidth: 18,
+      },
+      value: {
+        header: "",
+        minWidth: 16,
+      },
+    });
+
+    this.log("");
+  }
+}

--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -76,7 +76,7 @@ export default class CommitGet extends BaseCommand<typeof CommitGet> {
     this.log("");
 
     if (commit.commit_message) {
-      ux.info(commit.commit_message)
+      ux.info(commit.commit_message);
       this.log("");
     }
   }

--- a/src/commands/commit/get.ts
+++ b/src/commands/commit/get.ts
@@ -55,10 +55,6 @@ export default class CommitGet extends BaseCommand<typeof CommitGet> {
         value: formatCommitAuthor(commit),
       },
       {
-        key: "Commit message",
-        value: commit.commit_message ? commit.commit_message.trim() : "",
-      },
-      {
         key: "Created at",
         value: formatDate(commit.created_at),
       },
@@ -78,5 +74,10 @@ export default class CommitGet extends BaseCommand<typeof CommitGet> {
     });
 
     this.log("");
+
+    if (commit.commit_message) {
+      ux.info(commit.commit_message)
+      this.log("");
+    }
   }
 }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -140,7 +140,7 @@ export default class ApiV1 {
   }
 
   async getCommit({ args }: Props): Promise<AxiosResponse<GetCommitResp>> {
-    return this.get(`/commits/${args.id}`, {})
+    return this.get(`/commits/${args.id}`, {});
   }
 
   async commitAllChanges({
@@ -377,7 +377,7 @@ export type ValidateEmailLayoutResp = {
 
 export type ListCommitResp = PaginatedResp<Commit.CommitData>;
 
-export type GetCommitResp = Commit.CommitData
+export type GetCommitResp = Commit.CommitData;
 
 export type CommitAllChangesResp = {
   result?: "success";

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -140,7 +140,7 @@ export default class ApiV1 {
   }
 
   async getCommit({ args }: Props): Promise<AxiosResponse<GetCommitResp>> {
-    return this.get(`/commits/${args.id}`, {});
+    return this.get(`/commits/${args.id}`);
   }
 
   async commitAllChanges({

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -139,6 +139,10 @@ export default class ApiV1 {
     return this.get("/commits", { params });
   }
 
+  async getCommit({ args }: Props): Promise<AxiosResponse<GetCommitResp>> {
+    return this.get(`/commits/${args.id}`, {})
+  }
+
   async commitAllChanges({
     flags,
   }: Props): Promise<AxiosResponse<CommitAllChangesResp>> {
@@ -372,6 +376,8 @@ export type ValidateEmailLayoutResp = {
 };
 
 export type ListCommitResp = PaginatedResp<Commit.CommitData>;
+
+export type GetCommitResp = Commit.CommitData
 
 export type CommitAllChangesResp = {
   result?: "success";

--- a/test/commands/commit/get.test.ts
+++ b/test/commands/commit/get.test.ts
@@ -1,0 +1,102 @@
+import { test } from "@oclif/test";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/commit/get", () => {
+  describe("given no id arg", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .command(["commit get"])
+      .exit(2)
+      .it("exists with status 2");
+  });
+
+  describe("given a commit ID arg, and no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "getCommit",
+        sinon.stub().resolves(
+          factory.resp({
+            data: factory.commit(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["commit get", "example-id"])
+      .it("calls apiV1 getCommit with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getCommit as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                id: "example-id",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a commit ID arg, and flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "getCommit",
+        sinon.stub().resolves(
+          factory.resp({
+            data: factory.commit(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["commit get", "example-id", "--json"])
+      .it("calls apiV1 getCommit with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getCommit as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                id: "example-id",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                json: true,
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a commit that does not exist", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(
+        KnockApiV1.prototype,
+        "getCommit",
+        sinon.stub().resolves(
+          factory.resp({
+            status: 404,
+            statusText: "Not found",
+            data: {
+              code: "resource_missing",
+              message: "The resource you requested does not exist",
+              status: 404,
+              type: "api_error",
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["commit get", "foo"])
+      .catch("The resource you requested does not exist")
+      .it("throws an error for resource not found");
+  });
+});

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -226,6 +226,25 @@ describe("lib/api-v1", () => {
     });
   });
 
+  describe("getCommit", () => {
+    it("makes a GET request to /v1/commits/:id with supported params", async () => {
+      const apiV1 = new KnockApiV1(factory.gFlags(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "get").returns(
+        Promise.resolve({
+          data: factory.commit(),
+        }),
+      );
+
+      const args = { id: "foo" }
+      await apiV1.getCommit(factory.props({ args }))
+
+      sinon.assert.calledWith(stub, "/v1/commits/foo", {});
+
+      stub.restore();
+    })
+  })
+
   describe("commitAllChanges", () => {
     it("makes a PUT request to /v1/commits with supported params", async () => {
       const apiV1 = new KnockApiV1(factory.gFlags(), dummyConfig);

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -236,14 +236,14 @@ describe("lib/api-v1", () => {
         }),
       );
 
-      const args = { id: "foo" }
-      await apiV1.getCommit(factory.props({ args }))
+      const args = { id: "foo" };
+      await apiV1.getCommit(factory.props({ args }));
 
       sinon.assert.calledWith(stub, "/v1/commits/foo", {});
 
       stub.restore();
-    })
-  })
+    });
+  });
 
   describe("commitAllChanges", () => {
     it("makes a PUT request to /v1/commits with supported params", async () => {

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -239,7 +239,7 @@ describe("lib/api-v1", () => {
       const args = { id: "foo" };
       await apiV1.getCommit(factory.props({ args }));
 
-      sinon.assert.calledWith(stub, "/v1/commits/foo", {});
+      sinon.assert.calledWith(stub, "/v1/commits/foo");
 
       stub.restore();
     });


### PR DESCRIPTION
### Description
Adds a `knock commit get` command for retrieving one single commit based on an ID.

### Tasks
[KNO-4622](https://linear.app/knock/issue/KNO-4622/[cli]-add-knock-commits-get-command)
