### PR TITLE
chore(KNO-8961): remove withReadonlyField option

### DIFF
--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -35,7 +35,6 @@ export type EmailLayoutDirData = EmailLayoutDirContext & {
 
 type ReadLayoutDirOpts = {
   withExtractedFiles?: boolean;
-  withReadonlyField?: boolean;
 };
 
 /*
@@ -130,7 +129,7 @@ export const readEmailLayoutDir = async (
   opts: ReadLayoutDirOpts = {},
 ): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
   const { abspath } = layoutDirCtx;
-  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+  const { withExtractedFiles = false } = opts;
 
   const dirExists = await fs.pathExists(abspath);
   if (!dirExists) throw new Error(`${abspath} does not exist`);
@@ -143,9 +142,7 @@ export const readEmailLayoutDir = async (
 
   let [layoutJson] = result;
 
-  layoutJson = withReadonlyField
-    ? layoutJson
-    : omitDeep(layoutJson, ["__readonly"]);
+  layoutJson = omitDeep(layoutJson, ["__readonly"]);
 
   return withExtractedFiles
     ? joinExtractedFiles(layoutDirCtx, layoutJson)

--- a/src/lib/marshal/guide/reader.ts
+++ b/src/lib/marshal/guide/reader.ts
@@ -62,7 +62,6 @@ const readGuideDirs = async (
  */
 type ReadGuideDirOpts = {
   withExtractedFiles?: boolean;
-  withReadonlyField?: boolean;
 };
 
 export const readGuideDir = async (
@@ -70,7 +69,7 @@ export const readGuideDir = async (
   opts: ReadGuideDirOpts = {},
 ): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
   const { abspath } = guideDirCtx;
-  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+  const { withExtractedFiles = false } = opts;
 
   const dirExists = await fs.pathExists(abspath);
   if (!dirExists) throw new Error(`${abspath} does not exist`);
@@ -83,9 +82,7 @@ export const readGuideDir = async (
 
   let [guideJson] = result;
 
-  guideJson = withReadonlyField
-    ? guideJson
-    : omitDeep(guideJson, ["__readonly"]);
+  guideJson = omitDeep(guideJson, ["__readonly"]);
 
   return withExtractedFiles
     ? joinExtractedFiles(guideDirCtx, guideJson)

--- a/src/lib/marshal/message-type/reader.ts
+++ b/src/lib/marshal/message-type/reader.ts
@@ -73,7 +73,6 @@ const readMessageTypeDirs = async (
  */
 type ReadMessageTypeDirOpts = {
   withExtractedFiles?: boolean;
-  withReadonlyField?: boolean;
 };
 
 export const readMessageTypeDir = async (
@@ -81,7 +80,7 @@ export const readMessageTypeDir = async (
   opts: ReadMessageTypeDirOpts = {},
 ): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
   const { abspath } = messageTypeDirCtx;
-  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+  const { withExtractedFiles = false } = opts;
 
   const dirExists = await fs.pathExists(abspath);
   if (!dirExists) throw new Error(`${abspath} does not exist`);
@@ -95,9 +94,7 @@ export const readMessageTypeDir = async (
 
   let [messageTypeJson] = result;
 
-  messageTypeJson = withReadonlyField
-    ? messageTypeJson
-    : omitDeep(messageTypeJson, ["__readonly"]);
+  messageTypeJson = omitDeep(messageTypeJson, ["__readonly"]);
 
   return withExtractedFiles
     ? joinExtractedFiles(messageTypeDirCtx, messageTypeJson)

--- a/src/lib/marshal/partial/reader.ts
+++ b/src/lib/marshal/partial/reader.ts
@@ -62,7 +62,6 @@ const readPartialDirs = async (
  */
 type ReadPartialDirOpts = {
   withExtractedFiles?: boolean;
-  withReadonlyField?: boolean;
 };
 
 export const readPartialDir = async (
@@ -70,7 +69,7 @@ export const readPartialDir = async (
   opts: ReadPartialDirOpts = {},
 ): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
   const { abspath } = partialDirCtx;
-  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+  const { withExtractedFiles = false } = opts;
 
   const dirExists = await fs.pathExists(abspath);
   if (!dirExists) throw new Error(`${abspath} does not exist`);
@@ -84,9 +83,7 @@ export const readPartialDir = async (
 
   let [partialJson] = result;
 
-  partialJson = withReadonlyField
-    ? partialJson
-    : omitDeep(partialJson, ["__readonly"]);
+  partialJson = omitDeep(partialJson, ["__readonly"]);
 
   return withExtractedFiles
     ? joinExtractedFiles(partialDirCtx, partialJson)

--- a/src/lib/marshal/workflow/reader.ts
+++ b/src/lib/marshal/workflow/reader.ts
@@ -172,7 +172,6 @@ const joinExtractedFiles = async (
  */
 type ReadWorkflowDirOpts = {
   withExtractedFiles?: boolean;
-  withReadonlyField?: boolean;
 };
 
 export const readWorkflowDir = async (
@@ -180,7 +179,7 @@ export const readWorkflowDir = async (
   opts: ReadWorkflowDirOpts = {},
 ): Promise<ParseJsonResult | JoinExtractedFilesResult> => {
   const { abspath } = workflowDirCtx;
-  const { withExtractedFiles = false, withReadonlyField = false } = opts;
+  const { withExtractedFiles = false } = opts;
 
   const dirExists = await fs.pathExists(abspath);
   if (!dirExists) throw new Error(`${abspath} does not exist`);
@@ -194,9 +193,7 @@ export const readWorkflowDir = async (
 
   let [workflowJson] = result;
 
-  workflowJson = withReadonlyField
-    ? workflowJson
-    : omitDeep(workflowJson, ["__readonly"]);
+  workflowJson = omitDeep(workflowJson, ["__readonly"]);
 
   return withExtractedFiles
     ? joinExtractedFiles(workflowDirCtx, workflowJson)

--- a/test/lib/marshal/email-layout/reader.test.ts
+++ b/test/lib/marshal/email-layout/reader.test.ts
@@ -192,27 +192,7 @@ describe("lib/marshal/layout/reader", () => {
         expect(get(layout, ["text_layout@"])).to.equal(
           "text-layout-examples/text_layout.txt",
         );
-      });
-    });
-
-    describe("with the withReadonlyField opt of true", () => {
-      it("reads layout.json with the readonly field", async () => {
-        const [layout] = await readEmailLayoutDir(emailLayoutDirCtx, {
-          withReadonlyField: true,
-        });
-
-        expect(get(layout, ["name"])).to.equal("Transactional");
-        expect(get(layout, ["html_layout@"])).to.equal("html_layout.html");
-        expect(get(layout, ["text_layout@"])).to.equal(
-          "text-layout-examples/text_layout.txt",
-        );
-
-        expect(get(layout, ["__readonly"])).to.eql({
-          key: "transactional",
-          environment: "development",
-          created_at: "2023-09-18T18:32:18.398053Z",
-          updated_at: "2023-10-02T19:24:48.714630Z",
-        });
+        expect(get(layout, ["__readonly"])).to.equal(undefined);
       });
     });
 

--- a/test/lib/marshal/guide/reader.test.ts
+++ b/test/lib/marshal/guide/reader.test.ts
@@ -148,30 +148,6 @@ describe("lib/marshal/guide/reader", () => {
       });
     });
 
-    describe("with the withReadonlyField opt of true", () => {
-      it("reads guide.json with the readonly field", async () => {
-        const [guide] = await readGuideDir(guideDirCtx, {
-          withReadonlyField: true,
-        });
-
-        expect(get(guide, ["name"])).to.equal("Onboarding Guide");
-        expect(get(guide, ["description"])).to.equal(
-          "A comprehensive onboarding guide for new users.",
-        );
-
-        expect(get(guide, ["__readonly"])).to.eql({
-          key: "onboarding",
-          valid: true,
-          active: true,
-          environment: "development",
-          semver: "1.0.0",
-          created_at: "2024-09-17T23:28:39.939366Z",
-          updated_at: "2024-10-18T06:43:37.942727Z",
-          sha: "OdCrRlz43e2y0ZAHNqyIkp/Vva/xSK1shKF4i8vXx3Y=",
-        });
-      });
-    });
-
     describe("with the withExtractedFiles opt of true", () => {
       it("reads guide.json with the extracted fields inlined", async () => {
         const [guide] = await readGuideDir(guideDirCtx, {

--- a/test/lib/marshal/message-type/reader.test.ts
+++ b/test/lib/marshal/message-type/reader.test.ts
@@ -156,29 +156,7 @@ describe("lib/marshal/message-type/reader", () => {
         expect(get(messageType, ["preview@"])).to.equal("preview.html");
         expect(get(messageType, ["preview"])).to.equal(undefined);
         expect(get(messageType, ["__readonly"])).to.equal(undefined);
-      });
-    });
-
-    describe("with the withReadonlyField opt of true", () => {
-      it("reads message_type.json with the readonly field", async () => {
-        const [messageType] = await readMessageTypeDir(messageTypeDirCtx, {
-          withReadonlyField: true,
-        });
-
-        expect(get(messageType, ["name"])).to.equal("Modal");
-        expect(get(messageType, ["preview@"])).to.equal("preview.html");
-        expect(get(messageType, ["preview"])).to.equal(undefined);
-
-        expect(get(messageType, ["__readonly"])).to.eql({
-          key: "modal",
-          valid: true,
-          owner: "system",
-          environment: "development",
-          semver: "0.0.4",
-          created_at: "2024-09-17T23:28:39.939366Z",
-          updated_at: "2024-10-18T06:43:37.942727Z",
-          sha: "OdCrRlz43e2y0ZAHNqyIkp/Vva/xSK1shKF4i8vXx3Y=",
-        });
+        expect(get(messageType, ["__readonly"])).to.equal(undefined);
       });
     });
 

--- a/test/lib/marshal/message-type/reader.test.ts
+++ b/test/lib/marshal/message-type/reader.test.ts
@@ -156,7 +156,6 @@ describe("lib/marshal/message-type/reader", () => {
         expect(get(messageType, ["preview@"])).to.equal("preview.html");
         expect(get(messageType, ["preview"])).to.equal(undefined);
         expect(get(messageType, ["__readonly"])).to.equal(undefined);
-        expect(get(messageType, ["__readonly"])).to.equal(undefined);
       });
     });
 

--- a/test/lib/marshal/partial/reader.test.ts
+++ b/test/lib/marshal/partial/reader.test.ts
@@ -2,10 +2,14 @@ import * as path from "node:path";
 
 import { expect } from "@oclif/test";
 import * as fs from "fs-extra";
+import { get } from "lodash";
 
 import { sandboxDir } from "@/lib/helpers/const";
 import { DirContext } from "@/lib/helpers/fs";
-import { readAllForCommandTarget } from "@/lib/marshal/partial/reader";
+import {
+  readAllForCommandTarget,
+  readPartialDir,
+} from "@/lib/marshal/partial/reader";
 import { PartialDirContext } from "@/lib/run-context";
 
 const currCwd = process.cwd();
@@ -66,6 +70,83 @@ describe("lib/marshal/partial/reader", () => {
         expect(errors.length).to.equal(0);
         expect(partials.length).to.equal(1);
         expect(partials[0].key).to.equal("cta");
+      });
+    });
+  });
+
+  describe("readPartialDir", () => {
+    const samplePartialJson = {
+      icon_name: "BellIcon",
+      name: "CTA Button",
+      visual_block_enabled: false,
+      "content@": "content.html",
+      __readonly: {
+        environment: "development",
+        key: "cta-button",
+        type: "html",
+        valid: true,
+        created_at: "2024-09-17T23:28:39.939366Z",
+        updated_at: "2024-10-18T06:43:37.942727Z",
+      },
+    };
+
+    const partialDirPath = path.join(sandboxDir, "partials", "cta-button");
+
+    const partialDirCtx: PartialDirContext = {
+      type: "partial",
+      key: "cta-button",
+      abspath: partialDirPath,
+      exists: true,
+    };
+
+    before(() => {
+      fs.removeSync(sandboxDir);
+
+      // Set up a sample partial directory
+      fs.outputJsonSync(
+        path.join(partialDirPath, "partial.json"),
+        samplePartialJson,
+      );
+
+      fs.outputFileSync(
+        path.join(partialDirPath, "content.html"),
+        "<button>{{ content }}</button>",
+      );
+    });
+
+    after(() => {
+      process.chdir(currCwd);
+      fs.removeSync(sandboxDir);
+    });
+
+    describe("by default without any opts", () => {
+      it("reads partial.json without the readonly field and extracted files joined", async () => {
+        const [partial] = await readPartialDir(partialDirCtx);
+
+        expect(get(partial, ["icon_name"])).to.equal("BellIcon");
+        expect(get(partial, ["name"])).to.equal("CTA Button");
+        expect(get(partial, ["visual_block_enabled"])).to.equal(false);
+        expect(get(partial, ["content@"])).to.equal("content.html");
+        expect(get(partial, ["content"])).to.equal(undefined);
+        expect(get(partial, ["__readonly"])).to.equal(undefined);
+      });
+    });
+
+    describe("with the withExtractedFiles opt of true", () => {
+      it("reads partial.json with the extracted fields inlined", async () => {
+        const [partial] = await readPartialDir(partialDirCtx, {
+          withExtractedFiles: true,
+        });
+
+        expect(get(partial, ["icon_name"])).to.equal("BellIcon");
+        expect(get(partial, ["name"])).to.equal("CTA Button");
+        expect(get(partial, ["visual_block_enabled"])).to.equal(false);
+        expect(get(partial, ["content@"])).to.equal("content.html");
+        expect(get(partial, ["content"])).to.contain(
+          "<button>{{ content }}</button>",
+        );
+
+        expect(get(partial, ["__readonly"])).to.equal(undefined);
       });
     });
   });

--- a/test/lib/marshal/workflow/reader.test.ts
+++ b/test/lib/marshal/workflow/reader.test.ts
@@ -279,26 +279,6 @@ describe("lib/marshal/workflow/reader", () => {
       });
     });
 
-    describe("with the withReadonlyField opt of true", () => {
-      it("reads workflow.json with the readonly field", async () => {
-        const [workflow] = await readWorkflowDir(workflowDirCtx, {
-          withReadonlyField: true,
-        });
-
-        expect(get(workflow, ["name"])).to.equal("My cool workflow");
-        expect(get(workflow, ["steps", 0, "ref"])).to.equal("email_1");
-
-        expect(get(workflow, ["__readonly"])).to.eql({
-          environment: "development",
-          key: "my-cool-workflow",
-          active: false,
-          valid: true,
-          created_at: "2023-02-16T02:49:12.163499Z",
-          updated_at: "2023-04-25T14:28:43.486084Z",
-        });
-      });
-    });
-
     describe("with the withExtractedFiles opt of true", () => {
       it("reads workflow.json with the readonly field", async () => {
         const [workflow] = await readWorkflowDir(workflowDirCtx, {


### PR DESCRIPTION
### Description

This PR removes the `withReadonlyField` option from the various functions used to read resource directories. It appears we never set `withReadonlyField` to `true` anywhere within the codebase. 

### Tasks

[KNO-8961](https://linear.app/knock/issue/KNO-8961/cli-remove-withreadonlyfield-option-from-directory-read-functions)
