### PR TITLE
chore: export buildEmailLayoutDirBundle helper

### DIFF
--- a/src/isomorphic.ts
+++ b/src/isomorphic.ts
@@ -1,0 +1,4 @@
+/*
+ * IMPORTANT: You must only expose exports from isomorphic modules.
+ */
+export * as marshal from "./lib/marshal/index.isomorphic";

--- a/src/lib/marshal/email-layout/helpers.ts
+++ b/src/lib/marshal/email-layout/helpers.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 import { DirContext } from "@/lib/helpers/fs";
 import { EmailLayoutDirContext, RunContext } from "@/lib/run-context";
 
-export const LAYOUT_JSON = "layout.json";
+import { LAYOUT_JSON } from "./processor.isomorphic";
 
 export const emailLayoutJsonPath = (
   layoutDirCtx: EmailLayoutDirContext,

--- a/src/lib/marshal/email-layout/index.ts
+++ b/src/lib/marshal/email-layout/index.ts
@@ -1,4 +1,5 @@
 export * from "./helpers";
+export * from "./processor.isomorphic";
 export * from "./reader";
 export * from "./types";
 export * from "./writer";

--- a/src/lib/marshal/email-layout/processor.isomorphic.ts
+++ b/src/lib/marshal/email-layout/processor.isomorphic.ts
@@ -1,15 +1,15 @@
 import { cloneDeep, get, has, set, unset } from "lodash";
 
 import { AnyObj, split } from "@/lib/helpers/object.isomorphic";
-import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import {
   ObjKeyOrArrayIdx,
   ObjPath,
   omitDeep,
 } from "@/lib/helpers/object.isomorphic";
+import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
+import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { EmailLayoutData } from "./types";
-import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 export const LAYOUT_JSON = "layout.json";
 

--- a/src/lib/marshal/email-layout/processor.isomorphic.ts
+++ b/src/lib/marshal/email-layout/processor.isomorphic.ts
@@ -1,0 +1,130 @@
+import { cloneDeep, get, has, set, unset } from "lodash";
+
+import { AnyObj, split } from "@/lib/helpers/object.isomorphic";
+import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
+import {
+  ObjKeyOrArrayIdx,
+  ObjPath,
+  omitDeep,
+} from "@/lib/helpers/object.isomorphic";
+
+import { EmailLayoutData } from "./types";
+import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
+
+export const LAYOUT_JSON = "layout.json";
+
+export type EmailLayoutDirBundle = {
+  [relpath: string]: string;
+};
+
+/*
+ * Sanitize the email layout content into a format that's appropriate for reading
+ * and writing, by stripping out any annotation fields and handling readonly
+ * fields.
+ */
+const toEmailLayoutJson = (
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): AnyObj => {
+  // Move read only field under the dedicated field "__readonly".
+  const readonlyFields = emailLayout.__annotation?.readonly_fields || [];
+  const [readonly, remainder] = split(emailLayout, readonlyFields);
+  const emailLayoutjson = { ...remainder, __readonly: readonly };
+
+  // Strip out all schema annotations, so not to expose them to end users.
+  return omitDeep(emailLayoutjson, ["__annotation"]);
+};
+
+/*
+ * Traverse a given email layout data and compile extraction settings of every
+ * extractable field into a sorted map.
+ *
+ * NOTE: Currently we do NOT support content extraction at nested levels for
+ * email layouts.
+ */
+type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
+
+const compileExtractionSettings = (
+  emailLayout: EmailLayoutData<WithAnnotation>,
+): CompiledExtractionSettings => {
+  const extractableFields = get(
+    emailLayout,
+    ["__annotation", "extractable_fields"],
+    {},
+  );
+  const map: CompiledExtractionSettings = new Map();
+
+  for (const [key] of Object.entries(emailLayout)) {
+    // If the field we are on is extractable, then add its extraction
+    // settings to the map with the current object path.
+    if (key in extractableFields) {
+      map.set([key], extractableFields[key]);
+    }
+  }
+
+  return map;
+};
+
+/*
+ * For a given email layout payload, this function builds a "email layout
+ * directoy bundle". This is an object which contains all the relative paths and
+ * its file content. It includes the extractable fields, which are extracted out
+ * and added to the bundle as separate files.
+ */
+export const buildEmailLayoutDirBundle = (
+  remoteEmailLayout: EmailLayoutData<WithAnnotation>,
+  localEmailLayout: AnyObj = {},
+): EmailLayoutDirBundle => {
+  const bundle: EmailLayoutDirBundle = {};
+  const mutRemoteEmailLayout = cloneDeep(remoteEmailLayout);
+  // A map of extraction settings of every field in the email layout
+  const compiledExtractionSettings =
+    compileExtractionSettings(mutRemoteEmailLayout);
+
+  // Iterate through each extractable field, determine whether we need to
+  // extract the field content, and if so, perform the
+  // extraction.
+  for (const [objPathParts, extractionSettings] of compiledExtractionSettings) {
+    // If this layout doesn't have this field path, then we don't extract.
+    if (!has(mutRemoteEmailLayout, objPathParts)) continue;
+
+    // If the field at this path is extracted in the local layout, then
+    // always extract; otherwise extract based on the field settings default.
+    const objPathStr = ObjPath.stringify(objPathParts);
+
+    const extractedFilePath = get(
+      localEmailLayout,
+      `${objPathStr}${FILEPATH_MARKER}`,
+    );
+
+    const { default: extractByDefault, file_ext: fileExt } = extractionSettings;
+
+    if (!extractedFilePath && !extractByDefault) continue;
+
+    // By this point, we have a field where we need to extract its content.
+    const data = get(mutRemoteEmailLayout, objPathParts);
+    const fileName = objPathParts.pop();
+
+    // If we have an extracted file path from the local layout, we use that.
+    // In the other case we use the default path.
+    const relpath =
+      typeof extractedFilePath === "string"
+        ? extractedFilePath
+        : `${fileName}.${fileExt}`;
+
+    // Perform the extraction by adding the content and its file path to the
+    // bundle for writing to the file system later. Then replace the field
+    // content with the extracted file path and mark the field as extracted
+    // with @ suffix.
+    set(bundle, [relpath], data);
+    set(mutRemoteEmailLayout, `${objPathStr}${FILEPATH_MARKER}`, relpath);
+    unset(mutRemoteEmailLayout, objPathStr);
+  }
+
+  // At this point the bundle contains all extractable files, so we finally add
+  // the layout JSON realtive path + the file content.
+
+  return set(bundle, [LAYOUT_JSON], toEmailLayoutJson(mutRemoteEmailLayout));
+};
+
+// Exported for tests
+export { toEmailLayoutJson };

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -22,9 +22,9 @@ import { EmailLayoutDirContext } from "@/lib/run-context";
 import {
   EmailLayoutCommandTarget,
   isEmailLayoutDir,
-  LAYOUT_JSON,
   lsEmailLayoutJson,
 } from "./helpers";
+import { LAYOUT_JSON } from "./processor.isomorphic";
 
 type JoinExtractedFilesResult = [AnyObj, JsonDataError[]];
 

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -10,9 +10,9 @@ import { WithAnnotation } from "@/lib/marshal/shared/types";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
 import { isEmailLayoutDir } from "./helpers";
+import { buildEmailLayoutDirBundle, LAYOUT_JSON } from "./processor.isomorphic";
 import { readEmailLayoutDir } from "./reader";
 import { EmailLayoutData } from "./types";
-import { buildEmailLayoutDirBundle, LAYOUT_JSON } from "./processor.isomorphic";
 
 /*
  * Builds an email layout dir bundle, which consist of the email layout JSON +

--- a/src/lib/marshal/email-layout/writer.ts
+++ b/src/lib/marshal/email-layout/writer.ts
@@ -1,75 +1,23 @@
 import path from "node:path";
 
 import * as fs from "fs-extra";
-import { cloneDeep, get, has, set, uniqueId, unset } from "lodash";
+import { uniqueId } from "lodash";
 
 import { sandboxDir } from "@/lib/helpers/const";
 import { DirContext } from "@/lib/helpers/fs";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
-import {
-  ObjKeyOrArrayIdx,
-  ObjPath,
-  omitDeep,
-} from "@/lib/helpers/object.isomorphic";
-import { AnyObj, split } from "@/lib/helpers/object.isomorphic";
-import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
-import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
 import { EmailLayoutDirContext } from "@/lib/run-context";
 
-import { isEmailLayoutDir, LAYOUT_JSON } from "./helpers";
+import { isEmailLayoutDir } from "./helpers";
 import { readEmailLayoutDir } from "./reader";
 import { EmailLayoutData } from "./types";
+import { buildEmailLayoutDirBundle, LAYOUT_JSON } from "./processor.isomorphic";
 
-export type EmailLayoutDirBundle = {
-  [relpath: string]: string;
-};
-
-type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
-
-/* Traverse a given email layout data and compile extraction settings of every extractable
- * field into a sorted map.
- *
- * NOTE: Currently we do NOT support content extraction at nested levels for email layouts.
- */
-const compileExtractionSettings = (
-  emailLayout: EmailLayoutData<WithAnnotation>,
-): CompiledExtractionSettings => {
-  const extractableFields = get(
-    emailLayout,
-    ["__annotation", "extractable_fields"],
-    {},
-  );
-  const map: CompiledExtractionSettings = new Map();
-
-  for (const [key] of Object.entries(emailLayout)) {
-    // If the field we are on is extractable, then add its extraction
-    // settings to the map with the current object path.
-    if (key in extractableFields) {
-      map.set([key], extractableFields[key]);
-    }
-  }
-
-  return map;
-};
-
-/* Sanitize the email layout content into a format that's appropriate for reading
- * and writing, by stripping out any annotation fields and handling readonly
- * fields.
- */
-const toEmailLayoutJson = (
-  emailLayout: EmailLayoutData<WithAnnotation>,
-): AnyObj => {
-  // Move read only field under the dedicated field "__readonly".
-  const readonlyFields = emailLayout.__annotation?.readonly_fields || [];
-  const [readonly, remainder] = split(emailLayout, readonlyFields);
-  const emailLayoutjson = { ...remainder, __readonly: readonly };
-
-  // Strip out all schema annotations, so not to expose them to end users.
-  return omitDeep(emailLayoutjson, ["__annotation"]);
-};
-
-/* Builds an email layout dir bundle, which consist of the email layout JSON + the extractable files.
- * Then writes them into a layout directory on a local file system.
+/*
+ * Builds an email layout dir bundle, which consist of the email layout JSON +
+ * the extractable files.  Then writes them into a layout directory on a local
+ * file system.
  */
 export const writeEmailLayoutDirFromData = async (
   emailLayoutDirCtx: EmailLayoutDirContext,
@@ -117,68 +65,10 @@ export const writeEmailLayoutDirFromData = async (
   }
 };
 
-/* For a given email layout payload, this function builds a "email layout directoy bundle".
- * This is an object which contains all the relative paths and its file content.
- * It includes the extractable fields, which are extracted out and added to the bundle as separate files.
+/*
+ * This bulk write function takes the fetched email layouts data KNOCK API and
+ * writes them into a layouts "index" directory.
  */
-const buildEmailLayoutDirBundle = (
-  remoteEmailLayout: EmailLayoutData<WithAnnotation>,
-  localEmailLayout: AnyObj = {},
-): EmailLayoutDirBundle => {
-  const bundle: EmailLayoutDirBundle = {};
-  const mutRemoteEmailLayout = cloneDeep(remoteEmailLayout);
-  // A map of extraction settings of every field in the email layout
-  const compiledExtractionSettings =
-    compileExtractionSettings(mutRemoteEmailLayout);
-
-  // Iterate through each extractable field, determine whether we need to
-  // extract the field content, and if so, perform the
-  // extraction.
-  for (const [objPathParts, extractionSettings] of compiledExtractionSettings) {
-    // If this layout doesn't have this field path, then we don't extract.
-    if (!has(mutRemoteEmailLayout, objPathParts)) continue;
-
-    // If the field at this path is extracted in the local layout, then
-    // always extract; otherwise extract based on the field settings default.
-    const objPathStr = ObjPath.stringify(objPathParts);
-
-    const extractedFilePath = get(
-      localEmailLayout,
-      `${objPathStr}${FILEPATH_MARKER}`,
-    );
-
-    const { default: extractByDefault, file_ext: fileExt } = extractionSettings;
-
-    if (!extractedFilePath && !extractByDefault) continue;
-
-    // By this point, we have a field where we need to extract its content.
-    const data = get(mutRemoteEmailLayout, objPathParts);
-    const fileName = objPathParts.pop();
-
-    // If we have an extracted file path from the local layout, we use that. In the other
-    // case we use the default path.
-    const relpath =
-      typeof extractedFilePath === "string"
-        ? extractedFilePath
-        : `${fileName}.${fileExt}`;
-
-    // Perform the extraction by adding the content and its file path to the
-    // bundle for writing to the file system later. Then replace the field
-    // content with the extracted file path and mark the field as extracted
-    // with @ suffix.
-    set(bundle, [relpath], data);
-    set(mutRemoteEmailLayout, `${objPathStr}${FILEPATH_MARKER}`, relpath);
-    unset(mutRemoteEmailLayout, objPathStr);
-  }
-
-  // At this point the bundle contains all extractable files, so we finally add the layout
-  // JSON realtive path + the file content.
-
-  return set(bundle, [LAYOUT_JSON], toEmailLayoutJson(mutRemoteEmailLayout));
-};
-
-// This bulk write function takes the fetched email layouts data KNOCK API and writes
-// them into a layouts "index" directory.
 export const writeEmailLayoutIndexDir = async (
   indexDirCtx: DirContext,
   remoteEmailLayouts: EmailLayoutData<WithAnnotation>[],
@@ -262,4 +152,4 @@ const pruneLayoutsIndexDir = async (
 };
 
 // Exported for tests
-export { buildEmailLayoutDirBundle, pruneLayoutsIndexDir, toEmailLayoutJson };
+export { pruneLayoutsIndexDir };

--- a/src/lib/marshal/index.isomorphic.ts
+++ b/src/lib/marshal/index.isomorphic.ts
@@ -1,5 +1,5 @@
 /*
  * IMPORTANT: You must only expose exports from isomorphic modules.
  */
-export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";
 export { buildEmailLayoutDirBundle } from "./email-layout/processor.isomorphic";
+export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";

--- a/src/lib/marshal/index.isomorphic.ts
+++ b/src/lib/marshal/index.isomorphic.ts
@@ -1,0 +1,5 @@
+/*
+ * IMPORTANT: You must only expose exports from isomorphic modules.
+ */
+export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";
+export { buildEmailLayoutDirBundle } from "./email-layout/processor.isomorphic";

--- a/test/lib/marshal/layout/processor.test.ts
+++ b/test/lib/marshal/layout/processor.test.ts
@@ -1,0 +1,109 @@
+import { get } from "lodash";
+import { expect } from "chai";
+
+import {
+  buildEmailLayoutDirBundle,
+  toEmailLayoutJson,
+  EmailLayoutData,
+} from "@/lib/marshal/email-layout";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
+  key: "default",
+  name: "Default",
+  html_layout: "<html><body><p> Example content </html></body><p>",
+  text_layout: "Text {{content}}",
+  footer_links: [{ text: "Link 1", url: "https://example.com" }],
+  environment: "development",
+  updated_at: "2023-10-02T19:24:48.714630Z",
+  created_at: "2023-09-18T18:32:18.398053Z",
+  __annotation: {
+    extractable_fields: {
+      html_layout: { default: true, file_ext: "html" },
+      text_layout: { default: true, file_ext: "txt" },
+    },
+    readonly_fields: ["key", "environment", "created_at", "updated_at"],
+  },
+};
+
+describe("lib/marshal/layout/processor", () => {
+  describe("toEmailLayoutJson", () => {
+    it("moves over layout's readonly fields under __readonly field", () => {
+      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
+
+      expect(layoutJson.key).to.equal(undefined);
+      expect(layoutJson.environment).to.equal(undefined);
+      expect(layoutJson.created_at).to.equal(undefined);
+      expect(layoutJson.updated_at).to.equal(undefined);
+
+      expect(layoutJson.__readonly).to.eql({
+        key: "default",
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+        updated_at: "2023-10-02T19:24:48.714630Z",
+      });
+    });
+
+    it("removes all __annotation fields", () => {
+      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
+
+      expect(get(layoutJson, "__annotation")).to.equal(undefined);
+    });
+  });
+
+  describe("buildEmailLayoutDirBundle", () => {
+    describe("given a fetched layout that has not been pulled before", () => {
+      const result = buildEmailLayoutDirBundle(remoteEmailLayout);
+
+      expect(result).to.eql({
+        "html_layout.html": "<html><body><p> Example content </html></body><p>",
+        "text_layout.txt": "Text {{content}}",
+        "layout.json": {
+          name: "Default",
+          footer_links: [{ text: "Link 1", url: "https://example.com" }],
+          "html_layout@": "html_layout.html",
+          "text_layout@": "text_layout.txt",
+          __readonly: {
+            key: "default",
+            environment: "development",
+            created_at: "2023-09-18T18:32:18.398053Z",
+            updated_at: "2023-10-02T19:24:48.714630Z",
+          },
+        },
+      });
+    });
+
+    describe("given a fetched layout with a local version available", () => {
+      it("returns a dir bundle based on a local version and default extract settings", () => {
+        const localEmailLayout = {
+          name: "default",
+          "html_layout@": "foo/bar/layout.html",
+          "text_layout@": "text_layout.txt",
+        };
+
+        const result = buildEmailLayoutDirBundle(
+          remoteEmailLayout,
+          localEmailLayout,
+        );
+
+        expect(result).to.eql({
+          "foo/bar/layout.html":
+            "<html><body><p> Example content </html></body><p>",
+          "text_layout.txt": "Text {{content}}",
+          "layout.json": {
+            name: "Default",
+            footer_links: [{ text: "Link 1", url: "https://example.com" }],
+            "html_layout@": "foo/bar/layout.html",
+            "text_layout@": "text_layout.txt",
+            __readonly: {
+              key: "default",
+              environment: "development",
+              created_at: "2023-09-18T18:32:18.398053Z",
+              updated_at: "2023-10-02T19:24:48.714630Z",
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/test/lib/marshal/layout/processor.test.ts
+++ b/test/lib/marshal/layout/processor.test.ts
@@ -1,10 +1,10 @@
-import { get } from "lodash";
 import { expect } from "chai";
+import { get } from "lodash";
 
 import {
   buildEmailLayoutDirBundle,
-  toEmailLayoutJson,
   EmailLayoutData,
+  toEmailLayoutJson,
 } from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 

--- a/test/lib/marshal/layout/writer.test.ts
+++ b/test/lib/marshal/layout/writer.test.ts
@@ -2,63 +2,16 @@ import path from "node:path";
 
 import { expect } from "chai";
 import * as fs from "fs-extra";
-import { get } from "lodash";
 
 import { sandboxDir } from "@/lib/helpers/const";
 import {
-  buildEmailLayoutDirBundle,
   EmailLayoutData,
   LAYOUT_JSON,
   pruneLayoutsIndexDir,
-  toEmailLayoutJson,
 } from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
-const annotation = {
-  extractable_fields: {
-    html_layout: { default: true, file_ext: "html" },
-    text_layout: { default: true, file_ext: "txt" },
-  },
-  readonly_fields: ["key", "environment", "created_at", "updated_at"],
-};
-
-const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
-  key: "default",
-  name: "Default",
-  html_layout: "<html><body><p> Example content </html></body><p>",
-  text_layout: "Text {{content}}",
-  footer_links: [{ text: "Link 1", url: "https://example.com" }],
-  environment: "development",
-  updated_at: "2023-10-02T19:24:48.714630Z",
-  created_at: "2023-09-18T18:32:18.398053Z",
-  __annotation: annotation,
-};
-
 describe("lib/marshal/layout/writer", () => {
-  describe("toEmailLayoutJson", () => {
-    it("moves over layout's readonly fields under __readonly field", () => {
-      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
-
-      expect(layoutJson.key).to.equal(undefined);
-      expect(layoutJson.environment).to.equal(undefined);
-      expect(layoutJson.created_at).to.equal(undefined);
-      expect(layoutJson.updated_at).to.equal(undefined);
-
-      expect(layoutJson.__readonly).to.eql({
-        key: "default",
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
-        updated_at: "2023-10-02T19:24:48.714630Z",
-      });
-    });
-
-    it("removes all __annotation fields", () => {
-      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
-
-      expect(get(layoutJson, "__annotation")).to.equal(undefined);
-    });
-  });
-
   describe("pruneLayoutsIndexDir", () => {
     const remoteEmailLayouts: EmailLayoutData<WithAnnotation>[] = [
       {
@@ -70,7 +23,13 @@ describe("lib/marshal/layout/writer", () => {
         environment: "development",
         updated_at: "2023-10-02T19:24:48.714630Z",
         created_at: "2023-09-18T18:32:18.398053Z",
-        __annotation: annotation,
+        __annotation: {
+          extractable_fields: {
+            html_layout: { default: true, file_ext: "html" },
+            text_layout: { default: true, file_ext: "txt" },
+          },
+          readonly_fields: ["key", "environment", "created_at", "updated_at"],
+        },
       },
     ];
 
@@ -138,62 +97,6 @@ describe("lib/marshal/layout/writer", () => {
         await pruneLayoutsIndexDir(indexDirCtx, remoteEmailLayouts);
 
         expect(fs.pathExistsSync(layoutJsonPath)).to.equal(true);
-      });
-    });
-  });
-
-  describe("buildEmailLayoutDirBundle", () => {
-    describe("given a fetched layout that has not been pulled before", () => {
-      const result = buildEmailLayoutDirBundle(remoteEmailLayout);
-
-      expect(result).to.eql({
-        "html_layout.html": "<html><body><p> Example content </html></body><p>",
-        "text_layout.txt": "Text {{content}}",
-        "layout.json": {
-          name: "Default",
-          footer_links: [{ text: "Link 1", url: "https://example.com" }],
-          "html_layout@": "html_layout.html",
-          "text_layout@": "text_layout.txt",
-          __readonly: {
-            key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
-          },
-        },
-      });
-    });
-
-    describe("given a fetched layout with a local version available", () => {
-      it("returns a dir bundle based on a local version and default extract settings", () => {
-        const localEmailLayout = {
-          name: "default",
-          "html_layout@": "foo/bar/layout.html",
-          "text_layout@": "text_layout.txt",
-        };
-
-        const result = buildEmailLayoutDirBundle(
-          remoteEmailLayout,
-          localEmailLayout,
-        );
-
-        expect(result).to.eql({
-          "foo/bar/layout.html":
-            "<html><body><p> Example content </html></body><p>",
-          "text_layout.txt": "Text {{content}}",
-          "layout.json": {
-            name: "Default",
-            footer_links: [{ text: "Link 1", url: "https://example.com" }],
-            "html_layout@": "foo/bar/layout.html",
-            "text_layout@": "text_layout.txt",
-            __readonly: {
-              key: "default",
-              environment: "development",
-              created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
-            },
-          },
-        });
       });
     });
   });


### PR DESCRIPTION
### Description
Similar to #257 where we exported `buildWorkflowDirBundle`, this PR now exports `buildEmailLayoutDirBundle` so we can re-use this helper function in calculating diffs between versions. 

The nature of the changes and the reason for them are exactly the same (except for email layouts than workflows), as well as there is no new functional code in this PR. Refer to the PR description in #257 for more details. 

### Tasks
[KNO-4763](https://linear.app/knock/issue/KNO-4763/[cli]-export-buildemaillayoutdirbundle-helper)

