### PR TITLE
feat: skip system translation files when pushing

### DIFF
--- a/src/commands/translation/push.ts
+++ b/src/commands/translation/push.ts
@@ -85,7 +85,7 @@ export default class TranslationPush extends BaseCommand<
     spinner.start(`‣ Pushing`);
 
     for (const translation of translations) {
-      if (translation.namespace === "system") continue;
+      if (translation.namespace === Translation.SYSTEM_NAMESPACE) continue;
 
       // eslint-disable-next-line no-await-in-loop
       const resp = await this.apiV1.upsertTranslation(this.props, {

--- a/src/commands/translation/push.ts
+++ b/src/commands/translation/push.ts
@@ -85,6 +85,8 @@ export default class TranslationPush extends BaseCommand<
     spinner.start(`‣ Pushing`);
 
     for (const translation of translations) {
+      if (translation.namespace === "system") continue;
+
       // eslint-disable-next-line no-await-in-loop
       const resp = await this.apiV1.upsertTranslation(this.props, {
         locale_code: translation.localeCode,

--- a/src/lib/marshal/translation/helpers.ts
+++ b/src/lib/marshal/translation/helpers.ts
@@ -16,6 +16,8 @@ If a translation has no namespace, it is the same as the locale, e.g. \`en\`.
 If namespaced, it is formatted as namespace.locale, e.g. \`admin.en\`.
 `.trim();
 
+export const SYSTEM_NAMESPACE = "system";
+
 // Minimum data required to identify a single unique translation.
 export type TranslationIdentifier = {
   localeCode: string;


### PR DESCRIPTION
### Description
When pushing translations, skip the `system` translations. If pulled, the system file will be present, but we don't want to push it because in MAPI, it'll always return an error causing the push to fail.

### Tasks
[KNO-5652](https://linear.app/knock/issue/KNO-5652/skip-system-namespace-when-pushing-translations-in-the-cli)
