### PR TITLE
feat(KNO-8790): add command to pull all resources

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -11,6 +11,9 @@ export default class Pull extends BaseCommand<typeof Pull> {
       default: "development",
       summary: "The environment to use.",
     }),
+    "hide-uncommitted-changes": Flags.boolean({
+      summary: "Hide any uncommitted changes.",
+    }),
   };
 
   public async run(): Promise<void> {

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,8 +1,17 @@
+import { Flags } from "@oclif/core";
+
 import BaseCommand from "@/lib/base-command";
 
 export default class Pull extends BaseCommand<typeof Pull> {
   static summary =
     "Pull all resources from an environment into a local file system.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+  };
 
   public async run(): Promise<void> {
     // TODO

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -22,6 +22,7 @@ export default class Pull extends BaseCommand<typeof Pull> {
     }),
     "knock-dir": CustomFlags.dirPath({
       summary: "The target directory path to pull all resources into.",
+      required: true,
     }),
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
@@ -33,9 +34,7 @@ export default class Pull extends BaseCommand<typeof Pull> {
 
   public async run(): Promise<void> {
     const { flags } = this.props;
-
-    const defaultToCwd = { abspath: this.runContext.cwd, exists: true };
-    const targetDirCtx = flags["knock-dir"] || defaultToCwd;
+    const targetDirCtx = flags["knock-dir"];
 
     const prompt = targetDirCtx.exists
       ? `Pull latest resources into ${targetDirCtx.abspath}?\n  This will overwrite the contents of this directory.`

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,0 +1,11 @@
+import BaseCommand from "@/lib/base-command";
+
+export default class Pull extends BaseCommand<typeof Pull> {
+  static summary =
+    "Pull all resources from an environment into a local file system.";
+
+  public async run(): Promise<void> {
+    // TODO
+    this.log("TODO");
+  }
+}

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -14,6 +14,9 @@ export default class Pull extends BaseCommand<typeof Pull> {
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
+    force: Flags.boolean({
+      summary: "Remove the confirmation prompt.",
+    }),
   };
 
   public async run(): Promise<void> {

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -51,6 +51,9 @@ export default class Pull extends BaseCommand<typeof Pull> {
       ...(flags["hide-uncommitted-changes"]
         ? ["--hide-uncommitted-changes"]
         : []),
+      ...(flags["service-token"]
+        ? ["--service-token", flags["service-token"]]
+        : []),
       // Always use the force flag to skip prompts
       "--force",
     ];

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -20,7 +20,7 @@ export default class Pull extends BaseCommand<typeof Pull> {
       default: "development",
       summary: "The environment to use.",
     }),
-    dir: CustomFlags.dirPath({
+    "knock-dir": CustomFlags.dirPath({
       summary: "The target directory path to pull all resources into.",
     }),
     "hide-uncommitted-changes": Flags.boolean({
@@ -35,7 +35,7 @@ export default class Pull extends BaseCommand<typeof Pull> {
     const { flags } = this.props;
 
     const defaultToCwd = { abspath: this.runContext.cwd, exists: true };
-    const targetDirCtx = flags.dir || defaultToCwd;
+    const targetDirCtx = flags["knock-dir"] || defaultToCwd;
 
     const prompt = targetDirCtx.exists
       ? `Pull latest resources into ${targetDirCtx.abspath}?\n  This will overwrite the contents of this directory.`

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -48,6 +48,9 @@ export default class Pull extends BaseCommand<typeof Pull> {
       "--all",
       "--environment",
       flags.environment,
+      ...(flags["hide-uncommitted-changes"]
+        ? ["--hide-uncommitted-changes"]
+        : []),
       // Always use the force flag to skip prompts
       "--force",
     ];

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -91,7 +91,7 @@ describe("commands/pull", () => {
       [{ key: "workflow-a" }, { key: "workflow-bar" }],
     )
       .stdout()
-      .command(["pull", "--dir", "."])
+      .command(["pull", "--knock-dir", "."])
       .it(
         "calls apiV1 to list resources in the development environment",
         () => {
@@ -109,7 +109,7 @@ describe("commands/pull", () => {
       [{ key: "workflow-a" }, { key: "workflow-bar" }],
     )
       .stdout()
-      .command(["pull", "--dir", ".", "--environment", "staging"])
+      .command(["pull", "--knock-dir", ".", "--environment", "staging"])
       .it("calls apiV1 to list resources in the given environment", () => {
         assertApiV1ListFunctionsCalled({ environment: "staging" });
         sinon.assert.calledOnce(enquirer.prototype.prompt as any);
@@ -124,7 +124,7 @@ describe("commands/pull", () => {
       [{ key: "workflow-a" }, { key: "workflow-bar" }],
     )
       .stdout()
-      .command(["pull", "--dir", ".", "--hide-uncommitted-changes"])
+      .command(["pull", "--knock-dir", ".", "--hide-uncommitted-changes"])
       .it(
         "calls apiV1 to list resources with uncommitted changes hidden",
         () => {
@@ -143,7 +143,7 @@ describe("commands/pull", () => {
     )
       .env({ KNOCK_SERVICE_TOKEN: null })
       .stdout()
-      .command(["pull", "--dir", ".", "--service-token=token123"])
+      .command(["pull", "--knock-dir", ".", "--service-token=token123"])
       .it("calls apiV1 to list resources using the given service token", () => {
         assertApiV1ListFunctionsCalled({ "service-token": "token123" });
         sinon.assert.calledOnce(enquirer.prototype.prompt as any);
@@ -158,7 +158,7 @@ describe("commands/pull", () => {
       [{ key: "workflow-a" }, { key: "workflow-bar" }],
     )
       .stdout()
-      .command(["pull", "--dir", ".", "--force"])
+      .command(["pull", "--knock-dir", ".", "--force"])
       .it("skips the confirmation prompt", () => {
         assertApiV1ListFunctionsCalled({ environment: "development" });
         sinon.assert.notCalled(enquirer.prototype.prompt as any);
@@ -172,7 +172,7 @@ describe("commands/pull", () => {
     [{ key: "workflow1" }, { key: "workflow2" }],
   )
     .stdout()
-    .command(["pull", "--dir", "resources"])
+    .command(["pull", "--knock-dir", "resources"])
     .it(
       "writes directories to the file system, with individual dirs inside",
       () => {

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -83,95 +83,33 @@ describe("commands/pull", () => {
     fs.removeSync(sandboxDir);
   });
 
-  setupWithListStubs(
-    [{ key: "messages" }, { key: "transactional" }],
-    [{ key: "partial-a" }, { key: "partial-b" }],
-    [{ locale_code: "en" }, { locale_code: "es-MX" }],
-    [{ key: "workflow-a" }, { key: "workflow-bar" }],
-  )
-    .stdout()
-    .command(["pull", "--dir", "."])
-    .it("calls apiV1 to list resources with an annotate param", () => {
-      sinon.assert.calledWith(
-        KnockApiV1.prototype.listEmailLayouts as any,
-        sinon.match(
-          ({ args, flags }) =>
-            isEqual(args, {}) &&
-            isEqual(flags, {
-              all: true,
-              "layouts-dir": {
-                abspath: path.resolve(sandboxDir, "layouts"),
-                exists: false,
-              },
-              "service-token": "valid-token",
-              environment: "development",
-              force: true,
-              annotate: true,
-              limit: 100,
-            }),
-        ),
+  describe("without environment flag", () => {
+    setupWithListStubs(
+      [{ key: "messages" }, { key: "transactional" }],
+      [{ key: "partial-a" }, { key: "partial-b" }],
+      [{ locale_code: "en" }, { locale_code: "es-MX" }],
+      [{ key: "workflow-a" }, { key: "workflow-bar" }],
+    )
+      .stdout()
+      .command(["pull", "--dir", "."])
+      .it("calls apiV1 to list resources in the development environment", () =>
+        assertApiV1ListFunctionsCalled({ environment: "development" }),
       );
+  });
 
-      sinon.assert.calledWith(
-        KnockApiV1.prototype.listPartials as any,
-        sinon.match(
-          ({ args, flags }) =>
-            isEqual(args, {}) &&
-            isEqual(flags, {
-              all: true,
-              "partials-dir": {
-                abspath: path.resolve(sandboxDir, "partials"),
-                exists: false,
-              },
-              "service-token": "valid-token",
-              environment: "development",
-              force: true,
-              annotate: true,
-              limit: 100,
-            }),
-        ),
+  describe("with environment flag", () => {
+    setupWithListStubs(
+      [{ key: "messages" }, { key: "transactional" }],
+      [{ key: "partial-a" }, { key: "partial-b" }],
+      [{ locale_code: "en" }, { locale_code: "es-MX" }],
+      [{ key: "workflow-a" }, { key: "workflow-bar" }],
+    )
+      .stdout()
+      .command(["pull", "--dir", ".", "--environment", "staging"])
+      .it("calls apiV1 to list resources in the given environment", () =>
+        assertApiV1ListFunctionsCalled({ environment: "staging" }),
       );
-
-      sinon.assert.calledWith(
-        KnockApiV1.prototype.listTranslations as any,
-        sinon.match(
-          ({ args, flags }) =>
-            isEqual(args, {}) &&
-            isEqual(flags, {
-              all: true,
-              "translations-dir": {
-                abspath: path.resolve(sandboxDir, "translations"),
-                exists: false,
-              },
-              "service-token": "valid-token",
-              environment: "development",
-              force: true,
-              limit: 100,
-              format: "json",
-            }),
-        ),
-      );
-
-      sinon.assert.calledWith(
-        KnockApiV1.prototype.listWorkflows as any,
-        sinon.match(
-          ({ args, flags }) =>
-            isEqual(args, {}) &&
-            isEqual(flags, {
-              all: true,
-              "workflows-dir": {
-                abspath: path.resolve(sandboxDir, "workflows"),
-                exists: false,
-              },
-              "service-token": "valid-token",
-              environment: "development",
-              force: true,
-              annotate: true,
-              limit: 100,
-            }),
-        ),
-      );
-    });
+  });
 
   setupWithListStubs(
     [{ key: "layout1" }, { key: "layout2" }],
@@ -273,3 +211,91 @@ describe("commands/pull", () => {
     test.command(["pull"]).exit(2).it("exits with status 2");
   });
 });
+
+function assertApiV1ListFunctionsCalled(
+  expectedFlags: Record<string, unknown> = {},
+) {
+  sinon.assert.calledWith(
+    KnockApiV1.prototype.listEmailLayouts as any,
+    sinon.match(
+      ({ args, flags }) =>
+        isEqual(args, {}) &&
+        isEqual(flags, {
+          all: true,
+          "layouts-dir": {
+            abspath: path.resolve(sandboxDir, "layouts"),
+            exists: false,
+          },
+          "service-token": "valid-token",
+          environment: "development",
+          force: true,
+          annotate: true,
+          limit: 100,
+          ...expectedFlags,
+        }),
+    ),
+  );
+
+  sinon.assert.calledWith(
+    KnockApiV1.prototype.listPartials as any,
+    sinon.match(
+      ({ args, flags }) =>
+        isEqual(args, {}) &&
+        isEqual(flags, {
+          all: true,
+          "partials-dir": {
+            abspath: path.resolve(sandboxDir, "partials"),
+            exists: false,
+          },
+          "service-token": "valid-token",
+          environment: "development",
+          force: true,
+          annotate: true,
+          limit: 100,
+          ...expectedFlags,
+        }),
+    ),
+  );
+
+  sinon.assert.calledWith(
+    KnockApiV1.prototype.listTranslations as any,
+    sinon.match(
+      ({ args, flags }) =>
+        isEqual(args, {}) &&
+        isEqual(flags, {
+          all: true,
+          "translations-dir": {
+            abspath: path.resolve(sandboxDir, "translations"),
+            exists: false,
+          },
+          "service-token": "valid-token",
+          environment: "development",
+          force: true,
+          limit: 100,
+          format: "json",
+          ...expectedFlags,
+        }),
+    ),
+  );
+
+  sinon.assert.calledWith(
+    KnockApiV1.prototype.listWorkflows as any,
+    sinon.match(
+      ({ args, flags }) =>
+        isEqual(args, {}) &&
+        isEqual(flags, {
+          all: true,
+          "workflows-dir": {
+            abspath: path.resolve(sandboxDir, "workflows"),
+            exists: false,
+          },
+          "service-token": "valid-token",
+          environment: "development",
+          force: true,
+          annotate: true,
+          limit: 100,
+          ...expectedFlags,
+        }),
+    ),
+  );
+}

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -111,6 +111,64 @@ describe("commands/pull", () => {
             }),
         ),
       );
+
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.listPartials as any,
+        sinon.match(
+          ({ args, flags }) =>
+            isEqual(args, {}) &&
+            isEqual(flags, {
+              all: true,
+              "partials-dir": {
+                abspath: path.resolve(sandboxDir, "partials"),
+                exists: false,
+              },
+              "service-token": "valid-token",
+              environment: "development",
+              force: true,
+              annotate: true,
+              limit: 100,
+            }),
+        ),
+      );
+
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.listTranslations as any,
+        sinon.match(({ flags }) =>
+          isEqual(flags, {
+            all: true,
+            "translations-dir": {
+              abspath: path.resolve(sandboxDir, "translations"),
+              exists: false,
+            },
+            "service-token": "valid-token",
+            environment: "development",
+            force: true,
+            limit: 100,
+            format: "json",
+          }),
+        ),
+      );
+
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.listWorkflows as any,
+        sinon.match(
+          ({ args, flags }) =>
+            isEqual(args, {}) &&
+            isEqual(flags, {
+              all: true,
+              "workflows-dir": {
+                abspath: path.resolve(sandboxDir, "workflows"),
+                exists: false,
+              },
+              "service-token": "valid-token",
+              environment: "development",
+              force: true,
+              annotate: true,
+              limit: 100,
+            }),
+        ),
+      );
     });
 
   // describe("given a valid service token via flag", () => {

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -180,32 +180,72 @@ describe("commands/pull", () => {
     [{ key: "workflow1" }, { key: "workflow2" }],
   )
     .stdout()
-    .command(["pull", "--dir", "."])
+    .command(["pull", "--dir", "resources"])
     .it(
       "writes directories to the file system, with individual dirs inside",
       () => {
-        const path1 = path.resolve(sandboxDir, "layouts", "layout1");
+        const path1 = path.resolve(
+          sandboxDir,
+          "resources",
+          "layouts",
+          "layout1",
+        );
         expect(fs.pathExistsSync(path1)).to.equal(true);
 
-        const path2 = path.resolve(sandboxDir, "layouts", "layout2");
+        const path2 = path.resolve(
+          sandboxDir,
+          "resources",
+          "layouts",
+          "layout2",
+        );
         expect(fs.pathExistsSync(path2)).to.equal(true);
 
-        const path3 = path.resolve(sandboxDir, "partials", "partial1");
+        const path3 = path.resolve(
+          sandboxDir,
+          "resources",
+          "partials",
+          "partial1",
+        );
         expect(fs.pathExistsSync(path3)).to.equal(true);
 
-        const path4 = path.resolve(sandboxDir, "partials", "partial2");
+        const path4 = path.resolve(
+          sandboxDir,
+          "resources",
+          "partials",
+          "partial2",
+        );
         expect(fs.pathExistsSync(path4)).to.equal(true);
 
-        const path5 = path.resolve(sandboxDir, "translations", "en");
+        const path5 = path.resolve(
+          sandboxDir,
+          "resources",
+          "translations",
+          "en",
+        );
         expect(fs.pathExistsSync(path5)).to.equal(true);
 
-        const path6 = path.resolve(sandboxDir, "translations", "es-MX");
+        const path6 = path.resolve(
+          sandboxDir,
+          "resources",
+          "translations",
+          "es-MX",
+        );
         expect(fs.pathExistsSync(path6)).to.equal(true);
 
-        const path7 = path.resolve(sandboxDir, "workflows", "workflow1");
+        const path7 = path.resolve(
+          sandboxDir,
+          "resources",
+          "workflows",
+          "workflow1",
+        );
         expect(fs.pathExistsSync(path7)).to.equal(true);
 
-        const path8 = path.resolve(sandboxDir, "workflows", "workflow2");
+        const path8 = path.resolve(
+          sandboxDir,
+          "resources",
+          "workflows",
+          "workflow2",
+        );
         expect(fs.pathExistsSync(path8)).to.equal(true);
       },
     );

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 
-import { test } from "@oclif/test";
+import { expect, test } from "@oclif/test";
 import enquirer from "enquirer";
 import * as fs from "fs-extra";
 import { isEqual } from "lodash";
@@ -172,6 +172,43 @@ describe("commands/pull", () => {
         ),
       );
     });
+
+  setupWithListStubs(
+    [{ key: "layout1" }, { key: "layout2" }],
+    [{ key: "partial1" }, { key: "partial2" }],
+    [{ locale_code: "en" }, { locale_code: "es-MX" }],
+    [{ key: "workflow1" }, { key: "workflow2" }],
+  )
+    .stdout()
+    .command(["pull", "--dir", "."])
+    .it(
+      "writes directories to the file system, with individual dirs inside",
+      () => {
+        const path1 = path.resolve(sandboxDir, "layouts", "layout1");
+        expect(fs.pathExistsSync(path1)).to.equal(true);
+
+        const path2 = path.resolve(sandboxDir, "layouts", "layout2");
+        expect(fs.pathExistsSync(path2)).to.equal(true);
+
+        const path3 = path.resolve(sandboxDir, "partials", "partial1");
+        expect(fs.pathExistsSync(path3)).to.equal(true);
+
+        const path4 = path.resolve(sandboxDir, "partials", "partial2");
+        expect(fs.pathExistsSync(path4)).to.equal(true);
+
+        const path5 = path.resolve(sandboxDir, "translations", "en");
+        expect(fs.pathExistsSync(path5)).to.equal(true);
+
+        const path6 = path.resolve(sandboxDir, "translations", "es-MX");
+        expect(fs.pathExistsSync(path6)).to.equal(true);
+
+        const path7 = path.resolve(sandboxDir, "workflows", "workflow1");
+        expect(fs.pathExistsSync(path7)).to.equal(true);
+
+        const path8 = path.resolve(sandboxDir, "workflows", "workflow2");
+        expect(fs.pathExistsSync(path8)).to.equal(true);
+      },
+    );
 
   // describe("given a valid service token via flag", () => {
   //   test

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -134,19 +134,21 @@ describe("commands/pull", () => {
 
       sinon.assert.calledWith(
         KnockApiV1.prototype.listTranslations as any,
-        sinon.match(({ flags }) =>
-          isEqual(flags, {
-            all: true,
-            "translations-dir": {
-              abspath: path.resolve(sandboxDir, "translations"),
-              exists: false,
-            },
-            "service-token": "valid-token",
-            environment: "development",
-            force: true,
-            limit: 100,
-            format: "json",
-          }),
+        sinon.match(
+          ({ args, flags }) =>
+            isEqual(args, {}) &&
+            isEqual(flags, {
+              all: true,
+              "translations-dir": {
+                abspath: path.resolve(sandboxDir, "translations"),
+                exists: false,
+              },
+              "service-token": "valid-token",
+              environment: "development",
+              force: true,
+              limit: 100,
+              format: "json",
+            }),
         ),
       );
 

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -91,7 +91,7 @@ describe("commands/pull", () => {
   )
     .stdout()
     .command(["pull", "--dir", "."])
-    .it("calls apiV1 listEmailLayouts with an annotate param", () => {
+    .it("calls apiV1 to list resources with an annotate param", () => {
       sinon.assert.calledWith(
         KnockApiV1.prototype.listEmailLayouts as any,
         sinon.match(

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@oclif/test";
 
 describe("commands/pull", () => {
-  // describe("given a valid service token via flag", () => {
-  //   test
-  //     .stdout()
-  //     .command(["pull"])
-  //     .it("runs the command", (ctx) => {
-  //       expect(ctx.stdout).to.contain("TODO");
-  //     });
-  // });
+  describe("given a valid service token via flag", () => {
+    test
+      .stdout()
+      .command(["pull", "--service-token", "valid-token"])
+      .it("runs the command", (ctx) => {
+        expect(ctx.stdout).to.contain("TODO");
+      });
+  });
 
   describe("given a valid service token via env var", () => {
     test

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,9 +1,75 @@
 import { test } from "@oclif/test";
+import enquirer from "enquirer";
 import * as fs from "fs-extra";
+import * as path from "node:path";
 
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
 import { sandboxDir } from "@/lib/helpers/const";
+import { EmailLayoutData } from "@/lib/marshal/email-layout";
+import { PartialData } from "@/lib/marshal/partial";
+import { TranslationData } from "@/lib/marshal/translation";
+import { WorkflowData } from "@/lib/marshal/workflow";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
 
 const currCwd = process.cwd();
+
+const setupWithListStubs = (
+  manyLayoutsAttrs: Partial<EmailLayoutData>[],
+  manyPartialsAttrs: Partial<PartialData>[],
+  manyTranslationsAttrs: Partial<TranslationData>[],
+  manyWorkflowAttrs: Partial<WorkflowData>[],
+) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(KnockApiV1.prototype, "listEmailLayouts", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: {
+            entries: manyLayoutsAttrs.map((attrs) =>
+              factory.emailLayout(attrs),
+            ),
+            page_info: factory.pageInfo(),
+          },
+        }),
+      ),
+    )
+    .stub(KnockApiV1.prototype, "listPartials", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: {
+            entries: manyPartialsAttrs.map((attrs) => factory.partial(attrs)),
+            page_info: factory.pageInfo(),
+          },
+        }),
+      ),
+    )
+    .stub(KnockApiV1.prototype, "listTranslations", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: {
+            entries: manyTranslationsAttrs.map((attrs) =>
+              factory.translation(attrs),
+            ),
+            page_info: factory.pageInfo(),
+          },
+        }),
+      ),
+    )
+    .stub(KnockApiV1.prototype, "listWorkflows", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: {
+            entries: manyWorkflowAttrs.map((attrs) => factory.workflow(attrs)),
+            page_info: factory.pageInfo(),
+          },
+        }),
+      ),
+    )
+    .stub(enquirer.prototype, "prompt", (stub) =>
+      stub.onFirstCall().resolves({ input: "y" }),
+    );
 
 describe("commands/pull", () => {
   beforeEach(() => {
@@ -15,6 +81,36 @@ describe("commands/pull", () => {
     process.chdir(currCwd);
     fs.removeSync(sandboxDir);
   });
+
+  setupWithListStubs(
+    [{ key: "messages" }, { key: "transactional" }],
+    [{ key: "partial-a" }, { key: "partial-b" }],
+    [{ locale_code: "en" }, { locale_code: "es-MX" }],
+    [{ key: "workflow-a" }, { key: "workflow-bar" }],
+  )
+    .stdout()
+    .command(["pull", "--dir", "."])
+    .it("calls apiV1 listEmailLayouts with an annotate param", () => {
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.listEmailLayouts as any,
+        sinon.match(
+          ({ args, flags }) =>
+            isEqual(args, {}) &&
+            isEqual(flags, {
+              all: true,
+              "layouts-dir": {
+                abspath: path.resolve(sandboxDir, "layouts"),
+                exists: false,
+              },
+              "service-token": "valid-token",
+              environment: "development",
+              force: true,
+              annotate: true,
+              limit: 100,
+            }),
+        ),
+      );
+    });
 
   // describe("given a valid service token via flag", () => {
   //   test

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -111,6 +111,20 @@ describe("commands/pull", () => {
       );
   });
 
+  describe("with hide-uncommitted-changes flag", () => {
+    setupWithListStubs(
+      [{ key: "messages" }, { key: "transactional" }],
+      [{ key: "partial-a" }, { key: "partial-b" }],
+      [{ locale_code: "en" }, { locale_code: "es-MX" }],
+      [{ key: "workflow-a" }, { key: "workflow-bar" }],
+    )
+      .stdout()
+      .command(["pull", "--dir", ".", "--hide-uncommitted-changes"])
+      .it("calls apiV1 to list resources with uncommitted changes hidden", () =>
+        assertApiV1ListFunctionsCalled({ "hide-uncommitted-changes": true }),
+      );
+  });
+
   setupWithListStubs(
     [{ key: "layout1" }, { key: "layout2" }],
     [{ key: "partial1" }, { key: "partial2" }],

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,7 +1,10 @@
+import * as path from "node:path";
+
 import { test } from "@oclif/test";
 import enquirer from "enquirer";
 import * as fs from "fs-extra";
-import * as path from "node:path";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
 
 import { factory } from "@/../test/support";
 import KnockApiV1 from "@/lib/api-v1";
@@ -10,8 +13,6 @@ import { EmailLayoutData } from "@/lib/marshal/email-layout";
 import { PartialData } from "@/lib/marshal/partial";
 import { TranslationData } from "@/lib/marshal/translation";
 import { WorkflowData } from "@/lib/marshal/workflow";
-import { isEqual } from "lodash";
-import * as sinon from "sinon";
 
 const currCwd = process.cwd();
 

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -134,6 +134,22 @@ describe("commands/pull", () => {
       );
   });
 
+  describe("with service-token flag", () => {
+    setupWithListStubs(
+      [{ key: "messages" }, { key: "transactional" }],
+      [{ key: "partial-a" }, { key: "partial-b" }],
+      [{ locale_code: "en" }, { locale_code: "es-MX" }],
+      [{ key: "workflow-a" }, { key: "workflow-bar" }],
+    )
+      .env({ KNOCK_SERVICE_TOKEN: null })
+      .stdout()
+      .command(["pull", "--dir", ".", "--service-token=token123"])
+      .it("calls apiV1 to list resources using the given service token", () => {
+        assertApiV1ListFunctionsCalled({ "service-token": "token123" });
+        sinon.assert.calledOnce(enquirer.prototype.prompt as any);
+      });
+  });
+
   describe("with force flag", () => {
     setupWithListStubs(
       [{ key: "messages" }, { key: "transactional" }],
@@ -226,26 +242,7 @@ describe("commands/pull", () => {
       },
     );
 
-  // describe("given a valid service token via flag", () => {
-  //   test
-  //     .stdout()
-  //     .command(["pull", "--service-token", "valid-token"])
-  //     .it("runs the command", (ctx) => {
-  //       expect(ctx.stdout).to.contain("TODO");
-  //     });
-  // });
-
-  // describe("given a valid service token via env var", () => {
-  //   test
-  //     .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
-  //     .stdout()
-  //     .command(["pull"])
-  //     .it("runs the command", (ctx) => {
-  //       expect(ctx.stdout).to.contain("TODO");
-  //     });
-  // });
-
-  describe("given no service token flag", () => {
+  describe("without service token", () => {
     test.command(["pull"]).exit(2).it("exits with status 2");
   });
 });

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@oclif/test";
+
+describe("commands/pull", () => {
+  // describe("given a valid service token via flag", () => {
+  //   test
+  //     .stdout()
+  //     .command(["pull"])
+  //     .it("runs the command", (ctx) => {
+  //       expect(ctx.stdout).to.contain("TODO");
+  //     });
+  // });
+
+  describe("given a valid service token via env var", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .command(["pull"])
+      .it("runs the command", (ctx) => {
+        expect(ctx.stdout).to.contain("TODO");
+      });
+  });
+
+  describe("given no service token flag", () => {
+    test.command(["pull"]).exit(2).it("exits with status 2");
+  });
+});

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -1,24 +1,39 @@
-import { expect, test } from "@oclif/test";
+import { test } from "@oclif/test";
+import * as fs from "fs-extra";
+
+import { sandboxDir } from "@/lib/helpers/const";
+
+const currCwd = process.cwd();
 
 describe("commands/pull", () => {
-  describe("given a valid service token via flag", () => {
-    test
-      .stdout()
-      .command(["pull", "--service-token", "valid-token"])
-      .it("runs the command", (ctx) => {
-        expect(ctx.stdout).to.contain("TODO");
-      });
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+    process.chdir(sandboxDir);
+  });
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
   });
 
-  describe("given a valid service token via env var", () => {
-    test
-      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
-      .stdout()
-      .command(["pull"])
-      .it("runs the command", (ctx) => {
-        expect(ctx.stdout).to.contain("TODO");
-      });
-  });
+  // describe("given a valid service token via flag", () => {
+  //   test
+  //     .stdout()
+  //     .command(["pull", "--service-token", "valid-token"])
+  //     .it("runs the command", (ctx) => {
+  //       expect(ctx.stdout).to.contain("TODO");
+  //     });
+  // });
+
+  // describe("given a valid service token via env var", () => {
+  //   test
+  //     .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+  //     .stdout()
+  //     .command(["pull"])
+  //     .it("runs the command", (ctx) => {
+  //       expect(ctx.stdout).to.contain("TODO");
+  //     });
+  // });
 
   describe("given no service token flag", () => {
     test.command(["pull"]).exit(2).it("exits with status 2");

--- a/test/commands/pull.test.ts
+++ b/test/commands/pull.test.ts
@@ -92,8 +92,12 @@ describe("commands/pull", () => {
     )
       .stdout()
       .command(["pull", "--dir", "."])
-      .it("calls apiV1 to list resources in the development environment", () =>
-        assertApiV1ListFunctionsCalled({ environment: "development" }),
+      .it(
+        "calls apiV1 to list resources in the development environment",
+        () => {
+          assertApiV1ListFunctionsCalled({ environment: "development" });
+          sinon.assert.calledOnce(enquirer.prototype.prompt as any);
+        },
       );
   });
 
@@ -106,9 +110,10 @@ describe("commands/pull", () => {
     )
       .stdout()
       .command(["pull", "--dir", ".", "--environment", "staging"])
-      .it("calls apiV1 to list resources in the given environment", () =>
-        assertApiV1ListFunctionsCalled({ environment: "staging" }),
-      );
+      .it("calls apiV1 to list resources in the given environment", () => {
+        assertApiV1ListFunctionsCalled({ environment: "staging" });
+        sinon.assert.calledOnce(enquirer.prototype.prompt as any);
+      });
   });
 
   describe("with hide-uncommitted-changes flag", () => {
@@ -120,9 +125,28 @@ describe("commands/pull", () => {
     )
       .stdout()
       .command(["pull", "--dir", ".", "--hide-uncommitted-changes"])
-      .it("calls apiV1 to list resources with uncommitted changes hidden", () =>
-        assertApiV1ListFunctionsCalled({ "hide-uncommitted-changes": true }),
+      .it(
+        "calls apiV1 to list resources with uncommitted changes hidden",
+        () => {
+          assertApiV1ListFunctionsCalled({ "hide-uncommitted-changes": true });
+          sinon.assert.calledOnce(enquirer.prototype.prompt as any);
+        },
       );
+  });
+
+  describe("with force flag", () => {
+    setupWithListStubs(
+      [{ key: "messages" }, { key: "transactional" }],
+      [{ key: "partial-a" }, { key: "partial-b" }],
+      [{ locale_code: "en" }, { locale_code: "es-MX" }],
+      [{ key: "workflow-a" }, { key: "workflow-bar" }],
+    )
+      .stdout()
+      .command(["pull", "--dir", ".", "--force"])
+      .it("skips the confirmation prompt", () => {
+        assertApiV1ListFunctionsCalled({ environment: "development" });
+        sinon.assert.notCalled(enquirer.prototype.prompt as any);
+      });
   });
 
   setupWithListStubs(


### PR DESCRIPTION
### Description

This PR adds a new command to the Knock CLI: `knock pull`

This command pulls all email layouts, partials, translations, and workflows into a given directory. Resources will be stored in dedicated subdirectories. For example, if the command `knock pull --knock-dir my-directory` is used, workflows will be stored in `/my-directory/workflows`.

This new command works by delegating to the existing resource-specific `pull` commands. [The oclif docs generally discourage this approach](https://oclif.io/docs/running_programmatically), but this feels like the fastest way to add a “pull all” command without significantly refactoring all existing pull commands. The unit tests I added will make sure we don’t break the `knock pull` command in the future if we ever modify one of the resource-specific pull commands.

### Tasks

[KNO-8790](https://linear.app/knock/issue/KNO-8790/cli-add-command-to-pull-all-resources)

### Screenshots

<img width="1329" alt="Screenshot 2025-06-04 at 11 28 29 AM" src="https://github.com/user-attachments/assets/74d9b81b-8e3e-489e-b60e-612aa0334d42" />


