### PR TITLE
fix: pass in --strip-leading-paths to swc when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     }
   },
   "scripts": {
-    "build": "shx rm -rf dist && swc src -d dist",
+    "build": "shx rm -rf dist && swc src -d dist --strip-leading-paths",
     "lint": "eslint . --ext .ts --config .eslintrc.json",
     "lint.fix": "yarn run lint --fix",
     "format": "prettier \"src/**/*.+(ts|js)\" \"test/**/*.+(ts|js)\"",


### PR DESCRIPTION
### Description
Fixes the issue reported here, where the v0.1.13 release has no commands to run: https://github.com/knocklabs/knock-cli/issues/333

`swc` which we use to build a prod release had a change in behavior in its recent updates ([reference](https://github.com/swc-project/swc/issues/3028)), where it started including a source directory in the output directory. This interfered Oclif from discovering commands because it expects `/commands` directory to be available at the top level. 

```
// Oclif expects this:
dist/
  commands/
    whoami.js
    ..

// swc was building like this:
dist/
  src/
    commands/
      whoami.js
      ...
```

`swc` then added a `--strip-leading-paths` flag to revert this behavior ([here](https://github.com/swc-project/cli/issues/281)), and this PR now passes in this flag when building /dist. 

### Tasks
[KNO-5896](https://linear.app/knock/issue/KNO-5896/[cli]-v0113-knock-cli-having-no-commands-to-run)
