### PR TITLE
feat: add buildMessageTypeDirBundle helper

### DIFF
--- a/src/lib/marshal/email-layout/processor.isomorphic.ts
+++ b/src/lib/marshal/email-layout/processor.isomorphic.ts
@@ -6,7 +6,6 @@ import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { prepareResourceJson } from "../shared/helpers.isomorphic";
-
 import { EmailLayoutData } from "./types";
 
 export const LAYOUT_JSON = "layout.json";

--- a/src/lib/marshal/index.isomorphic.ts
+++ b/src/lib/marshal/index.isomorphic.ts
@@ -2,7 +2,7 @@
  * IMPORTANT: You must only expose exports from isomorphic modules.
  */
 export { buildEmailLayoutDirBundle } from "./email-layout/processor.isomorphic";
-export { buildPartialDirBundle } from "./partial/processor.isomorphic";
 export { buildMessageTypeDirBundle } from "./message-type/processor.isomorphic";
+export { buildPartialDirBundle } from "./partial/processor.isomorphic";
 export { buildTranslationDirBundle } from "./translation/processor.isomorphic";
 export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";

--- a/src/lib/marshal/index.isomorphic.ts
+++ b/src/lib/marshal/index.isomorphic.ts
@@ -3,5 +3,6 @@
  */
 export { buildEmailLayoutDirBundle } from "./email-layout/processor.isomorphic";
 export { buildPartialDirBundle } from "./partial/processor.isomorphic";
+export { buildMessageTypeDirBundle } from "./message-type/processor.isomorphic";
 export { buildTranslationDirBundle } from "./translation/processor.isomorphic";
 export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";

--- a/src/lib/marshal/message-type/index.ts
+++ b/src/lib/marshal/message-type/index.ts
@@ -1,0 +1,2 @@
+export * from "./processor.isomorphic";
+export * from "./types";

--- a/src/lib/marshal/message-type/processor.isomorphic.ts
+++ b/src/lib/marshal/message-type/processor.isomorphic.ts
@@ -6,7 +6,6 @@ import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { prepareResourceJson } from "../shared/helpers.isomorphic";
-
 import { MessageTypeData } from "./types";
 
 export const MESSAGE_TYPE_JSON = "message_type.json";

--- a/src/lib/marshal/message-type/types.ts
+++ b/src/lib/marshal/message-type/types.ts
@@ -1,0 +1,77 @@
+import { MaybeWithAnnotation } from "../shared/types";
+
+type VariantSchemaBooleanField = {
+  type: "boolean";
+  key: string;
+  label: string;
+  settings: {
+    required: boolean;
+    default: boolean;
+    description?: string;
+  };
+};
+
+type VariantSchemaMarkdownField = {
+  type: "markdown";
+  key: string;
+  label: string;
+  settings: {
+    required: boolean;
+    default: string;
+    description?: string;
+  };
+};
+
+type VariantSchemaTextField = {
+  type: "text";
+  key: string;
+  label: string;
+  settings: {
+    required: boolean;
+    default: string;
+    description?: string;
+    maxLength?: number;
+    minLength?: number;
+  };
+};
+
+type VariantSchemaTextareaField = {
+  type: "textarea";
+  key: string;
+  label: string;
+  settings: {
+    required: boolean;
+    default: string;
+    description?: string;
+    maxLength?: number;
+    minLength?: number;
+  };
+};
+
+type MessageTypeVariantSchemaField =
+  | VariantSchemaBooleanField
+  | VariantSchemaMarkdownField
+  | VariantSchemaTextField
+  | VariantSchemaTextareaField;
+
+type MessageTypeVariantSchema = {
+  fields: MessageTypeVariantSchemaField[];
+  key: string;
+  name: string;
+};
+
+// Message type payload data from the API.
+export type MessageTypeData<A extends MaybeWithAnnotation = unknown> = A & {
+  key: string;
+  valid: boolean;
+  owner: "system" | "user";
+  name: string;
+  variants: MessageTypeVariantSchema[];
+  preview: string;
+  semver: string | null;
+  description?: string;
+  icon_name?: string;
+  updated_at: string;
+  created_at: string;
+  environment: string;
+};

--- a/src/lib/marshal/partial/processor.isomorphic.ts
+++ b/src/lib/marshal/partial/processor.isomorphic.ts
@@ -6,7 +6,6 @@ import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { prepareResourceJson } from "../shared/helpers.isomorphic";
-
 import { PartialData, PartialType } from "./types";
 
 export const PARTIAL_JSON = "partial.json";

--- a/src/lib/marshal/partial/types.ts
+++ b/src/lib/marshal/partial/types.ts
@@ -1,5 +1,3 @@
-import { AnyObj } from "@/lib/helpers/object.isomorphic";
-
 import { MaybeWithAnnotation } from "../shared/types";
 
 export enum PartialType {
@@ -22,8 +20,4 @@ export type PartialData<A extends MaybeWithAnnotation = unknown> = A & {
   environment: string;
   updated_at: string;
   created_at: string;
-};
-
-export type PartialInput = AnyObj & {
-  key: string;
 };

--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -3,9 +3,9 @@ import { omitDeep } from "@/lib/helpers/object.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { EmailLayoutData } from "../email-layout";
+import { MessageTypeData } from "../message-type";
 import { PartialData } from "../partial";
 import { WorkflowData } from "../workflow";
-import { MessageTypeData } from "../message-type";
 
 /*
  * Sanitize the resource data into a format that's appropriate for reading

--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -1,0 +1,31 @@
+import { AnyObj, split } from "@/lib/helpers/object.isomorphic";
+import { omitDeep } from "@/lib/helpers/object.isomorphic";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+import { EmailLayoutData } from "../email-layout";
+import { PartialData } from "../partial";
+import { WorkflowData } from "../workflow";
+import { MessageTypeData } from "../message-type";
+
+/*
+ * Sanitize the resource data into a format that's appropriate for reading
+ * and writing, by stripping out any annotation fields and handling readonly
+ * fields.
+ */
+type ResourceData<A extends WithAnnotation> =
+  | EmailLayoutData<A>
+  | PartialData<A>
+  | WorkflowData<A>
+  | MessageTypeData<A>;
+
+export const prepareResourceJson = (
+  resource: ResourceData<WithAnnotation>,
+): AnyObj => {
+  // Move read only field under the dedicated field "__readonly".
+  const readonlyFields = resource.__annotation?.readonly_fields || [];
+  const [readonly, remainder] = split(resource, readonlyFields);
+  const resourceJson = { ...remainder, __readonly: readonly };
+
+  // Strip out all schema annotations, so not to expose them to end users.
+  return omitDeep(resourceJson, ["__annotation"]);
+};

--- a/src/lib/marshal/workflow/processor.isomorphic.ts
+++ b/src/lib/marshal/workflow/processor.isomorphic.ts
@@ -16,13 +16,14 @@ import {
   ObjKeyOrArrayIdx,
   ObjPath,
   omitDeep,
-  split,
 } from "@/lib/helpers/object.isomorphic";
 import {
   FILEPATH_MARKED_RE,
   FILEPATH_MARKER,
 } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
+
+import { prepareResourceJson } from "../shared/helpers.isomorphic";
 
 import { StepType, WorkflowData, WorkflowStepData } from "./types";
 
@@ -31,22 +32,6 @@ export const VISUAL_BLOCKS_JSON = "visual_blocks.json";
 
 export type WorkflowDirBundle = {
   [relpath: string]: string;
-};
-
-/*
- * Sanitize the workflow content into a format that's appropriate for reading
- * and writing, by stripping out any annotation fields and handling readonly
- * fields.
- */
-const toWorkflowJson = (workflow: WorkflowData<WithAnnotation>): AnyObj => {
-  // Move read only fields of a workflow under the dedicated field "__readonly".
-  const readonlyFields = workflow.__annotation?.readonly_fields || [];
-  const [readonly, remainder] = split(workflow, readonlyFields);
-
-  const worklfowJson = { ...remainder, __readonly: readonly };
-
-  // Strip out all schema annotations, so not to expose them to end users.
-  return omitDeep(worklfowJson, ["__annotation"]);
 };
 
 /*
@@ -373,8 +358,8 @@ export const buildWorkflowDirBundle = (
   );
 
   // Then, prepare the workflow data to be written into a workflow json file.
-  return set(bundle, [WORKFLOW_JSON], toWorkflowJson(mutWorkflow));
+  return set(bundle, [WORKFLOW_JSON], prepareResourceJson(mutWorkflow));
 };
 
 // Exported for tests.
-export { formatExtractedFilePath, toWorkflowJson };
+export { formatExtractedFilePath };

--- a/src/lib/marshal/workflow/processor.isomorphic.ts
+++ b/src/lib/marshal/workflow/processor.isomorphic.ts
@@ -24,7 +24,6 @@ import {
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { prepareResourceJson } from "../shared/helpers.isomorphic";
-
 import { StepType, WorkflowData, WorkflowStepData } from "./types";
 
 export const WORKFLOW_JSON = "workflow.json";

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -1,10 +1,8 @@
 import { expect } from "chai";
-import { get } from "lodash";
 
 import {
   buildEmailLayoutDirBundle,
   EmailLayoutData,
-  toEmailLayoutJson,
 } from "@/lib/marshal/email-layout";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
@@ -27,30 +25,6 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
 };
 
 describe("lib/marshal/layout/processor", () => {
-  describe("toEmailLayoutJson", () => {
-    it("moves over layout's readonly fields under __readonly field", () => {
-      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
-
-      expect(layoutJson.key).to.equal(undefined);
-      expect(layoutJson.environment).to.equal(undefined);
-      expect(layoutJson.created_at).to.equal(undefined);
-      expect(layoutJson.updated_at).to.equal(undefined);
-
-      expect(layoutJson.__readonly).to.eql({
-        key: "default",
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
-        updated_at: "2023-10-02T19:24:48.714630Z",
-      });
-    });
-
-    it("removes all __annotation fields", () => {
-      const layoutJson = toEmailLayoutJson(remoteEmailLayout);
-
-      expect(get(layoutJson, "__annotation")).to.equal(undefined);
-    });
-  });
-
   describe("buildEmailLayoutDirBundle", () => {
     describe("given a fetched layout that has not been pulled before", () => {
       const result = buildEmailLayoutDirBundle(remoteEmailLayout);

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -1,0 +1,143 @@
+import { expect } from "chai";
+
+import {
+  buildMessageTypeDirBundle,
+  MessageTypeData,
+} from "@/lib/marshal/message-type";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+const remoteMessageType: MessageTypeData<WithAnnotation> = {
+  key: "banner",
+  valid: true,
+  owner: "user",
+  name: "Banner",
+  variants: [
+    {
+      key: "default",
+      name: "Default",
+      fields: [
+        {
+          type: "text",
+          key: "title",
+          label: "Title",
+          settings: {
+            required: true,
+            default: "",
+          },
+        },
+      ],
+    },
+  ],
+  preview: "<div>{{ title }}</div>",
+  semver: null,
+  description: "My little banner",
+  environment: "development",
+  updated_at: "2023-10-02T19:24:48.714630Z",
+  created_at: "2023-09-18T18:32:18.398053Z",
+  __annotation: {
+    extractable_fields: {
+      preview: { default: true, file_ext: "html" },
+    },
+    readonly_fields: [
+      "key",
+      "valid",
+      "owner",
+      "environment",
+      "semver",
+      "created_at",
+      "updated_at",
+    ],
+  },
+};
+
+describe("lib/marshal/message-typel/processor", () => {
+  describe("buildMessageTypeDirBundle", () => {
+    describe("given a fetched message type that has not been pulled before", () => {
+      const result = buildMessageTypeDirBundle(remoteMessageType);
+
+      expect(result).to.eql({
+        "preview.html": "<div>{{ title }}</div>",
+        "message_type.json": {
+          name: "Banner",
+          variants: [
+            {
+              key: "default",
+              name: "Default",
+              fields: [
+                {
+                  type: "text",
+                  key: "title",
+                  label: "Title",
+                  settings: {
+                    required: true,
+                    default: "",
+                  },
+                },
+              ],
+            },
+          ],
+          description: "My little banner",
+          "preview@": "preview.html",
+          __readonly: {
+            key: "banner",
+            valid: true,
+            owner: "user",
+            environment: "development",
+            semver: null,
+            created_at: "2023-09-18T18:32:18.398053Z",
+            updated_at: "2023-10-02T19:24:48.714630Z",
+          },
+        },
+      });
+    });
+
+    describe("given a fetched message type with a local version available", () => {
+      it("returns a dir bundle based on a local version and default extract settings", () => {
+        const localMessageType = {
+          ...remoteMessageType,
+          "preview@": "foo/bar/baz.html",
+        };
+
+        const result = buildMessageTypeDirBundle(
+          remoteMessageType,
+          localMessageType,
+        );
+
+        expect(result).to.eql({
+          "foo/bar/baz.html": "<div>{{ title }}</div>",
+          "message_type.json": {
+            name: "Banner",
+            variants: [
+              {
+                key: "default",
+                name: "Default",
+                fields: [
+                  {
+                    type: "text",
+                    key: "title",
+                    label: "Title",
+                    settings: {
+                      required: true,
+                      default: "",
+                    },
+                  },
+                ],
+              },
+            ],
+            description: "My little banner",
+            "preview@": "foo/bar/baz.html",
+            __readonly: {
+              key: "banner",
+              valid: true,
+              owner: "user",
+              environment: "development",
+              semver: null,
+              created_at: "2023-09-18T18:32:18.398053Z",
+              updated_at: "2023-10-02T19:24:48.714630Z",
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -1,16 +1,16 @@
 import { expect } from "chai";
-import { get } from "lodash";
 
 import {
   buildPartialDirBundle,
   PartialData,
   PartialType,
-  toPartialJson,
 } from "@/lib/marshal/partial";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remotePartial: PartialData<WithAnnotation> = {
   key: "default",
+  valid: true,
+  visual_block_enabled: true,
   type: PartialType.Html,
   name: "Default",
   content: "<html><body><p> Example content </html></body><p>",
@@ -22,37 +22,18 @@ const remotePartial: PartialData<WithAnnotation> = {
     extractable_fields: {
       content: { default: true, file_ext: "txt" },
     },
-    readonly_fields: ["key", "type", "environment", "created_at", "updated_at"],
+    readonly_fields: [
+      "key",
+      "valid",
+      "type",
+      "environment",
+      "created_at",
+      "updated_at",
+    ],
   },
 };
 
 describe("lib/marshal/partial/processor", () => {
-  describe("toPartialJson", () => {
-    it("moves over partial's readonly fields under __readonly field", () => {
-      const partialJson = toPartialJson(remotePartial);
-
-      expect(partialJson.key).to.equal(undefined);
-      expect(partialJson.type).to.equal(undefined);
-      expect(partialJson.environment).to.equal(undefined);
-      expect(partialJson.created_at).to.equal(undefined);
-      expect(partialJson.updated_at).to.equal(undefined);
-
-      expect(partialJson.__readonly).to.eql({
-        key: "default",
-        type: PartialType.Html,
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
-        updated_at: "2023-10-02T19:24:48.714630Z",
-      });
-    });
-
-    it("removes all __annotation fields", () => {
-      const partialJson = toPartialJson(remotePartial);
-
-      expect(get(partialJson, "__annotation")).to.equal(undefined);
-    });
-  });
-
   describe("buildPartialDirBundle", () => {
     describe("given a fetched partial that has not been pulled before", () => {
       const result = buildPartialDirBundle(remotePartial);
@@ -61,10 +42,12 @@ describe("lib/marshal/partial/processor", () => {
         "content.html": "<html><body><p> Example content </html></body><p>",
         "partial.json": {
           name: "Default",
+          visual_block_enabled: true,
           description: "Default HTML partial",
           "content@": "content.html",
           __readonly: {
             key: "default",
+            valid: true,
             type: PartialType.Html,
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
@@ -76,22 +59,24 @@ describe("lib/marshal/partial/processor", () => {
 
     describe("given a fetched partial with a local version available", () => {
       it("returns a dir bundle based on a local version and default extract settings", () => {
-        const localpartial = {
+        const localPartial = {
           name: "default",
           "content@": "foo/bar/partial.html",
         };
 
-        const result = buildPartialDirBundle(remotePartial, localpartial);
+        const result = buildPartialDirBundle(remotePartial, localPartial);
 
         expect(result).to.eql({
           "foo/bar/partial.html":
             "<html><body><p> Example content </html></body><p>",
           "partial.json": {
             name: "Default",
+            visual_block_enabled: true,
             description: "Default HTML partial",
             "content@": "foo/bar/partial.html",
             __readonly: {
               key: "default",
+              valid: true,
               type: PartialType.Html,
               environment: "development",
               created_at: "2023-09-18T18:32:18.398053Z",

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -2,8 +2,8 @@ import { expect } from "@oclif/test";
 import { get } from "lodash";
 
 import { xpath } from "@/../test/support";
-import { WithAnnotation } from "@/lib/marshal/shared/types";
 import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
 import {
   buildWorkflowDirBundle,
   formatExtractedFilePath,

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -3,11 +3,11 @@ import { get } from "lodash";
 
 import { xpath } from "@/../test/support";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import {
   buildWorkflowDirBundle,
   formatExtractedFilePath,
   StepType,
-  toWorkflowJson,
   WorkflowData,
 } from "@/lib/marshal/workflow";
 
@@ -168,9 +168,9 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
 };
 
 describe("lib/marshal/workflow/processor", () => {
-  describe("toWorkflowJson", () => {
+  describe("prepareResourceJson", () => {
     it("moves over workflow's readonly fields under __readonly field", () => {
-      const workflowJson = toWorkflowJson(remoteWorkflow);
+      const workflowJson = prepareResourceJson(remoteWorkflow);
 
       expect(workflowJson.key).to.equal(undefined);
       expect(workflowJson.active).to.equal(undefined);
@@ -189,7 +189,7 @@ describe("lib/marshal/workflow/processor", () => {
     });
 
     it("removes all __annotation fields", () => {
-      const workflowJson = toWorkflowJson(remoteWorkflow);
+      const workflowJson = prepareResourceJson(remoteWorkflow);
 
       expect(get(workflowJson, "__annotation")).to.equal(undefined);
 


### PR DESCRIPTION
### Description

A prerequisite for https://github.com/knocklabs/control/pull/3600, to be able to show commit diffs for message types.

### Tasks
[KNO-6509](https://linear.app/knock/issue/KNO-6509/[cli]-add-buildmessagetypedirbundle-helper)
