### PR TITLE
feat: add option to get and pull translation content in po format

### DIFF
--- a/src/commands/translation/get.ts
+++ b/src/commands/translation/get.ts
@@ -17,11 +17,11 @@ export default class TranslationGet extends BaseCommand<typeof TranslationGet> {
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
-    format: Flags.string({
+    format: Flags.option({
       summary: "Specify the output format of the returned translations.",
-      options: ["json", "po"],
+      options: ["json", "po"] as const,
       default: "json",
-    }),
+    })(),
   };
 
   static args = {
@@ -105,10 +105,10 @@ export default class TranslationGet extends BaseCommand<typeof TranslationGet> {
     });
 
     this.log("");
-    if (format === "po") {
-      ux.log(translation.content);
-    } else {
+    if (format === "json") {
       ux.styledJSON(JSON.parse(translation.content));
+    } else {
+      ux.log(translation.content);
     }
   }
 }

--- a/src/commands/translation/get.ts
+++ b/src/commands/translation/get.ts
@@ -17,6 +17,11 @@ export default class TranslationGet extends BaseCommand<typeof TranslationGet> {
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
+    format: Flags.string({
+      summary: "Specify the output format of the returned translations.",
+      options: ["json", "po"],
+      default: "json",
+    }),
   };
 
   static args = {
@@ -48,8 +53,11 @@ export default class TranslationGet extends BaseCommand<typeof TranslationGet> {
 
   render(translation: ApiV1.GetTranslationResp): void {
     const { translationRef } = this.props.args;
-    const { environment: env, "hide-uncommitted-changes": commitedOnly } =
-      this.props.flags;
+    const {
+      environment: env,
+      "hide-uncommitted-changes": commitedOnly,
+      format,
+    } = this.props.flags;
 
     const qualifier =
       env === "development" && !commitedOnly ? "(including uncommitted)" : "";
@@ -97,6 +105,10 @@ export default class TranslationGet extends BaseCommand<typeof TranslationGet> {
     });
 
     this.log("");
-    ux.styledJSON(JSON.parse(translation.content));
+    if (format === "po") {
+      ux.log(translation.content);
+    } else {
+      ux.styledJSON(JSON.parse(translation.content));
+    }
   }
 }

--- a/src/commands/translation/pull.ts
+++ b/src/commands/translation/pull.ts
@@ -41,11 +41,11 @@ export default class TranslationPull extends BaseCommand<
     force: Flags.boolean({
       summary: "Remove the confirmation prompt.",
     }),
-    format: Flags.string({
+    format: Flags.option({
       summary: "Specify the output format of the returned translations.",
-      options: ["json", "po"],
+      options: ["json", "po"] as const,
       default: "json",
-    }),
+    })(),
   };
 
   static args = {
@@ -96,7 +96,9 @@ export default class TranslationPull extends BaseCommand<
       this.apiV1.getTranslation(this.props, targetCtx),
     );
 
-    await Translation.writeTranslationFile(targetCtx, resp.data, flags.format);
+    await Translation.writeTranslationFile(targetCtx, resp.data, {
+      format: flags.format,
+    });
 
     const actioned = targetCtx.exists ? "updated" : "created";
     this.log(
@@ -125,11 +127,9 @@ export default class TranslationPull extends BaseCommand<
 
     const filters = { localeCode: targetCtx.key };
     const translations = await this.listAllTranslations(filters);
-    await Translation.writeTranslationFiles(
-      targetCtx,
-      translations,
-      flags.format,
-    );
+    await Translation.writeTranslationFiles(targetCtx, translations, {
+      format: flags.format,
+    });
     spinner.stop();
 
     const actioned = targetCtx.exists ? "updated" : "created";
@@ -155,11 +155,9 @@ export default class TranslationPull extends BaseCommand<
     spinner.start(`‣ Loading`);
 
     const translations = await this.listAllTranslations();
-    await Translation.writeTranslationFiles(
-      targetCtx,
-      translations,
-      flags.format,
-    );
+    await Translation.writeTranslationFiles(targetCtx, translations, {
+      format: flags.format,
+    });
     spinner.stop();
 
     const action = targetCtx.exists ? "updated" : "created";

--- a/src/commands/translation/pull.ts
+++ b/src/commands/translation/pull.ts
@@ -96,7 +96,7 @@ export default class TranslationPull extends BaseCommand<
       this.apiV1.getTranslation(this.props, targetCtx),
     );
 
-    await Translation.writeTranslationFile(targetCtx, resp.data);
+    await Translation.writeTranslationFile(targetCtx, resp.data, flags.format);
 
     const actioned = targetCtx.exists ? "updated" : "created";
     this.log(
@@ -125,7 +125,11 @@ export default class TranslationPull extends BaseCommand<
 
     const filters = { localeCode: targetCtx.key };
     const translations = await this.listAllTranslations(filters);
-    await Translation.writeTranslationFiles(targetCtx, translations);
+    await Translation.writeTranslationFiles(
+      targetCtx,
+      translations,
+      flags.format,
+    );
     spinner.stop();
 
     const actioned = targetCtx.exists ? "updated" : "created";
@@ -151,7 +155,11 @@ export default class TranslationPull extends BaseCommand<
     spinner.start(`‣ Loading`);
 
     const translations = await this.listAllTranslations();
-    await Translation.writeTranslationFiles(targetCtx, translations);
+    await Translation.writeTranslationFiles(
+      targetCtx,
+      translations,
+      flags.format,
+    );
     spinner.stop();
 
     const action = targetCtx.exists ? "updated" : "created";

--- a/src/commands/translation/pull.ts
+++ b/src/commands/translation/pull.ts
@@ -41,6 +41,11 @@ export default class TranslationPull extends BaseCommand<
     force: Flags.boolean({
       summary: "Remove the confirmation prompt.",
     }),
+    format: Flags.string({
+      summary: "Specify the output format of the returned translations.",
+      options: ["json", "po"],
+      default: "json",
+    }),
   };
 
   static args = {

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -181,6 +181,7 @@ export default class ApiV1 {
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
       locale_code: filters.localeCode,
       namespace: filters.namespace,
+      format: flags.format,
       ...toPageParams(flags),
     });
 
@@ -195,6 +196,7 @@ export default class ApiV1 {
       environment: flags.environment,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
       namespace: translation.namespace,
+      format: flags.format,
     });
 
     return this.get(`/translations/${translation.localeCode}`, { params });

--- a/src/lib/marshal/translation/helpers.ts
+++ b/src/lib/marshal/translation/helpers.ts
@@ -7,7 +7,11 @@ import localeData from "locale-codes";
 import { DirContext, isDirectory } from "@/lib/helpers/fs";
 import { RunContext, TranslationDirContext } from "@/lib/run-context";
 
-import { formatFileName, formatRef } from "./processor.isomorphic";
+import {
+  formatFileName,
+  formatRef,
+  TranslationFormat,
+} from "./processor.isomorphic";
 import { TranslationData } from "./types";
 
 export const translationRefDescription = `
@@ -29,10 +33,6 @@ export type TranslationFileContext = TranslationIdentifier & {
   abspath: string;
   exists: boolean;
 };
-
-export type TranslationFormat = "json" | "po";
-
-export const DEFAULT_TRANSLATION_FORMAT = "json";
 
 /*
  * Returns a human readable language for the given locale code.
@@ -74,7 +74,7 @@ export const buildTranslationFileCtx = async (
     translationIdentifier.localeCode,
     translationIdentifier.namespace,
   );
-  const filename = formatFileName(ref, { format: options?.format });
+  const filename = formatFileName(ref, options);
   const abspath = path.resolve(dirPath, filename);
   const exists = await fs.pathExists(abspath);
 

--- a/src/lib/marshal/translation/helpers.ts
+++ b/src/lib/marshal/translation/helpers.ts
@@ -63,9 +63,10 @@ export const buildTranslationFileCtx = async (
   dirPath: string,
   localeCode: string,
   namespace: string | undefined,
+  format: string | undefined,
 ): Promise<TranslationFileContext> => {
   const ref = formatRef(localeCode, namespace);
-  const filename = formatFileName(ref);
+  const filename = formatFileName(ref, format);
   const abspath = path.resolve(dirPath, filename);
   const exists = await fs.pathExists(abspath);
 
@@ -116,6 +117,7 @@ type CommandTargetProps = {
   flags: {
     all: boolean | undefined;
     "translations-dir": DirContext | undefined;
+    format: string | undefined;
   };
   args: {
     translationRef: string | undefined;
@@ -200,6 +202,7 @@ export const ensureValidCommandTarget = async (
       targetDirPath,
       localeCode,
       namespace,
+      flags.format,
     );
     return { type: "translationFile", context: translationFileCtx };
   }

--- a/src/lib/marshal/translation/helpers.ts
+++ b/src/lib/marshal/translation/helpers.ts
@@ -117,7 +117,7 @@ type CommandTargetProps = {
   flags: {
     all: boolean | undefined;
     "translations-dir": DirContext | undefined;
-    format: string | undefined;
+    format?: string | undefined;
   };
   args: {
     translationRef: string | undefined;

--- a/src/lib/marshal/translation/processor.isomorphic.ts
+++ b/src/lib/marshal/translation/processor.isomorphic.ts
@@ -1,9 +1,12 @@
-import { DEFAULT_TRANSLATION_FORMAT, TranslationFormat } from "./helpers";
 import { TranslationData } from "./types";
 
 type TranslationDirBundle = {
   [relpath: string]: string;
 };
+
+export type TranslationFormat = "json" | "po";
+
+export const DEFAULT_TRANSLATION_FORMAT = "json";
 
 /*
  * Returns a formatted translation "ref".
@@ -62,7 +65,7 @@ export const buildTranslationDirBundle = (
 
   const translation = input;
   const content =
-    format === "po" ? translation.content : JSON.parse(translation.content);
+    format === "json" ? JSON.parse(translation.content) : translation.content;
   return {
     [formatFileName(translation, { format })]: content,
   };

--- a/src/lib/marshal/translation/processor.isomorphic.ts
+++ b/src/lib/marshal/translation/processor.isomorphic.ts
@@ -42,20 +42,23 @@ type OneOrMoreTranslationData = TranslationData | TranslationData[];
 
 export const buildTranslationDirBundle = (
   input: OneOrMoreTranslationData,
+  format: string | undefined,
 ): TranslationDirBundle => {
   if (Array.isArray(input)) {
     const translations = input;
 
     return Object.fromEntries(
       translations.map((translation) => [
-        formatFileName(translation),
+        formatFileName(translation, format),
         JSON.parse(translation.content),
       ]),
     );
   }
 
   const translation = input;
+  const content =
+    format === "po" ? translation.content : JSON.parse(translation.content);
   return {
-    [formatFileName(translation)]: JSON.parse(translation.content),
+    [formatFileName(translation, format)]: content,
   };
 };

--- a/src/lib/marshal/translation/processor.isomorphic.ts
+++ b/src/lib/marshal/translation/processor.isomorphic.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TRANSLATION_FORMAT, TranslationFormat } from "./helpers";
 import { TranslationData } from "./types";
 
 type TranslationDirBundle = {
@@ -18,14 +19,15 @@ export const formatRef = (
  */
 export const formatFileName = (
   input: string | TranslationData,
-  format: string | undefined,
+  options?: {
+    format?: TranslationFormat;
+  },
 ): string => {
+  const extension = options?.format ?? DEFAULT_TRANSLATION_FORMAT;
   const ref =
     typeof input === "string"
       ? input
       : formatRef(input.locale_code, input.namespace);
-
-  const extension = format === "po" ? "po" : "json";
 
   return `${ref}.${extension}`;
 };
@@ -42,14 +44,17 @@ type OneOrMoreTranslationData = TranslationData | TranslationData[];
 
 export const buildTranslationDirBundle = (
   input: OneOrMoreTranslationData,
-  format: string | undefined,
+  options?: {
+    format?: TranslationFormat;
+  },
 ): TranslationDirBundle => {
+  const format = options?.format ?? DEFAULT_TRANSLATION_FORMAT;
   if (Array.isArray(input)) {
     const translations = input;
 
     return Object.fromEntries(
       translations.map((translation) => [
-        formatFileName(translation, format),
+        formatFileName(translation, { format }),
         JSON.parse(translation.content),
       ]),
     );
@@ -59,6 +64,6 @@ export const buildTranslationDirBundle = (
   const content =
     format === "po" ? translation.content : JSON.parse(translation.content);
   return {
-    [formatFileName(translation, format)]: content,
+    [formatFileName(translation, { format })]: content,
   };
 };

--- a/src/lib/marshal/translation/processor.isomorphic.ts
+++ b/src/lib/marshal/translation/processor.isomorphic.ts
@@ -16,13 +16,18 @@ export const formatRef = (
  * Returns a formatted translation file name based on the given translation ref
  * or payload.
  */
-export const formatFileName = (input: string | TranslationData): string => {
+export const formatFileName = (
+  input: string | TranslationData,
+  format: string | undefined,
+): string => {
   const ref =
     typeof input === "string"
       ? input
       : formatRef(input.locale_code, input.namespace);
 
-  return `${ref}.json`;
+  const extension = format === "po" ? "po" : "json";
+
+  return `${ref}.${extension}`;
 };
 
 /*

--- a/src/lib/marshal/translation/writer.ts
+++ b/src/lib/marshal/translation/writer.ts
@@ -17,10 +17,16 @@ import { TranslationData } from "./types";
 export const writeTranslationFile = async (
   translationFileCtx: TranslationFileContext,
   translation: TranslationData,
-): Promise<void> =>
-  fs.outputJson(translationFileCtx.abspath, JSON.parse(translation.content), {
-    spaces: DOUBLE_SPACES,
-  });
+  format: string | undefined,
+): Promise<void> => {
+  if (format === "po") {
+    fs.outputFile(translationFileCtx.abspath, translation.content);
+  } else {
+    fs.outputJson(translationFileCtx.abspath, JSON.parse(translation.content), {
+      spaces: DOUBLE_SPACES,
+    });
+  }
+};
 
 /*
  * The bulk write function that takes the fetched translations data from Knock
@@ -30,6 +36,7 @@ export const writeTranslationFile = async (
 export const writeTranslationFiles = async (
   targetDirCtx: TranslationDirContext | DirContext,
   translations: TranslationData[],
+  format: string | undefined,
 ): Promise<void> => {
   const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
 
@@ -56,9 +63,10 @@ export const writeTranslationFiles = async (
           localeDirPath,
           translation.locale_code,
           translation.namespace,
+          format,
         );
 
-        return writeTranslationFile(translationFileCtx, translation);
+        return writeTranslationFile(translationFileCtx, translation, format);
       },
     );
 

--- a/src/lib/marshal/translation/writer.ts
+++ b/src/lib/marshal/translation/writer.ts
@@ -8,13 +8,14 @@ import { DirContext } from "@/lib/helpers/fs";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import { TranslationDirContext } from "@/lib/run-context";
 
+import { buildTranslationFileCtx, TranslationFileContext } from "./helpers";
 import {
-  buildTranslationFileCtx,
-  TranslationFileContext,
+  DEFAULT_TRANSLATION_FORMAT,
   TranslationFormat,
-} from "./helpers";
+} from "./processor.isomorphic";
 import { TranslationData } from "./types";
 
+// TODO: Extend and use this type everywhere rather than re-defining opts.
 type WriteTranslationFileOpts = {
   format?: TranslationFormat;
 };
@@ -27,7 +28,9 @@ export const writeTranslationFile = async (
   translation: TranslationData,
   options?: WriteTranslationFileOpts,
 ): Promise<void> => {
-  switch (options?.format) {
+  const format = options?.format ?? DEFAULT_TRANSLATION_FORMAT;
+
+  switch (format) {
     case "json":
       return fs.outputJson(
         translationFileCtx.abspath,

--- a/test/commands/translation/get.test.ts
+++ b/test/commands/translation/get.test.ts
@@ -36,8 +36,8 @@ describe("commands/translation/get", () => {
               }) &&
               isEqual(flags, {
                 "service-token": "valid-token",
-
                 environment: "development",
+                format: "json",
               }),
           ),
           sinon.match((translation) =>
@@ -78,9 +78,9 @@ describe("commands/translation/get", () => {
               }) &&
               isEqual(flags, {
                 "service-token": "valid-token",
-
                 "hide-uncommitted-changes": true,
                 environment: "staging",
+                format: "json",
               }),
           ),
           sinon.match((translation) =>

--- a/test/commands/translation/pull.test.ts
+++ b/test/commands/translation/pull.test.ts
@@ -91,9 +91,9 @@ describe("commands/translation/pull", () => {
                 exists: false,
               },
               "service-token": "valid-token",
-
               environment: "development",
               limit: 100,
+              format: "json",
             }),
           ),
         );
@@ -146,8 +146,8 @@ describe("commands/translation/pull", () => {
               }) &&
               isEqual(flags, {
                 "service-token": "valid-token",
-
                 environment: "development",
+                format: "json",
               }),
           ),
           sinon.match((translation) =>
@@ -205,9 +205,9 @@ describe("commands/translation/pull", () => {
               isEqual(flags, {
                 all: true,
                 "service-token": "valid-token",
-
                 environment: "development",
                 limit: 100,
+                format: "json",
               }),
           ),
           sinon.match((filters) =>


### PR DESCRIPTION
### Description
Adds the option to get and pull translation content in the po format. Updates the writer to write to .json or .po files depending on the format flag.

### Tasks
[KNO-5913](https://linear.app/knock/issue/KNO-5913/export-translations-as-po-from-cli)

### Screenshots
![Screenshot 2024-05-08 at 9 02 18 AM](https://github.com/knocklabs/knock-cli/assets/12838032/21f123d9-5ace-495e-9c7b-5f4afeaa0e00)
![Screenshot 2024-05-08 at 9 03 10 AM](https://github.com/knocklabs/knock-cli/assets/12838032/0ed627b6-b35d-48d1-9ed2-69c50bad8b20)
