### PR TITLE
feat(KNO-8764): remove read-only fields from serialized resources

### DIFF
--- a/src/lib/helpers/object.isomorphic.ts
+++ b/src/lib/helpers/object.isomorphic.ts
@@ -6,30 +6,9 @@
  * reason there are some restrictions for which nodejs imports are allowed in
  * this module. See `.eslintrc.json` for more details.
  */
-import {
-  isNil,
-  isPlainObject,
-  merge as _merge,
-  omit,
-  omitBy,
-  pick,
-} from "lodash";
+import { isNil, isPlainObject, merge as _merge, omit, omitBy } from "lodash";
 
 export type AnyObj = Record<string, unknown>;
-
-/*
- * Split an object into two based on keys provided (similar to Map.split/2 in
- * Elixir)
- */
-export const split = (
-  obj: AnyObj,
-  paths: string | string[],
-): [AnyObj, AnyObj] => {
-  const picked = pick(obj, paths);
-  const remainder = omit(obj, paths);
-
-  return [picked, remainder];
-};
 
 /*
  * Omit a given key or keys recursively from an object or an array.

--- a/src/lib/marshal/email-layout/processor.isomorphic.ts
+++ b/src/lib/marshal/email-layout/processor.isomorphic.ts
@@ -1,7 +1,10 @@
 import { cloneDeep, get, has, set, unset } from "lodash";
 
-import { AnyObj } from "@/lib/helpers/object.isomorphic";
-import { ObjKeyOrArrayIdx, ObjPath } from "@/lib/helpers/object.isomorphic";
+import {
+  AnyObj,
+  ObjKeyOrArrayIdx,
+  ObjPath,
+} from "@/lib/helpers/object.isomorphic";
 import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
@@ -46,7 +49,7 @@ const compileExtractionSettings = (
 
 /*
  * For a given email layout payload, this function builds a "email layout
- * directoy bundle". This is an object which contains all the relative paths and
+ * directory bundle". This is an object which contains all the relative paths and
  * its file content. It includes the extractable fields, which are extracted out
  * and added to the bundle as separate files.
  */

--- a/src/lib/marshal/email-layout/reader.ts
+++ b/src/lib/marshal/email-layout/reader.ts
@@ -142,6 +142,8 @@ export const readEmailLayoutDir = async (
 
   let [layoutJson] = result;
 
+  // Read-only fields were previously stored under "__readonly" in layout JSON files.
+  // We remove these, in case we're reading a JSON file created by an older version of the CLI.
   layoutJson = omitDeep(layoutJson, ["__readonly"]);
 
   return withExtractedFiles

--- a/src/lib/marshal/message-type/reader.ts
+++ b/src/lib/marshal/message-type/reader.ts
@@ -94,6 +94,8 @@ export const readMessageTypeDir = async (
 
   let [messageTypeJson] = result;
 
+  // Read-only fields were previously stored under "__readonly" in message type JSON files.
+  // We remove these, in case we're reading a JSON file created by an older version of the CLI.
   messageTypeJson = omitDeep(messageTypeJson, ["__readonly"]);
 
   return withExtractedFiles

--- a/src/lib/marshal/partial/reader.ts
+++ b/src/lib/marshal/partial/reader.ts
@@ -83,6 +83,8 @@ export const readPartialDir = async (
 
   let [partialJson] = result;
 
+  // Read-only fields were previously stored under "__readonly" in partial JSON files.
+  // We remove these, in case we're reading a JSON file created by an older version of the CLI.
   partialJson = omitDeep(partialJson, ["__readonly"]);
 
   return withExtractedFiles

--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -1,5 +1,6 @@
-import { AnyObj, split } from "@/lib/helpers/object.isomorphic";
-import { omitDeep } from "@/lib/helpers/object.isomorphic";
+import { omit } from "lodash";
+
+import { AnyObj, omitDeep } from "@/lib/helpers/object.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 import { EmailLayoutData } from "../email-layout";
@@ -23,10 +24,9 @@ type ResourceData<A extends WithAnnotation> =
 export const prepareResourceJson = (
   resource: ResourceData<WithAnnotation>,
 ): AnyObj => {
-  // Move read only field under the dedicated field "__readonly".
+  // Remove all fields marked as readonly in the schema annotation
   const readonlyFields = resource.__annotation?.readonly_fields || [];
-  const [readonly, remainder] = split(resource, readonlyFields);
-  const resourceJson = { ...remainder, __readonly: readonly };
+  const resourceJson = omit(resource, readonlyFields);
 
   // Strip out all schema annotations, so not to expose them to end users.
   return omitDeep(resourceJson, ["__annotation"]);

--- a/src/lib/marshal/workflow/reader.ts
+++ b/src/lib/marshal/workflow/reader.ts
@@ -193,6 +193,8 @@ export const readWorkflowDir = async (
 
   let [workflowJson] = result;
 
+  // Read-only fields were previously stored under "__readonly" in workflow JSON files.
+  // We remove these, in case we're reading a JSON file created by an older version of the CLI.
   workflowJson = omitDeep(workflowJson, ["__readonly"]);
 
   return withExtractedFiles

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -138,12 +138,12 @@ describe("commands/layout/push", () => {
           footer_links: [],
           "html_layout@": "html_layout.html",
           "text_layout@": "text_layout.txt",
-          __readonly: {
-            key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-09-29T19:08:04.129228Z",
-          },
+          // __readonly: {
+          //   key: "default",
+          //   environment: "development",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-09-29T19:08:04.129228Z",
+          // },
         });
       });
   });

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -138,12 +138,6 @@ describe("commands/layout/push", () => {
           footer_links: [],
           "html_layout@": "html_layout.html",
           "text_layout@": "text_layout.txt",
-          // __readonly: {
-          //   key: "default",
-          //   environment: "development",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-09-29T19:08:04.129228Z",
-          // },
         });
       });
   });

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -192,6 +192,37 @@ describe("commands/message-type/push", () => {
           );
         },
       );
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "banner"])
+      .it("writes the upserted layout data into message_type.json", () => {
+        const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+        const messageTypeJson = fs.readJsonSync(abspath);
+
+        expect(messageTypeJson).to.eql({
+          name: "Banner",
+          description: "My little banner",
+          variants: [
+            {
+              key: "default",
+              name: "Default",
+              fields: [
+                {
+                  type: "text",
+                  key: "title",
+                  label: "Title",
+                  settings: {
+                    required: true,
+                    default: "",
+                  },
+                },
+              ],
+            },
+          ],
+          "preview@": "preview.html",
+        });
+      });
   });
 
   describe("given a message_type.json file with syntax errors", () => {

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -196,33 +196,36 @@ describe("commands/message-type/push", () => {
     setupWithStub({ data: { message_type: mockMessageTypeData } })
       .stdout()
       .command(["message-type push", "banner"])
-      .it("writes the upserted layout data into message_type.json", () => {
-        const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
-        const messageTypeJson = fs.readJsonSync(abspath);
+      .it(
+        "writes the upserted message type data into message_type.json",
+        () => {
+          const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+          const messageTypeJson = fs.readJsonSync(abspath);
 
-        expect(messageTypeJson).to.eql({
-          name: "Banner",
-          description: "My little banner",
-          variants: [
-            {
-              key: "default",
-              name: "Default",
-              fields: [
-                {
-                  type: "text",
-                  key: "title",
-                  label: "Title",
-                  settings: {
-                    required: true,
-                    default: "",
+          expect(messageTypeJson).to.eql({
+            name: "Banner",
+            description: "My little banner",
+            variants: [
+              {
+                key: "default",
+                name: "Default",
+                fields: [
+                  {
+                    type: "text",
+                    key: "title",
+                    label: "Title",
+                    settings: {
+                      required: true,
+                      default: "",
+                    },
                   },
-                },
-              ],
-            },
-          ],
-          "preview@": "preview.html",
-        });
-      });
+                ],
+              },
+            ],
+            "preview@": "preview.html",
+          });
+        },
+      );
   });
 
   describe("given a message_type.json file with syntax errors", () => {

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -145,14 +145,14 @@ describe("commands/partial/push", () => {
           description: "This is a default partial",
           icon_name: "Microphone",
           visual_block_enabled: true,
-          __readonly: {
-            valid: true,
-            type: "html",
-            key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-09-29T19:08:04.129228Z",
-          },
+          // __readonly: {
+          //   valid: true,
+          //   type: "html",
+          //   key: "default",
+          //   environment: "development",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-09-29T19:08:04.129228Z",
+          // },
         });
       });
   });

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -145,14 +145,6 @@ describe("commands/partial/push", () => {
           description: "This is a default partial",
           icon_name: "Microphone",
           visual_block_enabled: true,
-          // __readonly: {
-          //   valid: true,
-          //   type: "html",
-          //   key: "default",
-          //   environment: "development",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-09-29T19:08:04.129228Z",
-          // },
         });
       });
   });

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -134,13 +134,13 @@ describe("commands/workflow/push", () => {
         expect(workflowJson).to.eql({
           name: "New comment",
           steps: [],
-          __readonly: {
-            key: "new-comment",
-            active: false,
-            valid: false,
-            created_at: "2022-12-31T12:00:00.000000Z",
-            updated_at: "2022-12-31T12:00:00.000000Z",
-          },
+          // __readonly: {
+          //   key: "new-comment",
+          //   active: false,
+          //   valid: false,
+          //   created_at: "2022-12-31T12:00:00.000000Z",
+          //   updated_at: "2022-12-31T12:00:00.000000Z",
+          // },
         });
       });
   });

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -134,13 +134,6 @@ describe("commands/workflow/push", () => {
         expect(workflowJson).to.eql({
           name: "New comment",
           steps: [],
-          // __readonly: {
-          //   key: "new-comment",
-          //   active: false,
-          //   valid: false,
-          //   created_at: "2022-12-31T12:00:00.000000Z",
-          //   updated_at: "2022-12-31T12:00:00.000000Z",
-          // },
         });
       });
   });

--- a/test/lib/helpers/object.test.ts
+++ b/test/lib/helpers/object.test.ts
@@ -7,36 +7,9 @@ import {
   ObjPath,
   omitDeep,
   prune,
-  split,
 } from "@/lib/helpers/object.isomorphic";
 
 describe("lib/helpers/object", () => {
-  describe("split", () => {
-    describe("given a key to extract from an object", () => {
-      it("returns a tuple with a new extracted object plus the old object with a removed key", () => {
-        const obj = {
-          a: 1,
-          b: 2,
-          c: 3,
-        };
-        const result = split(obj, "a");
-        expect(result).to.eql([{ a: 1 }, { b: 2, c: 3 }]);
-      });
-    });
-
-    describe("given a list of keys to extract from an object", () => {
-      it("returns a tuple with a new extracted object plus the old object with removed keys", () => {
-        const obj = {
-          a: 1,
-          b: 2,
-          c: 3,
-        };
-        const result = split(obj, ["a", "b", "x"]);
-        expect(result).to.eql([{ a: 1, b: 2 }, { c: 3 }]);
-      });
-    });
-  });
-
   describe("omitDeep", () => {
     describe("given an object with target key(s) to remove", () => {
       it("returns an object with target key(s) removed recursively", () => {

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -63,12 +63,6 @@ describe("lib/marshal/layout/processor", () => {
             footer_links: [{ text: "Link 1", url: "https://example.com" }],
             "html_layout@": "foo/bar/layout.html",
             "text_layout@": "text_layout.txt",
-            // __readonly: {
-            //   key: "default",
-            //   environment: "development",
-            //   created_at: "2023-09-18T18:32:18.398053Z",
-            //   updated_at: "2023-10-02T19:24:48.714630Z",
-            // },
           },
         });
       });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -37,12 +37,12 @@ describe("lib/marshal/layout/processor", () => {
           footer_links: [{ text: "Link 1", url: "https://example.com" }],
           "html_layout@": "html_layout.html",
           "text_layout@": "text_layout.txt",
-          __readonly: {
-            key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
-          },
+          // __readonly: {
+          //   key: "default",
+          //   environment: "development",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-10-02T19:24:48.714630Z",
+          // },
         },
       });
     });
@@ -69,12 +69,12 @@ describe("lib/marshal/layout/processor", () => {
             footer_links: [{ text: "Link 1", url: "https://example.com" }],
             "html_layout@": "foo/bar/layout.html",
             "text_layout@": "text_layout.txt",
-            __readonly: {
-              key: "default",
-              environment: "development",
-              created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
-            },
+            // __readonly: {
+            //   key: "default",
+            //   environment: "development",
+            //   created_at: "2023-09-18T18:32:18.398053Z",
+            //   updated_at: "2023-10-02T19:24:48.714630Z",
+            // },
           },
         });
       });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -37,12 +37,6 @@ describe("lib/marshal/layout/processor", () => {
           footer_links: [{ text: "Link 1", url: "https://example.com" }],
           "html_layout@": "html_layout.html",
           "text_layout@": "text_layout.txt",
-          // __readonly: {
-          //   key: "default",
-          //   environment: "development",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-10-02T19:24:48.714630Z",
-          // },
         },
       });
     });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -4,6 +4,7 @@ import {
   buildEmailLayoutDirBundle,
   EmailLayoutData,
 } from "@/lib/marshal/email-layout";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
@@ -25,6 +26,36 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
 };
 
 describe("lib/marshal/layout/processor", () => {
+  describe("prepareResourceJson", () => {
+    it("removes all fields present in __readonly field", () => {
+      const emailLayoutJson = prepareResourceJson(remoteEmailLayout);
+
+      // Readonly fields should be removed
+      expect(emailLayoutJson.environment).to.equal(undefined);
+      expect(emailLayoutJson.key).to.equal(undefined);
+      expect(emailLayoutJson.created_at).to.equal(undefined);
+      expect(emailLayoutJson.updated_at).to.equal(undefined);
+
+      // Non-readonly fields should be preserved
+      expect(emailLayoutJson.name).to.equal("Default");
+      expect(emailLayoutJson.html_layout).to.equal(
+        "<html><body><p> Example content </html></body><p>",
+      );
+      expect(emailLayoutJson.text_layout).to.equal("Text {{content}}");
+      expect(emailLayoutJson.footer_links).to.deep.equal([
+        { text: "Link 1", url: "https://example.com" },
+      ]);
+
+      // __readonly itself should be removed
+      expect(emailLayoutJson.__readonly).to.equal(undefined);
+    });
+
+    it("removes all __annotation fields", () => {
+      const emailLayoutJson = prepareResourceJson(remoteEmailLayout);
+      expect(emailLayoutJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildEmailLayoutDirBundle", () => {
     describe("given a fetched layout that has not been pulled before", () => {
       const result = buildEmailLayoutDirBundle(remoteEmailLayout);

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -68,14 +68,6 @@ describe("lib/marshal/guide/processor", () => {
               },
             },
           ],
-          // __readonly: {
-          //   key: "success-banner",
-          //   valid: true,
-          //   active: true,
-          //   environment: "development",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-10-02T19:24:48.714630Z",
-          // },
         },
       });
     });

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -68,14 +68,14 @@ describe("lib/marshal/guide/processor", () => {
               },
             },
           ],
-          __readonly: {
-            key: "success-banner",
-            valid: true,
-            active: true,
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
-          },
+          // __readonly: {
+          //   key: "success-banner",
+          //   valid: true,
+          //   active: true,
+          //   environment: "development",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-10-02T19:24:48.714630Z",
+          // },
         },
       });
     });

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import { buildGuideDirBundle, GuideData } from "@/lib/marshal/guide";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteGuide: GuideData<WithAnnotation> = {
@@ -43,6 +44,49 @@ const remoteGuide: GuideData<WithAnnotation> = {
 };
 
 describe("lib/marshal/guide/processor", () => {
+  describe("prepareResourceJson", () => {
+    it("removes all fields present in __readonly field", () => {
+      const guideJson = prepareResourceJson(remoteGuide);
+
+      // Readonly fields should be removed
+      expect(guideJson.key).to.equal(undefined);
+      expect(guideJson.active).to.equal(undefined);
+      expect(guideJson.valid).to.equal(undefined);
+      expect(guideJson.environment).to.equal(undefined);
+      expect(guideJson.created_at).to.equal(undefined);
+      expect(guideJson.updated_at).to.equal(undefined);
+
+      // Non-readonly fields should be preserved
+      expect(guideJson.name).to.equal("Success Banner");
+      expect(guideJson.description).to.equal("My little success banner");
+      expect(guideJson.priority).to.equal(10);
+      expect(guideJson.channel_key).to.equal("in-app-guide");
+      expect(guideJson.type).to.equal("banner");
+      expect(guideJson.semver).to.equal("0.0.1");
+      expect(guideJson.steps).to.deep.equal([
+        {
+          ref: "step_1",
+          name: "Step one",
+          schema_key: "banner",
+          schema_semver: "0.0.1",
+          schema_variant_key: "default",
+          values: {
+            title: "The You You Are",
+            message: "The work is mysterious and important",
+          },
+        },
+      ]);
+
+      // __readonly itself should be removed
+      expect(guideJson.__readonly).to.equal(undefined);
+    });
+
+    it("removes all __annotation fields", () => {
+      const guideJson = prepareResourceJson(remoteGuide);
+      expect(guideJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildGuideDirBundle", () => {
     describe("given a fetched guide that has not been pulled before", () => {
       const result = buildGuideDirBundle(remoteGuide);

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -78,15 +78,15 @@ describe("lib/marshal/message-typel/processor", () => {
           ],
           description: "My little banner",
           "preview@": "preview.html",
-          __readonly: {
-            key: "banner",
-            valid: true,
-            owner: "user",
-            environment: "development",
-            semver: "0.0.1",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
-          },
+          // __readonly: {
+          //   key: "banner",
+          //   valid: true,
+          //   owner: "user",
+          //   environment: "development",
+          //   semver: "0.0.1",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-10-02T19:24:48.714630Z",
+          // },
         },
       });
     });
@@ -126,15 +126,15 @@ describe("lib/marshal/message-typel/processor", () => {
             ],
             description: "My little banner",
             "preview@": "foo/bar/baz.html",
-            __readonly: {
-              key: "banner",
-              valid: true,
-              owner: "user",
-              environment: "development",
-              semver: "0.0.1",
-              created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
-            },
+            // __readonly: {
+            //   key: "banner",
+            //   valid: true,
+            //   owner: "user",
+            //   environment: "development",
+            //   semver: "0.0.1",
+            //   created_at: "2023-09-18T18:32:18.398053Z",
+            //   updated_at: "2023-10-02T19:24:48.714630Z",
+            // },
           },
         });
       });

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -117,15 +117,6 @@ describe("lib/marshal/message-typel/processor", () => {
             ],
             description: "My little banner",
             "preview@": "foo/bar/baz.html",
-            // __readonly: {
-            //   key: "banner",
-            //   valid: true,
-            //   owner: "user",
-            //   environment: "development",
-            //   semver: "0.0.1",
-            //   created_at: "2023-09-18T18:32:18.398053Z",
-            //   updated_at: "2023-10-02T19:24:48.714630Z",
-            // },
           },
         });
       });

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -78,15 +78,6 @@ describe("lib/marshal/message-typel/processor", () => {
           ],
           description: "My little banner",
           "preview@": "preview.html",
-          // __readonly: {
-          //   key: "banner",
-          //   valid: true,
-          //   owner: "user",
-          //   environment: "development",
-          //   semver: "0.0.1",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-10-02T19:24:48.714630Z",
-          // },
         },
       });
     });

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -4,6 +4,7 @@ import {
   buildMessageTypeDirBundle,
   MessageTypeData,
 } from "@/lib/marshal/message-type";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteMessageType: MessageTypeData<WithAnnotation> = {
@@ -51,6 +52,51 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
 };
 
 describe("lib/marshal/message-typel/processor", () => {
+  describe("prepareResourceJson", () => {
+    it("removes all fields present in __readonly field", () => {
+      const messageTypeJson = prepareResourceJson(remoteMessageType);
+
+      // Readonly fields should be removed
+      expect(messageTypeJson.key).to.equal(undefined);
+      expect(messageTypeJson.valid).to.equal(undefined);
+      expect(messageTypeJson.owner).to.equal(undefined);
+      expect(messageTypeJson.environment).to.equal(undefined);
+      expect(messageTypeJson.semver).to.equal(undefined);
+      expect(messageTypeJson.created_at).to.equal(undefined);
+      expect(messageTypeJson.updated_at).to.equal(undefined);
+
+      // Non-readonly fields should be preserved
+      expect(messageTypeJson.name).to.equal("Banner");
+      expect(messageTypeJson.variants).to.deep.equal([
+        {
+          key: "default",
+          name: "Default",
+          fields: [
+            {
+              type: "text",
+              key: "title",
+              label: "Title",
+              settings: {
+                required: true,
+                default: "",
+              },
+            },
+          ],
+        },
+      ]);
+      expect(messageTypeJson.preview).to.equal("<div>{{ title }}</div>");
+      expect(messageTypeJson.description).to.equal("My little banner");
+
+      // __readonly itself should be removed
+      expect(messageTypeJson.__readonly).to.equal(undefined);
+    });
+
+    it("removes all __annotation fields", () => {
+      const messageTypeJson = prepareResourceJson(remoteMessageType);
+      expect(messageTypeJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildMessageTypeDirBundle", () => {
     describe("given a fetched message type that has not been pulled before", () => {
       const result = buildMessageTypeDirBundle(remoteMessageType);

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -45,14 +45,6 @@ describe("lib/marshal/partial/processor", () => {
           visual_block_enabled: true,
           description: "Default HTML partial",
           "content@": "content.html",
-          // __readonly: {
-          //   key: "default",
-          //   valid: true,
-          //   type: PartialType.Html,
-          //   environment: "development",
-          //   created_at: "2023-09-18T18:32:18.398053Z",
-          //   updated_at: "2023-10-02T19:24:48.714630Z",
-          // },
         },
       });
     });

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -45,14 +45,14 @@ describe("lib/marshal/partial/processor", () => {
           visual_block_enabled: true,
           description: "Default HTML partial",
           "content@": "content.html",
-          __readonly: {
-            key: "default",
-            valid: true,
-            type: PartialType.Html,
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
-          },
+          // __readonly: {
+          //   key: "default",
+          //   valid: true,
+          //   type: PartialType.Html,
+          //   environment: "development",
+          //   created_at: "2023-09-18T18:32:18.398053Z",
+          //   updated_at: "2023-10-02T19:24:48.714630Z",
+          // },
         },
       });
     });
@@ -74,14 +74,14 @@ describe("lib/marshal/partial/processor", () => {
             visual_block_enabled: true,
             description: "Default HTML partial",
             "content@": "foo/bar/partial.html",
-            __readonly: {
-              key: "default",
-              valid: true,
-              type: PartialType.Html,
-              environment: "development",
-              created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
-            },
+            // __readonly: {
+            //   key: "default",
+            //   valid: true,
+            //   type: PartialType.Html,
+            //   environment: "development",
+            //   created_at: "2023-09-18T18:32:18.398053Z",
+            //   updated_at: "2023-10-02T19:24:48.714630Z",
+            // },
           },
         });
       });

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -66,14 +66,6 @@ describe("lib/marshal/partial/processor", () => {
             visual_block_enabled: true,
             description: "Default HTML partial",
             "content@": "foo/bar/partial.html",
-            // __readonly: {
-            //   key: "default",
-            //   valid: true,
-            //   type: PartialType.Html,
-            //   environment: "development",
-            //   created_at: "2023-09-18T18:32:18.398053Z",
-            //   updated_at: "2023-10-02T19:24:48.714630Z",
-            // },
           },
         });
       });

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -5,6 +5,7 @@ import {
   PartialData,
   PartialType,
 } from "@/lib/marshal/partial";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remotePartial: PartialData<WithAnnotation> = {
@@ -34,6 +35,36 @@ const remotePartial: PartialData<WithAnnotation> = {
 };
 
 describe("lib/marshal/partial/processor", () => {
+  describe("prepareResourceJson", () => {
+    it("removes all fields present in __readonly field", () => {
+      const partialJson = prepareResourceJson(remotePartial);
+
+      // Readonly fields should be removed
+      expect(partialJson.key).to.equal(undefined);
+      expect(partialJson.valid).to.equal(undefined);
+      expect(partialJson.type).to.equal(undefined);
+      expect(partialJson.environment).to.equal(undefined);
+      expect(partialJson.created_at).to.equal(undefined);
+      expect(partialJson.updated_at).to.equal(undefined);
+
+      // Non-readonly fields should be preserved
+      expect(partialJson.name).to.equal("Default");
+      expect(partialJson.visual_block_enabled).to.equal(true);
+      expect(partialJson.content).to.equal(
+        "<html><body><p> Example content </html></body><p>",
+      );
+      expect(partialJson.description).to.equal("Default HTML partial");
+
+      // __readonly itself should be removed
+      expect(partialJson.__readonly).to.equal(undefined);
+    });
+
+    it("removes all __annotation fields", () => {
+      const partialJson = prepareResourceJson(remotePartial);
+      expect(partialJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildPartialDirBundle", () => {
     describe("given a fetched partial that has not been pulled before", () => {
       const result = buildPartialDirBundle(remotePartial);

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -584,13 +584,6 @@ describe("lib/marshal/workflow/processor", () => {
                 },
               },
             ],
-            // __readonly: {
-            //   key: "new-comment",
-            //   active: false,
-            //   valid: false,
-            //   created_at: "2022-12-31T12:00:00.000000Z",
-            //   updated_at: "2022-12-31T12:00:00.000000Z",
-            // },
           },
           [xpath("email_1/settings/pre_content.txt")]: "{{ foo }}",
           [xpath("email_1/visual_blocks.json")]: JSON.stringify(

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -356,13 +356,6 @@ describe("lib/marshal/workflow/processor", () => {
                 ],
               },
             ],
-            // __readonly: {
-            //   key: "new-comment",
-            //   active: false,
-            //   valid: false,
-            //   created_at: "2022-12-31T12:00:00.000000Z",
-            //   updated_at: "2022-12-31T12:00:00.000000Z",
-            // },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
           [xpath("email_1/html_body.html")]:

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -388,13 +388,6 @@ describe("lib/marshal/workflow/processor", () => {
               },
             },
           ],
-          __readonly: {
-            key: "new-comment",
-            active: false,
-            valid: false,
-            created_at: "2022-12-31T12:00:00.000000Z",
-            updated_at: "2022-12-31T12:00:00.000000Z",
-          },
         };
 
         const result = buildWorkflowDirBundle(remoteWorkflow, localWorkflow);
@@ -486,13 +479,6 @@ describe("lib/marshal/workflow/processor", () => {
                 ],
               },
             ],
-            // __readonly: {
-            //   key: "new-comment",
-            //   active: false,
-            //   valid: false,
-            //   created_at: "2022-12-31T12:00:00.000000Z",
-            //   updated_at: "2022-12-31T12:00:00.000000Z",
-            // },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
           // And here..

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -169,23 +169,23 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
 
 describe("lib/marshal/workflow/processor", () => {
   describe("prepareResourceJson", () => {
-    it("moves over workflow's readonly fields under __readonly field", () => {
+    it("removes all fields present in __readonly field", () => {
       const workflowJson = prepareResourceJson(remoteWorkflow);
 
+      // Readonly fields should be removed
+      expect(workflowJson.environment).to.equal(undefined);
       expect(workflowJson.key).to.equal(undefined);
-      expect(workflowJson.active).to.equal(undefined);
       expect(workflowJson.active).to.equal(undefined);
       expect(workflowJson.valid).to.equal(undefined);
       expect(workflowJson.created_at).to.equal(undefined);
       expect(workflowJson.updated_at).to.equal(undefined);
 
-      expect(workflowJson.__readonly).to.eql({
-        key: "new-comment",
-        active: false,
-        valid: false,
-        created_at: "2022-12-31T12:00:00.000000Z",
-        updated_at: "2022-12-31T12:00:00.000000Z",
-      });
+      // Non-readonly fields should be preserved
+      expect(workflowJson.name).to.equal("New comment");
+      expect(workflowJson.steps).not.to.equal(undefined);
+
+      // __readonly itself should be removed
+      expect(workflowJson.__readonly).to.equal(undefined);
     });
 
     it("removes all __annotation fields", () => {
@@ -356,13 +356,13 @@ describe("lib/marshal/workflow/processor", () => {
                 ],
               },
             ],
-            __readonly: {
-              key: "new-comment",
-              active: false,
-              valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
-            },
+            // __readonly: {
+            //   key: "new-comment",
+            //   active: false,
+            //   valid: false,
+            //   created_at: "2022-12-31T12:00:00.000000Z",
+            //   updated_at: "2022-12-31T12:00:00.000000Z",
+            // },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
           [xpath("email_1/html_body.html")]:
@@ -493,13 +493,13 @@ describe("lib/marshal/workflow/processor", () => {
                 ],
               },
             ],
-            __readonly: {
-              key: "new-comment",
-              active: false,
-              valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
-            },
+            // __readonly: {
+            //   key: "new-comment",
+            //   active: false,
+            //   valid: false,
+            //   created_at: "2022-12-31T12:00:00.000000Z",
+            //   updated_at: "2022-12-31T12:00:00.000000Z",
+            // },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
           // And here..
@@ -605,13 +605,13 @@ describe("lib/marshal/workflow/processor", () => {
                 },
               },
             ],
-            __readonly: {
-              key: "new-comment",
-              active: false,
-              valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
-            },
+            // __readonly: {
+            //   key: "new-comment",
+            //   active: false,
+            //   valid: false,
+            //   created_at: "2022-12-31T12:00:00.000000Z",
+            //   updated_at: "2022-12-31T12:00:00.000000Z",
+            // },
           },
           [xpath("email_1/settings/pre_content.txt")]: "{{ foo }}",
           [xpath("email_1/visual_blocks.json")]: JSON.stringify(


### PR DESCRIPTION
### Description

This PR updates the CLI so that when we store the serialized representations of resources, we completely remove all read-only fields. The `__readonly` field will no longer be present in resource JSON files.

### Tasks

[KNO-8764](https://linear.app/knock/issue/KNO-8764/cli-remove-readonly-properties-from-serialized-resources)
