### PR TITLE
feat: add message-type push and validate commands

### DIFF
--- a/src/commands/message-type/push.ts
+++ b/src/commands/message-type/push.ts
@@ -1,0 +1,132 @@
+import { Args, Flags } from "@oclif/core";
+
+import BaseCommand from "@/lib/base-command";
+import { KnockEnv } from "@/lib/helpers/const";
+import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
+import { merge } from "@/lib/helpers/object.isomorphic";
+import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
+import { indentString } from "@/lib/helpers/string";
+import { spinner } from "@/lib/helpers/ux";
+import * as MessageType from "@/lib/marshal/message-type";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+import MessageTypeValidate from "./validate";
+
+export default class MessageTypePush extends BaseCommand<
+  typeof MessageTypePush
+> {
+  static summary =
+    "Push one or more message types from a local file system to Knock.";
+
+  static flags = {
+    environment: Flags.string({
+      summary:
+        "Pushing a message type is only allowed in the development environment",
+      default: KnockEnv.Development,
+      options: [KnockEnv.Development],
+    }),
+    all: Flags.boolean({
+      summary: "Whether to push all message types from the target directory.",
+    }),
+    "message-types-dir": CustomFlags.dirPath({
+      summary: "The target directory path to find all message types to push.",
+      dependsOn: ["all"],
+    }),
+    commit: Flags.boolean({
+      summary: "Push and commit the message type(s) at the same time",
+    }),
+    "commit-message": Flags.string({
+      summary: "Use the given value as the commit message",
+      char: "m",
+      dependsOn: ["commit"],
+    }),
+  };
+
+  static args = {
+    messageTypeKey: Args.string({
+      required: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = this.props;
+
+    // 1. First read all message type directories found for the given command.
+    const target = await MessageType.ensureValidCommandTarget(
+      this.props,
+      this.runContext,
+    );
+    const [messageTypes, readErrors] =
+      await MessageType.readAllForCommandTarget(target, {
+        withExtractedFiles: true,
+      });
+
+    if (readErrors.length > 0) {
+      this.error(formatErrors(readErrors, { prependBy: "\n\n" }));
+    }
+
+    if (messageTypes.length === 0) {
+      this.error(
+        `No message type directories found in ${target.context.abspath}`,
+      );
+    }
+
+    // 2. Then validate them all ahead of pushing them.
+    spinner.start(`‣ Validating`);
+
+    const apiErrors = await MessageTypeValidate.validateAll(
+      this.apiV1,
+      this.props,
+      messageTypes,
+    );
+
+    if (apiErrors.length > 0) {
+      this.error(formatErrors(apiErrors, { prependBy: "\n\n" }));
+    }
+
+    spinner.stop();
+
+    // 3. Finally push up each message type, abort on the first error.
+    spinner.start(`‣ Pushing`);
+
+    for (const messageType of messageTypes) {
+      const props = merge(this.props, { flags: { annotate: true } });
+
+      // eslint-disable-next-line no-await-in-loop
+      const resp = await this.apiV1.upsertMessageType<WithAnnotation>(props, {
+        ...messageType.content,
+        key: messageType.key,
+      });
+
+      if (isSuccessResp(resp)) {
+        // Update the message type directory with the successfully pushed message
+        // type payload from the server.
+        // eslint-disable-next-line no-await-in-loop
+        await MessageType.writeMessageTypeDirFromData(
+          messageType,
+          resp.data.message_type!,
+        );
+        continue;
+      }
+
+      const error = new SourceError(
+        formatErrorRespMessage(resp),
+        MessageType.messageTypeJsonPath(messageType),
+        "ApiError",
+      );
+      this.error(formatError(error));
+    }
+
+    spinner.stop();
+
+    // 4. Display a success message.
+    const messageTypeKeys = messageTypes.map((w) => w.key);
+    const actioned = flags.commit ? "pushed and committed" : "pushed";
+
+    this.log(
+      `‣ Successfully ${actioned} ${messageTypes.length} message type(s):\n` +
+        indentString(messageTypeKeys.join("\n"), 4),
+    );
+  }
+}

--- a/src/commands/message-type/validate.ts
+++ b/src/commands/message-type/validate.ts
@@ -1,0 +1,120 @@
+import { Args, Flags } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand, { Props } from "@/lib/base-command";
+import { KnockEnv } from "@/lib/helpers/const";
+import { formatErrors, SourceError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
+import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
+import { indentString } from "@/lib/helpers/string";
+import { spinner } from "@/lib/helpers/ux";
+import * as MessageType from "@/lib/marshal/message-type";
+
+import MessageTypePush from "./push";
+
+export default class MessageTypeValidate extends BaseCommand<
+  typeof MessageTypeValidate
+> {
+  static summary =
+    "Validate one or more message types from a local file system.";
+
+  static flags = {
+    environment: Flags.string({
+      summary:
+        "Validating a message type is only done in the development environment",
+      default: KnockEnv.Development,
+      options: [KnockEnv.Development],
+    }),
+    all: Flags.boolean({
+      summary:
+        "Whether to validate all message types from the target directory.",
+    }),
+    "message-types-dir": CustomFlags.dirPath({
+      summary:
+        "The target directory path to find all message types to validate.",
+      dependsOn: ["all"],
+    }),
+  };
+
+  static args = {
+    messageTypeKey: Args.string({
+      required: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    // 1. Read all message type directories found for the given command.
+    const target = await MessageType.ensureValidCommandTarget(
+      this.props,
+      this.runContext,
+    );
+
+    const [messageTypes, readErrors] =
+      await MessageType.readAllForCommandTarget(target, {
+        withExtractedFiles: true,
+      });
+
+    if (readErrors.length > 0) {
+      this.error(formatErrors(readErrors, { prependBy: "\n\n" }));
+    }
+
+    if (messageTypes.length === 0) {
+      this.error(
+        `No message type directories found in ${target.context.abspath}`,
+      );
+    }
+
+    // 2. Validate each message type data.
+    spinner.start(`‣ Validating`);
+
+    const apiErrors = await MessageTypeValidate.validateAll(
+      this.apiV1,
+      this.props,
+      messageTypes,
+    );
+
+    if (apiErrors.length > 0) {
+      this.error(formatErrors(apiErrors, { prependBy: "\n\n" }));
+    }
+
+    spinner.stop();
+
+    // 3. Display a success message.
+    const messageTypeKeys = messageTypes.map((w) => w.key);
+    this.log(
+      `‣ Successfully validated ${messageTypes.length} message type(s):\n` +
+        indentString(messageTypeKeys.join("\n"), 4),
+    );
+  }
+
+  static async validateAll(
+    api: ApiV1.T,
+    props: Props<typeof MessageTypeValidate | typeof MessageTypePush>,
+    messageTypes: MessageType.MessageTypeDirData[],
+  ): Promise<SourceError[]> {
+    // TODO: Throw an error if a non validation error (e.g. authentication error)
+    // instead of printing out same error messages repeatedly.
+
+    const errorPromises = messageTypes.map(async (messageType) => {
+      const resp = await api.validateMessageType(props, {
+        ...messageType.content,
+        key: messageType.key,
+      });
+
+      if (isSuccessResp(resp)) return;
+
+      const error = new SourceError(
+        formatErrorRespMessage(resp),
+        MessageType.messageTypeJsonPath(messageType),
+        "ApiError",
+      );
+      return error;
+    });
+
+    const errors = (await Promise.all(errorPromises)).filter(
+      (e): e is Exclude<typeof e, undefined> => Boolean(e),
+    );
+
+    return errors;
+  }
+}

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -379,6 +379,35 @@ export default class ApiV1 {
     return this.get(`/message_types/${args.messageTypeKey}`, { params });
   }
 
+  async upsertMessageType<A extends MaybeWithAnnotation>(
+    { flags }: Props,
+    messageType: MessageType.MessageTypeInput,
+  ): Promise<AxiosResponse<UpsertMessageTypeResp<A>>> {
+    const params = prune({
+      environment: flags.environment,
+      annotate: flags.annotate,
+      commit: flags.commit,
+      commit_message: flags["commit-message"],
+    });
+    const data = { messageType };
+
+    return this.put(`/message_types/${messageType.key}`, data, { params });
+  }
+
+  async validateMessageType(
+    { flags }: Props,
+    messageType: MessageType.MessageTypeInput,
+  ): Promise<AxiosResponse<ValidateMessageTypeResp>> {
+    const params = prune({
+      environment: flags.environment,
+    });
+    const data = { messageType };
+
+    return this.put(`/message_types/${messageType.key}/validate`, data, {
+      params,
+    });
+  }
+
   // By methods:
 
   async get(
@@ -504,3 +533,13 @@ export type ListMessageTypeResp<A extends MaybeWithAnnotation = unknown> =
 
 export type GetMessageTypeResp<A extends MaybeWithAnnotation = unknown> =
   MessageType.MessageTypeData<A>;
+
+export type UpsertMessageTypeResp<A extends MaybeWithAnnotation = unknown> = {
+  message_type?: MessageType.MessageTypeData<A>;
+  errors?: InputError[];
+};
+
+export type ValidateMessageTypeResp = {
+  message_type?: MessageType.MessageTypeData;
+  errors?: InputError[];
+};

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -389,7 +389,7 @@ export default class ApiV1 {
       commit: flags.commit,
       commit_message: flags["commit-message"],
     });
-    const data = { messageType };
+    const data = { message_type: messageType };
 
     return this.put(`/message_types/${messageType.key}`, data, { params });
   }
@@ -401,7 +401,7 @@ export default class ApiV1 {
     const params = prune({
       environment: flags.environment,
     });
-    const data = { messageType };
+    const data = { message_type: messageType };
 
     return this.put(`/message_types/${messageType.key}/validate`, data, {
       params,

--- a/src/lib/marshal/message-type/types.ts
+++ b/src/lib/marshal/message-type/types.ts
@@ -1,3 +1,5 @@
+import { AnyObj } from "@/lib/helpers/object.isomorphic";
+
 import { MaybeWithAnnotation } from "../shared/types";
 
 type VariantSchemaBooleanField = {
@@ -55,4 +57,8 @@ export type MessageTypeData<A extends MaybeWithAnnotation = unknown> = A & {
   updated_at: string;
   created_at: string;
   environment: string;
+};
+
+export type MessageTypeInput = AnyObj & {
+  key: string;
 };

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -9,7 +9,7 @@ import { factory } from "@/../test/support";
 import MessageTypeValidate from "@/commands/message-type/validate";
 import KnockApiV1 from "@/lib/api-v1";
 import { sandboxDir } from "@/lib/helpers/const";
-import { MessageTypeData, MESSAGE_TYPE_JSON } from "@/lib/marshal/message-type";
+import { MESSAGE_TYPE_JSON, MessageTypeData } from "@/lib/marshal/message-type";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const messageTypeJsonFile = "banner/message_type.json";

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -1,0 +1,397 @@
+import * as path from "node:path";
+
+import { expect, test } from "@oclif/test";
+import * as fs from "fs-extra";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import MessageTypeValidate from "@/commands/message-type/validate";
+import KnockApiV1 from "@/lib/api-v1";
+import { sandboxDir } from "@/lib/helpers/const";
+import { MessageTypeData, MESSAGE_TYPE_JSON } from "@/lib/marshal/message-type";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+
+const messageTypeJsonFile = "banner/message_type.json";
+
+const mockMessageTypeData: MessageTypeData<WithAnnotation> = {
+  key: "banner",
+  valid: true,
+  owner: "user",
+  name: "Banner",
+  variants: [
+    {
+      key: "default",
+      name: "Default",
+      fields: [
+        {
+          type: "text",
+          key: "title",
+          label: "Title",
+          settings: {
+            required: true,
+            default: "",
+          },
+        },
+      ],
+    },
+  ],
+  preview: "<div>{{ title }}</div>",
+  semver: "0.0.1",
+  description: "My little banner",
+  environment: "development",
+  updated_at: "2023-10-02T19:24:48.714630Z",
+  created_at: "2023-09-18T18:32:18.398053Z",
+  __annotation: {
+    extractable_fields: {
+      preview: { default: true, file_ext: "html" },
+    },
+    readonly_fields: [
+      "key",
+      "valid",
+      "owner",
+      "environment",
+      "semver",
+      "created_at",
+      "updated_at",
+    ],
+  },
+};
+
+const setupWithStub = (attrs = {}) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(MessageTypeValidate, "validateAll", (stub) => stub.resolves([]))
+    .stub(KnockApiV1.prototype, "upsertMessageType", (stub) =>
+      stub.resolves(factory.resp(attrs)),
+    );
+
+const currCwd = process.cwd();
+
+describe("commands/message-type/push", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  describe("given a message type directory exists, for the message type key", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputJsonSync(abspath, {
+        name: "Banner",
+        description: "My little banner",
+        variants: [
+          {
+            key: "default",
+            name: "Default",
+            fields: [
+              {
+                type: "text",
+                key: "title",
+                label: "Title",
+              },
+            ],
+          },
+        ],
+        preview: "<div>{{ title }}</div>",
+      });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "banner"])
+      .it("calls apiV1 upsertMessageType with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.upsertMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, { messageTypeKey: "banner" }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                annotate: true,
+              }),
+          ),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "banner",
+              name: "Banner",
+              description: "My little banner",
+              variants: [
+                {
+                  key: "default",
+                  name: "Default",
+                  fields: [
+                    {
+                      type: "text",
+                      key: "title",
+                      label: "Title",
+                    },
+                  ],
+                },
+              ],
+              preview: "<div>{{ title }}</div>",
+            }),
+          ),
+        );
+      });
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command([
+        "message-type push",
+        "banner",
+        "--commit",
+        "-m",
+        "this is a commit comment!",
+      ])
+      .it(
+        "calls apiV1 upsertMessageType with commit flags, if provided",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.upsertMessageType as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { messageTypeKey: "banner" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  commit: true,
+                  "commit-message": "this is a commit comment!",
+                  annotate: true,
+                }),
+            ),
+            sinon.match((messageType) =>
+              isEqual(messageType, {
+                key: "banner",
+                name: "Banner",
+                description: "My little banner",
+                variants: [
+                  {
+                    key: "default",
+                    name: "Default",
+                    fields: [
+                      {
+                        type: "text",
+                        key: "title",
+                        label: "Title",
+                      },
+                    ],
+                  },
+                ],
+                preview: "<div>{{ title }}</div>",
+              }),
+            ),
+          );
+        },
+      );
+  });
+
+  describe("given a message_type.json file with syntax errors", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputFileSync(abspath, '{"name":"Welcome",}');
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "banner"])
+      .catch((error) => expect(error.message).to.match(/JsonSyntaxError/))
+      .it("throws an error");
+  });
+
+  describe("given a message_type.json file, with data errors", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputJsonSync(abspath, { name: 1242 });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({
+      status: 422,
+      data: { errors: [{ field: "name", message: "must be a string" }] },
+    })
+      .stdout()
+      .command(["message-type push", "banner"])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /JsonDataError.*"name" must be a string/,
+        ),
+      )
+      .it("throws an error");
+  });
+
+  describe("given a nonexistent message type directory", () => {
+    beforeEach(() => {
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "does-not-exist"])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /^Cannot locate a message type directory/,
+        ),
+      )
+      .it("throws an error");
+  });
+
+  describe("given no message type key arg or --all flag", () => {
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push"])
+      .exit(2)
+      .it("exits with status 2");
+  });
+
+  describe("given both message type key arg and --all flag", () => {
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "banner", "--all"])
+      .exit(2)
+      .it("exits with status 2");
+  });
+
+  describe("given --all and multiple message types", () => {
+    const indexDirPath = path.resolve(sandboxDir, "message-types");
+
+    beforeEach(() => {
+      const bannerMessageTypeJson = path.resolve(
+        indexDirPath,
+        "banner",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(bannerMessageTypeJson, {
+        name: "Banner",
+        variants: [
+          {
+            key: "default",
+            name: "Default",
+            fields: [
+              {
+                type: "text",
+                key: "title",
+                label: "Title",
+              },
+            ],
+          },
+        ],
+        preview: "<div>{{ title }}</div>",
+      });
+
+      const modalMessageTypeJson = path.resolve(
+        indexDirPath,
+        "modal",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(modalMessageTypeJson, {
+        name: "Modal",
+        variants: [
+          {
+            key: "default",
+            name: "Default",
+            fields: [
+              {
+                type: "text",
+                key: "title",
+                label: "Title",
+              },
+            ],
+          },
+        ],
+        preview: "<div>{{ title }}</div>",
+      });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command([
+        "message-type push",
+        "--all",
+        "--message-types-dir",
+        "message-types",
+      ])
+      .it("calls apiV1 upsertMessageType with expected props twice", () => {
+        // Validate all first
+        const stub1 = MessageTypeValidate.validateAll as any;
+        sinon.assert.calledOnce(stub1);
+
+        const stub2 = KnockApiV1.prototype.upsertMessageType as any;
+        sinon.assert.calledTwice(stub2);
+
+        const expectedFlags = {
+          annotate: true,
+          "service-token": "valid-token",
+          environment: "development",
+          all: true,
+          "message-types-dir": {
+            abspath: indexDirPath,
+            exists: true,
+          },
+        };
+
+        sinon.assert.calledWith(
+          stub2.firstCall,
+          sinon.match(({ flags }) => isEqual(flags, expectedFlags)),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "banner",
+              name: "Banner",
+              variants: [
+                {
+                  key: "default",
+                  name: "Default",
+                  fields: [
+                    {
+                      type: "text",
+                      key: "title",
+                      label: "Title",
+                    },
+                  ],
+                },
+              ],
+              preview: "<div>{{ title }}</div>",
+            }),
+          ),
+        );
+
+        sinon.assert.calledWith(
+          stub2.secondCall,
+          sinon.match(({ flags }) => isEqual(flags, expectedFlags)),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "modal",
+              name: "Modal",
+              variants: [
+                {
+                  key: "default",
+                  name: "Default",
+                  fields: [
+                    {
+                      type: "text",
+                      key: "title",
+                      label: "Title",
+                    },
+                  ],
+                },
+              ],
+              preview: "<div>{{ title }}</div>",
+            }),
+          ),
+        );
+      });
+  });
+});

--- a/test/commands/message-type/validate.test.ts
+++ b/test/commands/message-type/validate.test.ts
@@ -1,0 +1,299 @@
+import * as path from "node:path";
+import { expect, test } from "@oclif/test";
+import * as fs from "fs-extra";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+import { sandboxDir } from "@/lib/helpers/const";
+import { MESSAGE_TYPE_JSON } from "@/lib/marshal/message-type";
+
+const messageTypeJsonFile = "card/message_type.json";
+
+const setupWithStub = (attrs = {}) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(KnockApiV1.prototype, "validateMessageType", (stub) =>
+      stub.resolves(factory.resp(attrs)),
+    );
+
+const currCwd = process.cwd();
+
+describe("commands/message-type/validate (a single message type)", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  describe("given a message type directory exists, for the message type key", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputJsonSync(abspath, { name: "Card" });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command(["message-type validate", "card"])
+      .it("calls apiV1 validateMessageType with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.validateMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, { messageTypeKey: "card" }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "card",
+              name: "Card",
+            }),
+          ),
+        );
+      });
+  });
+
+  describe("given a message_type.json file with syntax errors", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputFileSync(abspath, '{"name":"Card",}');
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command(["message-type validate", "card"])
+      .catch((error) => expect(error.message).to.match(/JsonSyntaxError/))
+      .it("throws an error");
+  });
+
+  describe("given a message_type.json file with data errors", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+      fs.outputJsonSync(abspath, { name: 123 });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({
+      status: 422,
+      data: { errors: [{ field: "name", message: "must be a string" }] },
+    })
+      .stdout()
+      .command(["message-type validate", "card"])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /JsonDataError.*"name" must be a string/,
+        ),
+      )
+      .it("throws an error");
+  });
+
+  describe("given a nonexistent message type directory", () => {
+    beforeEach(() => {
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command(["message-type validate", "does-not-exist"])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /^Cannot locate a message type directory/,
+        ),
+      )
+      .it("throws an error");
+  });
+
+  describe("given no message type key arg nor --all flag", () => {
+    setupWithStub()
+      .stdout()
+      .command(["message-type validate"])
+      .exit(2)
+      .it("exits with status 2");
+  });
+});
+
+describe("commands/message-type/validate (all message types)", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  describe("given a nonexistent message types index directory", () => {
+    beforeEach(() => {
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command([
+        "message-type validate",
+        "--all",
+        "--message-types-dir",
+        "message_types",
+      ])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /Cannot locate message type directories in/,
+        ),
+      )
+      .it("throws an error");
+  });
+
+  describe("given a message types index directory with 2 valid message types", () => {
+    const indexDirPath = path.resolve(sandboxDir, "message_types");
+
+    beforeEach(() => {
+      const cardMessageTypeJson = path.resolve(
+        indexDirPath,
+        "card",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(cardMessageTypeJson, {
+        name: "Card",
+        description: "Card component",
+      });
+
+      const modalMessageTypeJson = path.resolve(
+        indexDirPath,
+        "modal",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(modalMessageTypeJson, {
+        name: "Modal",
+        description: "Modal component",
+      });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command([
+        "message-type validate",
+        "--all",
+        "--message-types-dir",
+        "message_types",
+      ])
+      .it("calls apiV1 validateMessageType with expected props twice", () => {
+        const stub = KnockApiV1.prototype.validateMessageType as any;
+        sinon.assert.calledTwice(stub);
+
+        const expectedArgs = {};
+        const expectedFlags = {
+          "service-token": "valid-token",
+          environment: "development",
+          all: true,
+          "message-types-dir": {
+            abspath: indexDirPath,
+            exists: true,
+          },
+        };
+
+        sinon.assert.calledWith(
+          stub.firstCall,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, expectedArgs) && isEqual(flags, expectedFlags),
+          ),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "card",
+              name: "Card",
+              description: "Card component",
+            }),
+          ),
+        );
+
+        sinon.assert.calledWith(
+          stub.secondCall,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, expectedArgs) && isEqual(flags, expectedFlags),
+          ),
+          sinon.match((messageType) =>
+            isEqual(messageType, {
+              key: "modal",
+              name: "Modal",
+              description: "Modal component",
+            }),
+          ),
+        );
+      });
+  });
+
+  describe("given a message types directory with 1 valid and 1 invalid message type", () => {
+    const indexDirPath = path.resolve(sandboxDir, "message_types");
+
+    beforeEach(() => {
+      const bannerMessageTypeJson = path.resolve(
+        indexDirPath,
+        "banner",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(bannerMessageTypeJson, {
+        name: "Banner",
+        description: "Banner component",
+      });
+
+      const invalidMessageTypeJson = path.resolve(
+        indexDirPath,
+        "invalid",
+        MESSAGE_TYPE_JSON,
+      );
+      fs.outputJsonSync(invalidMessageTypeJson, { name: 123 });
+
+      process.chdir(sandboxDir);
+    });
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "validateMessageType", (stub) =>
+        stub
+          .onFirstCall()
+          .resolves(factory.resp())
+          .onSecondCall()
+          .resolves(
+            factory.resp({
+              status: 422,
+              data: {
+                errors: [{ field: "name", message: "must be a string" }],
+              },
+            }),
+          ),
+      )
+      .stdout()
+      .command([
+        "message-type validate",
+        "--all",
+        "--message-types-dir",
+        "message_types",
+      ])
+      .catch((error) =>
+        expect(error.message).to.match(
+          /JsonDataError: data at "name" must be a string/,
+        ),
+      )
+      .it("calls apiV1 validateMessageType twice, then errors", () => {
+        const stub = KnockApiV1.prototype.validateMessageType as any;
+        sinon.assert.calledTwice(stub);
+      });
+  });
+});

--- a/test/commands/message-type/validate.test.ts
+++ b/test/commands/message-type/validate.test.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+
 import { expect, test } from "@oclif/test";
 import * as fs from "fs-extra";
 import { isEqual } from "lodash";


### PR DESCRIPTION
### Description

Adds the knock message-type `validate` and `push` commands. The implementation is mostly the same as other resource command modules.

### Tasks
[KNO-7502](https://linear.app/knock/issue/KNO-7502/[cli]-knock-validatepush-message-type-commands)

