### PR TITLE
feat: add message-type list and get commands

### DIFF
--- a/src/commands/message-type/get.ts
+++ b/src/commands/message-type/get.ts
@@ -1,0 +1,124 @@
+import { Args, Flags, ux } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatDateTime } from "@/lib/helpers/date";
+import { ApiError } from "@/lib/helpers/error";
+import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
+import { spinner } from "@/lib/helpers/ux";
+
+export default class MessageTypeGet extends BaseCommand<typeof MessageTypeGet> {
+  static summary = "Display a single in-app message type from an environment.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    "hide-uncommitted-changes": Flags.boolean({
+      summary: "Hide any uncommitted changes.",
+    }),
+  };
+
+  static args = {
+    messageTypeKey: Args.string({
+      required: true,
+    }),
+  };
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.GetMessageTypeResp | void> {
+    spinner.start("‣ Loading");
+
+    const { messageType } = await this.loadMessageType();
+
+    spinner.stop();
+
+    const { flags } = this.props;
+    if (flags.json) return messageType;
+
+    this.render(messageType);
+  }
+
+  private async loadMessageType(): Promise<{
+    messageType: ApiV1.GetMessageTypeResp;
+  }> {
+    const messageTypeResp = await this.apiV1.getMessageType(this.props);
+
+    if (!isSuccessResp(messageTypeResp)) {
+      const message = formatErrorRespMessage(messageTypeResp);
+      ux.error(new ApiError(message));
+    }
+
+    return {
+      messageType: messageTypeResp.data,
+    };
+  }
+
+  render(messageType: ApiV1.GetMessageTypeResp): void {
+    const { messageTypeKey } = this.props.args;
+    const { environment: env, "hide-uncommitted-changes": commitedOnly } =
+      this.props.flags;
+
+    const qualifier =
+      env === "development" && !commitedOnly ? "(including uncommitted)" : "";
+
+    this.log(
+      `‣ Showing in-app message type \`${messageTypeKey}\` in \`${env}\` environment ${qualifier}\n`,
+    );
+
+    /*
+     * Message type table
+     */
+
+    const rows = [
+      {
+        key: "Name",
+        value: messageType.name,
+      },
+      {
+        key: "Key",
+        value: messageType.key,
+      },
+      {
+        key: "Description",
+        value: messageType.description || "-",
+      },
+      {
+        key: "Owner",
+        value: messageType.owner,
+      },
+      {
+        key: "Created at",
+        value: formatDateTime(messageType.created_at),
+      },
+      {
+        key: "Updated at",
+        value: formatDateTime(messageType.updated_at),
+      },
+      {
+        key: "Schema",
+        value:
+          (messageType.variants || []).length > 0
+            ? "\n" + JSON.stringify(messageType.variants, null, 2)
+            : "-",
+      },
+      {
+        key: "Preview template",
+        value: messageType.preview ? "\n" + messageType.preview : "-",
+      },
+    ];
+
+    ux.table(rows, {
+      key: {
+        header: "Message type",
+        minWidth: 24,
+      },
+      value: {
+        header: "",
+        minWidth: 24,
+      },
+    });
+  }
+}

--- a/src/commands/message-type/list.ts
+++ b/src/commands/message-type/list.ts
@@ -1,0 +1,103 @@
+import { Flags, ux } from "@oclif/core";
+import { AxiosResponse } from "axios";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatDate } from "@/lib/helpers/date";
+import { merge } from "@/lib/helpers/object.isomorphic";
+import {
+  maybePromptPageAction,
+  pageFlags,
+  paramsForPageAction,
+} from "@/lib/helpers/page";
+import { withSpinner } from "@/lib/helpers/request";
+
+export default class MessageTypeList extends BaseCommand<
+  typeof MessageTypeList
+> {
+  static summary = "Display all in-app message types for an environment.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    "hide-uncommitted-changes": Flags.boolean({
+      summary: "Hide any uncommitted changes.",
+    }),
+    ...pageFlags,
+  };
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.ListMessageTypeResp | void> {
+    const resp = await this.request();
+
+    const { flags } = this.props;
+    if (flags.json) return resp.data;
+
+    this.render(resp.data);
+  }
+
+  async request(
+    pageParams = {},
+  ): Promise<AxiosResponse<ApiV1.ListMessageTypeResp>> {
+    const props = merge(this.props, { flags: { ...pageParams } });
+
+    return withSpinner<ApiV1.ListMessageTypeResp>(() =>
+      this.apiV1.listMessageTypes(props),
+    );
+  }
+
+  async render(data: ApiV1.ListMessageTypeResp): Promise<void> {
+    const { entries } = data;
+    const { environment: env, "hide-uncommitted-changes": committedOnly } =
+      this.props.flags;
+
+    const qualifier =
+      env === "development" && !committedOnly ? "(including uncommitted)" : "";
+
+    this.log(
+      `‣ Showing ${entries.length} in-app message types in \`${env}\` environment ${qualifier}\n`,
+    );
+
+    /*
+     * Message types list table
+     */
+
+    ux.table(entries, {
+      key: {
+        header: "Key",
+      },
+      name: {
+        header: "Name",
+      },
+      description: {
+        header: "Description",
+      },
+      owner: {
+        header: "Owner",
+      },
+      updated_at: {
+        header: "Updated at",
+        get: (entry) => formatDate(entry.updated_at),
+      },
+    });
+
+    return this.prompt(data);
+  }
+
+  async prompt(data: ApiV1.ListMessageTypeResp): Promise<void> {
+    const { page_info } = data;
+
+    const pageAction = await maybePromptPageAction(page_info);
+    const pageParams = pageAction && paramsForPageAction(pageAction, page_info);
+
+    if (pageParams) {
+      this.log("\n");
+
+      const resp = await this.request(pageParams);
+      return this.render(resp.data);
+    }
+  }
+}

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -7,6 +7,7 @@ import { prune } from "@/lib/helpers/object.isomorphic";
 import { PaginatedResp, toPageParams } from "@/lib/helpers/page";
 import * as Commit from "@/lib/marshal/commit";
 import * as EmailLayout from "@/lib/marshal/email-layout";
+import * as MessageType from "@/lib/marshal/message-type";
 import * as Partial from "@/lib/marshal/partial";
 import { MaybeWithAnnotation } from "@/lib/marshal/shared/types";
 import * as Translation from "@/lib/marshal/translation";
@@ -350,6 +351,34 @@ export default class ApiV1 {
     });
   }
 
+  // By resources: Message types
+
+  async listMessageTypes<A extends MaybeWithAnnotation>({
+    flags,
+  }: Props): Promise<AxiosResponse<ListMessageTypeResp<A>>> {
+    const params = prune({
+      environment: flags.environment,
+      hide_uncommitted_changes: flags["hide-uncommitted-changes"],
+      annotate: flags.annotate,
+      ...toPageParams(flags),
+    });
+
+    return this.get("/message_types", { params });
+  }
+
+  async getMessageType<A extends MaybeWithAnnotation>({
+    args,
+    flags,
+  }: Props): Promise<AxiosResponse<GetMessageTypeResp<A>>> {
+    const params = prune({
+      environment: flags.environment,
+      annotate: flags.annotate,
+      hide_uncommitted_changes: flags["hide-uncommitted-changes"],
+    });
+
+    return this.get(`/message_types/${args.messageTypeKey}`, { params });
+  }
+
   // By methods:
 
   async get(
@@ -469,3 +498,9 @@ export type ValidatePartialResp = {
   partial?: Partial.PartialData;
   errors?: InputError[];
 };
+
+export type ListMessageTypeResp<A extends MaybeWithAnnotation = unknown> =
+  PaginatedResp<MessageType.MessageTypeData<A>>;
+
+export type GetMessageTypeResp<A extends MaybeWithAnnotation = unknown> =
+  MessageType.MessageTypeData<A>;

--- a/src/lib/marshal/message-type/types.ts
+++ b/src/lib/marshal/message-type/types.ts
@@ -4,50 +4,31 @@ type VariantSchemaBooleanField = {
   type: "boolean";
   key: string;
   label: string;
-  settings: {
-    required: boolean;
-    default: boolean;
-    description?: string;
-  };
+  settings: Record<string, unknown>;
 };
 
 type VariantSchemaMarkdownField = {
   type: "markdown";
   key: string;
   label: string;
-  settings: {
-    required: boolean;
-    default: string;
-    description?: string;
-  };
+  settings: Record<string, unknown>;
 };
 
 type VariantSchemaTextField = {
   type: "text";
   key: string;
   label: string;
-  settings: {
-    required: boolean;
-    default: string;
-    description?: string;
-    maxLength?: number;
-    minLength?: number;
-  };
+  settings: Record<string, unknown>;
 };
 
 type VariantSchemaTextareaField = {
   type: "textarea";
   key: string;
   label: string;
-  settings: {
-    required: boolean;
-    default: string;
-    description?: string;
-    maxLength?: number;
-    minLength?: number;
-  };
+  settings: Record<string, unknown>;
 };
 
+// TODO: Type the remaining schema field types.
 type MessageTypeVariantSchemaField =
   | VariantSchemaBooleanField
   | VariantSchemaMarkdownField

--- a/test/commands/commit/get.test.ts
+++ b/test/commands/commit/get.test.ts
@@ -11,7 +11,7 @@ describe("commands/commit/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["commit get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a commit ID arg, and no flags", () => {

--- a/test/commands/layout/get.test.ts
+++ b/test/commands/layout/get.test.ts
@@ -11,7 +11,7 @@ describe("commands/layout/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["layout get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given an email layout key arg, and no flags", () => {

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -204,7 +204,7 @@ describe("commands/layout/push", () => {
       .stdout()
       .command(["layout push"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given both email layout key arg and --all flag", () => {
@@ -212,7 +212,7 @@ describe("commands/layout/push", () => {
       .stdout()
       .command(["layout push", "default", "--all"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given --all and a nonexistent layouts index directory", () => {

--- a/test/commands/layout/validate.test.ts
+++ b/test/commands/layout/validate.test.ts
@@ -119,7 +119,7 @@ describe("commands/layout/validate (a single layout)", () => {
       .stdout()
       .command(["layout validate"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 });
 

--- a/test/commands/message-type/get.test.ts
+++ b/test/commands/message-type/get.test.ts
@@ -17,7 +17,7 @@ describe("commands/message-type/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["message-type get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a message type key arg, and no flags", () => {

--- a/test/commands/message-type/get.test.ts
+++ b/test/commands/message-type/get.test.ts
@@ -1,0 +1,119 @@
+import { test } from "@oclif/test";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/message-type/get", () => {
+  const whoami = {
+    account_name: "Collab.io",
+    account_slug: "collab-io",
+    service_token_name: "My cool token",
+  };
+
+  describe("given no message type key arg", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .command(["message-type get"])
+      .exit(2)
+      .it("exists with status 2");
+  });
+
+  describe("given a message type key arg, and no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getMessageType", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.messageType(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["message-type get", "foo"])
+      .it("calls apiV1 getMessageType with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                messageTypeKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a message type key arg, and flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getMessageType", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.messageType(),
+          }),
+        ),
+      )
+      .stdout()
+      .command([
+        "message-type get",
+        "foo",
+        "--hide-uncommitted-changes",
+        "--environment",
+        "development",
+      ])
+      .it("calls apiV1 getMessageType with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                messageTypeKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                "hide-uncommitted-changes": true,
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a message type key that does not exist", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getMessageType", (stub) =>
+        stub.resolves(
+          factory.resp({
+            status: 404,
+            statusText: "Not found",
+            data: {
+              code: "resource_missing",
+              message: "The resource you requested does not exist",
+              status: 404,
+              type: "api_error",
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["message-type get", "foo"])
+      .catch("The resource you requested does not exist")
+      .it("throws an error for resource not found");
+  });
+});

--- a/test/commands/message-type/list.test.ts
+++ b/test/commands/message-type/list.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/message-type/list", () => {
+  const emptyEntriesResp = factory.resp({
+    data: {
+      page_info: factory.pageInfo(),
+      entries: [],
+    },
+  });
+
+  describe("given no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+        stub.resolves(emptyEntriesResp),
+      )
+      .stdout()
+      .command(["message-type list"])
+      .it("calls apiV1 listMessageTypes with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listMessageTypes as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+        stub.resolves(emptyEntriesResp),
+      )
+      .stdout()
+      .command([
+        "message-type list",
+        "--hide-uncommitted-changes",
+        "--environment",
+        "development",
+        "--limit",
+        "5",
+        "--after",
+        "xyz",
+      ])
+      .it("calls apiV1 listMessageTypes with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listMessageTypes as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                "hide-uncommitted-changes": true,
+                environment: "development",
+                limit: 5,
+                after: "xyz",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a list of message types in response", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: {
+              page_info: factory.pageInfo(),
+              entries: [
+                factory.messageType({ key: "card" }),
+                factory.messageType({ key: "banner" }),
+                factory.messageType({ key: "modal" }),
+              ],
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["message-type list"])
+      .it("displays the list of message types", (ctx) => {
+        expect(ctx.stdout).to.contain("Showing 3 in-app message types in");
+        expect(ctx.stdout).to.contain("card");
+        expect(ctx.stdout).to.contain("banner");
+        expect(ctx.stdout).to.contain("modal");
+
+        expect(ctx.stdout).to.not.contain("toast");
+      });
+  });
+
+  describe("given the first page of paginated message types in resp", () => {
+    const paginatedMessageTypesResp = factory.resp({
+      data: {
+        page_info: factory.pageInfo({
+          after: "xyz",
+        }),
+        entries: [
+          factory.messageType({ key: "card" }),
+          factory.messageType({ key: "banner" }),
+          factory.messageType({ key: "modal" }),
+        ],
+      },
+    });
+
+    describe("plus a next page action from the prompt input", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+          stub.resolves(paginatedMessageTypesResp),
+        )
+        .stub(enquirer.prototype, "prompt", (stub) =>
+          stub
+            .onFirstCall()
+            .resolves({ input: "n" })
+            .onSecondCall()
+            .resolves({ input: "" }),
+        )
+        .stdout()
+        .command(["message-type list"])
+        .it(
+          "calls apiV1 listMessageTypes for the second time with page params",
+          () => {
+            const listMessageTypesFn = KnockApiV1.prototype
+              .listMessageTypes as any;
+
+            sinon.assert.calledTwice(listMessageTypesFn);
+
+            // First call without page params.
+            sinon.assert.calledWith(
+              listMessageTypesFn.firstCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                  }),
+              ),
+            );
+
+            // Second call with page params to fetch the next page.
+            sinon.assert.calledWith(
+              listMessageTypesFn.secondCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                    after: "xyz",
+                  }),
+              ),
+            );
+          },
+        );
+    });
+
+    describe("plus a previous page action input from the prompt", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+          stub.resolves(paginatedMessageTypesResp),
+        )
+        .stub(enquirer.prototype, "prompt", (stub) =>
+          stub.onFirstCall().resolves({ input: "p" }),
+        )
+        .stdout()
+        .command(["message-type list"])
+        .it(
+          "calls apiV1 listMessageTypes once for the initial page only",
+          () => {
+            sinon.assert.calledOnce(
+              KnockApiV1.prototype.listMessageTypes as any,
+            );
+          },
+        );
+    });
+  });
+});

--- a/test/commands/partial/get.test.ts
+++ b/test/commands/partial/get.test.ts
@@ -17,7 +17,7 @@ describe("commands/partial/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["partial get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a partial key arg, and no flags", () => {

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -213,7 +213,7 @@ describe("commands/partial/push", () => {
       .stdout()
       .command(["partial push"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given both partial key arg and --all flag", () => {
@@ -221,7 +221,7 @@ describe("commands/partial/push", () => {
       .stdout()
       .command(["partial push", "default", "--all"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given --all and a nonexistent partials index directory", () => {

--- a/test/commands/partial/validate.test.ts
+++ b/test/commands/partial/validate.test.ts
@@ -119,7 +119,7 @@ describe("commands/partial/validate (a single partial)", () => {
       .stdout()
       .command(["partial validate"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 });
 

--- a/test/commands/ping.test.ts
+++ b/test/commands/ping.test.ts
@@ -46,6 +46,6 @@ describe("commands/ping", () => {
   });
 
   describe("given no service token flag", () => {
-    test.command(["ping"]).exit(2).it("exists with status 2");
+    test.command(["ping"]).exit(2).it("exits with status 2");
   });
 });

--- a/test/commands/translation/get.test.ts
+++ b/test/commands/translation/get.test.ts
@@ -11,7 +11,7 @@ describe("commands/translation/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["translation get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a translation ref arg, and no flags", () => {

--- a/test/commands/translation/push.test.ts
+++ b/test/commands/translation/push.test.ts
@@ -151,7 +151,7 @@ describe("commands/translation/push", () => {
       .stdout()
       .command(["translation push"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given --all and a nonexistent translations index directory", () => {

--- a/test/commands/translation/validate.test.ts
+++ b/test/commands/translation/validate.test.ts
@@ -130,7 +130,7 @@ describe("commands/translation/validate (a single translation)", () => {
       .stdout()
       .command(["translation validate"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a valid en translation file in po format", () => {

--- a/test/commands/whoami.test.ts
+++ b/test/commands/whoami.test.ts
@@ -54,6 +54,6 @@ describe("commands/whoami", () => {
   });
 
   describe("given no service token flag", () => {
-    test.command(["whoami"]).exit(2).it("exists with status 2");
+    test.command(["whoami"]).exit(2).it("exits with status 2");
   });
 });

--- a/test/commands/workflow/activate.test.ts
+++ b/test/commands/workflow/activate.test.ts
@@ -22,7 +22,7 @@ describe("commands/workflow/activate", () => {
       .stdout()
       .command(["workflow activate"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given no environment flag", () => {
@@ -30,7 +30,7 @@ describe("commands/workflow/activate", () => {
       .stdout()
       .command(["workflow activate", "workflow-x"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given the workflow key arg and the environment flag", () => {

--- a/test/commands/workflow/get.test.ts
+++ b/test/commands/workflow/get.test.ts
@@ -17,7 +17,7 @@ describe("commands/workflow/get", () => {
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
       .command(["workflow get"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given a workflow key arg, and no flags", () => {

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -201,7 +201,7 @@ describe("commands/workflow/push", () => {
       .stdout()
       .command(["workflow push"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given both workflow key arg and --all flag", () => {
@@ -209,7 +209,7 @@ describe("commands/workflow/push", () => {
       .stdout()
       .command(["workflow push", "foo", "--all"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given --all and a nonexistent workflows index directory", () => {

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -22,7 +22,7 @@ describe("commands/workflow/run", () => {
       .stdout()
       .command(["workflow run"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given no recipients flag", () => {
@@ -30,7 +30,7 @@ describe("commands/workflow/run", () => {
       .stdout()
       .command(["workflow run", "workflow-x"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 
   describe("given the workflow key arg, the environment flag and the recipient flag", () => {

--- a/test/commands/workflow/validate.test.ts
+++ b/test/commands/workflow/validate.test.ts
@@ -120,7 +120,7 @@ describe("commands/workflow/validate (a single workflow)", () => {
       .stdout()
       .command(["workflow validate"])
       .exit(2)
-      .it("exists with status 2");
+      .it("exits with status 2");
   });
 });
 

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -6,6 +6,7 @@ import { BFlags, Props } from "@/lib/base-command";
 import { PageInfo } from "@/lib/helpers/page";
 import { CommitData } from "@/lib/marshal/commit";
 import { EmailLayoutData } from "@/lib/marshal/email-layout";
+import { MessageTypeData } from "@/lib/marshal/message-type";
 import { PartialData, PartialType } from "@/lib/marshal/partial";
 import { TranslationData } from "@/lib/marshal/translation";
 import {
@@ -177,6 +178,42 @@ export const partial = (attrs: Partial<PartialData> = {}): PartialData => {
     content: "<div>{{heading}}<button>{{cta}}</button></div>",
     created_at: "2022-12-31T12:00:00.000000Z",
     updated_at: "2022-12-31T12:00:00.000000Z",
+    ...attrs,
+  };
+};
+
+export const messageType = (
+  attrs: Partial<MessageTypeData> = {},
+): MessageTypeData => {
+  return {
+    key: "banner",
+    valid: true,
+    owner: "user",
+    description: "My banner",
+    name: "Banner",
+    icon_name: "Flag",
+    semver: null,
+    variants: [
+      {
+        key: "default",
+        name: "Default",
+        fields: [
+          {
+            type: "text",
+            key: "title",
+            label: "Title",
+            settings: {
+              required: true,
+              default: "Banner title",
+            },
+          },
+        ],
+      },
+    ],
+    preview: "<div>{{title}}</div>",
+    created_at: "2022-12-31T12:00:00.000000Z",
+    updated_at: "2022-12-31T12:00:00.000000Z",
+    environment: "development",
     ...attrs,
   };
 };


### PR DESCRIPTION
### Description
This PR adds the get and the list commands for message types. (i.e. `knock message-type list` and `knock message-type get ...`). Depends on https://github.com/knocklabs/control/pull/4300.

Will do the pull command in a separate PR.

### Tasks
https://linear.app/knock/issue/KNO-5966/[cli]-knock-message-type-list-and-get-commands
