### PR TITLE
chore: exclude system translation file when reading from disk

### DIFF
--- a/src/commands/translation/push.ts
+++ b/src/commands/translation/push.ts
@@ -85,8 +85,6 @@ export default class TranslationPush extends BaseCommand<
     spinner.start(`‣ Pushing`);
 
     for (const translation of translations) {
-      if (translation.namespace === Translation.SYSTEM_NAMESPACE) continue;
-
       // eslint-disable-next-line no-await-in-loop
       const resp = await this.apiV1.upsertTranslation(this.props, {
         locale_code: translation.localeCode,

--- a/src/lib/marshal/translation/reader.ts
+++ b/src/lib/marshal/translation/reader.ts
@@ -10,9 +10,9 @@ import {
   isTranslationDir,
   lsTranslationDir,
   parseTranslationRef,
+  SYSTEM_NAMESPACE,
   TranslationCommandTarget,
   TranslationFileContext,
-  SYSTEM_NAMESPACE,
 } from "./helpers";
 
 // Hydrated translation file context with its content.

--- a/src/lib/marshal/translation/reader.ts
+++ b/src/lib/marshal/translation/reader.ts
@@ -12,6 +12,7 @@ import {
   parseTranslationRef,
   TranslationCommandTarget,
   TranslationFileContext,
+  SYSTEM_NAMESPACE,
 } from "./helpers";
 
 // Hydrated translation file context with its content.
@@ -40,6 +41,12 @@ const readTranslationFiles = async (
     if (!parsedRef) continue;
 
     const { localeCode, namespace } = parsedRef;
+
+    // Skip the system translation file when reading from the disk by default,
+    // as it is not user editable and should be excluded from the validate or
+    // push commands. Consider making this an option in the future.
+    if (namespace === SYSTEM_NAMESPACE) continue;
+
     // eslint-disable-next-line no-await-in-loop
     const [content, readJsonErrors] = await readJson(abspath);
 

--- a/test/lib/marshal/email-layout/reader.test.ts
+++ b/test/lib/marshal/email-layout/reader.test.ts
@@ -69,6 +69,7 @@ describe("lib/marshal/layout/reader", () => {
       });
     });
   });
+
   describe("readExtractedFileSync", () => {
     const emailLayoutDirCtx: EmailLayoutDirContext = {
       type: "email_layout",
@@ -110,7 +111,7 @@ describe("lib/marshal/layout/reader", () => {
         const fileContent = `
           {{ vars.app_name }} ({{ vars.app_url }})
           <p>
-          Hello {{ recipient.name 
+          Hello {{ recipient.name
           </p>
        `.trimStart();
 

--- a/test/lib/marshal/translation/reader.test.ts
+++ b/test/lib/marshal/translation/reader.test.ts
@@ -4,10 +4,8 @@ import { expect } from "@oclif/test";
 import * as fs from "fs-extra";
 
 import { sandboxDir } from "@/lib/helpers/const";
-// import { JsonDataError } from "@/lib/helpers/error";
-// import { LAYOUT_JSON } from "@/lib/marshal/email-layout";
-import { readAllForCommandTarget } from "@/lib/marshal/translation/reader";
 import { SYSTEM_NAMESPACE } from "@/lib/marshal/translation/helpers";
+import { readAllForCommandTarget } from "@/lib/marshal/translation/reader";
 import { TranslationDirContext } from "@/lib/run-context";
 
 const currCwd = process.cwd();

--- a/test/lib/marshal/translation/reader.test.ts
+++ b/test/lib/marshal/translation/reader.test.ts
@@ -1,0 +1,65 @@
+import * as path from "node:path";
+
+import { expect } from "@oclif/test";
+import * as fs from "fs-extra";
+
+import { sandboxDir } from "@/lib/helpers/const";
+// import { JsonDataError } from "@/lib/helpers/error";
+// import { LAYOUT_JSON } from "@/lib/marshal/email-layout";
+import { readAllForCommandTarget } from "@/lib/marshal/translation/reader";
+import { SYSTEM_NAMESPACE } from "@/lib/marshal/translation/helpers";
+import { TranslationDirContext } from "@/lib/run-context";
+
+const currCwd = process.cwd();
+
+describe("lib/marshal/translation/reader", () => {
+  describe("readAllForCommandTarget", () => {
+    const translationLocaleDirPath = path.join(
+      sandboxDir,
+      "translations",
+      "en",
+    );
+
+    before(() => {
+      fs.removeSync(sandboxDir);
+
+      // Set up a sample translation locale directory.
+      fs.outputJsonSync(path.join(translationLocaleDirPath, "en.json"), {
+        foo: "bar",
+      });
+      fs.outputJsonSync(path.join(translationLocaleDirPath, "hello.en.json"), {
+        foo: "bar",
+      });
+      fs.outputJsonSync(path.join(translationLocaleDirPath, "system.en.json"), {
+        foo: "bar",
+      });
+    });
+
+    after(() => {
+      process.chdir(currCwd);
+      fs.removeSync(sandboxDir);
+    });
+
+    describe("given a translation locale dir target with a system translation file", () => {
+      it("returns translation files without the system translation", async () => {
+        const translationDirCtx: TranslationDirContext = {
+          type: "translation",
+          key: "en",
+          abspath: translationLocaleDirPath,
+          exists: true,
+        };
+
+        const [translations, errors] = await readAllForCommandTarget({
+          type: "translationDir",
+          context: translationDirCtx,
+        });
+
+        expect(errors.length).to.equal(0);
+
+        expect(
+          translations.find((t) => t.namespace === SYSTEM_NAMESPACE),
+        ).to.equal(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description
Following up to #320, this PR excludes a system translation file when reading from the disk. The push --all command validates each item before pushing them up one by one, so currently it will fail at the validation step with a system translation file. Excluding from reading should take care of it for both the validate and push operations. 

### Tasks
[KNO-5652](https://linear.app/knock/issue/KNO-5652/skip-system-namespace-when-pushing-translations-in-the-cli)