### PR TITLE
fix: point to the right run file for bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Knock CLI",
   "author": "@knocklabs",
   "bin": {
-    "knock": "./bin/run"
+    "knock": "./bin/run.js"
   },
   "homepage": "https://github.com/knocklabs/knock-cli",
   "license": "MIT",


### PR DESCRIPTION
### Description
Should address the issue reported by a customer, where the newly released v0.1.11 is missing a bin executable: https://knocklabs.slack.com/archives/C01RLET7A6B/p1714425404345129

#290 was included in this release, which upgraded Oclif to the most recent major version 3. And one of the required changes/migration step was to [update bin scripts](https://github.com/oclif/core/blob/main/guides/V3_MIGRATION.md#bin-scripts-for-esmcjs-interoperability) in /bin. What wasn't explicitly called out in the migration guide, but it now appears to be also required is to update the bin path in package.json.

Also, there was an issue in a homebrew release github action from the v0.1.11 release: https://github.com/knocklabs/homebrew-tap/actions/runs/8853400621/job/24314418434. Unclear whether this is a related issue, but we will try cutting a new release and see.

### Tasks
[KNO-5869](https://linear.app/knock/issue/KNO-5869/[cli]-v0111-missing-knock-command-in-npm-bin)
