### PR TITLE
feat(KNO-8764): remove sha and updated_at properties from serialized resources

### DIFF
--- a/src/lib/marshal/email-layout/processor.isomorphic.ts
+++ b/src/lib/marshal/email-layout/processor.isomorphic.ts
@@ -1,7 +1,10 @@
 import { cloneDeep, get, has, set, unset } from "lodash";
 
-import { AnyObj } from "@/lib/helpers/object.isomorphic";
-import { ObjKeyOrArrayIdx, ObjPath } from "@/lib/helpers/object.isomorphic";
+import {
+  AnyObj,
+  ObjKeyOrArrayIdx,
+  ObjPath,
+} from "@/lib/helpers/object.isomorphic";
 import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
 import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
 
@@ -46,7 +49,7 @@ const compileExtractionSettings = (
 
 /*
  * For a given email layout payload, this function builds a "email layout
- * directoy bundle". This is an object which contains all the relative paths and
+ * directory bundle". This is an object which contains all the relative paths and
  * its file content. It includes the extractable fields, which are extracted out
  * and added to the bundle as separate files.
  */

--- a/src/lib/marshal/email-layout/types.ts
+++ b/src/lib/marshal/email-layout/types.ts
@@ -12,6 +12,7 @@ export type EmailLayoutData<A extends MaybeWithAnnotation = unknown> = A & {
   environment: string;
   updated_at: string;
   created_at: string;
+  sha?: string;
 };
 
 export type EmailLayoutInput = AnyObj & {

--- a/src/lib/marshal/email-layout/types.ts
+++ b/src/lib/marshal/email-layout/types.ts
@@ -12,7 +12,7 @@ export type EmailLayoutData<A extends MaybeWithAnnotation = unknown> = A & {
   environment: string;
   updated_at: string;
   created_at: string;
-  sha?: string;
+  sha: string;
 };
 
 export type EmailLayoutInput = AnyObj & {

--- a/src/lib/marshal/guide/types.ts
+++ b/src/lib/marshal/guide/types.ts
@@ -37,6 +37,7 @@ export type GuideData<A extends MaybeWithAnnotation = unknown> = A & {
   updated_at: string;
   created_at: string;
   environment: string;
+  sha?: string;
 };
 
 export type GuideInput = AnyObj & {

--- a/src/lib/marshal/guide/types.ts
+++ b/src/lib/marshal/guide/types.ts
@@ -37,7 +37,7 @@ export type GuideData<A extends MaybeWithAnnotation = unknown> = A & {
   updated_at: string;
   created_at: string;
   environment: string;
-  sha?: string;
+  sha: string;
 };
 
 export type GuideInput = AnyObj & {

--- a/src/lib/marshal/message-type/types.ts
+++ b/src/lib/marshal/message-type/types.ts
@@ -73,7 +73,7 @@ export type MessageTypeData<A extends MaybeWithAnnotation = unknown> = A & {
   updated_at: string;
   created_at: string;
   environment: string;
-  sha?: string;
+  sha: string;
 };
 
 export type MessageTypeInput = AnyObj & {

--- a/src/lib/marshal/message-type/types.ts
+++ b/src/lib/marshal/message-type/types.ts
@@ -73,6 +73,7 @@ export type MessageTypeData<A extends MaybeWithAnnotation = unknown> = A & {
   updated_at: string;
   created_at: string;
   environment: string;
+  sha?: string;
 };
 
 export type MessageTypeInput = AnyObj & {

--- a/src/lib/marshal/partial/types.ts
+++ b/src/lib/marshal/partial/types.ts
@@ -22,7 +22,7 @@ export type PartialData<A extends MaybeWithAnnotation = unknown> = A & {
   environment: string;
   updated_at: string;
   created_at: string;
-  sha?: string;
+  sha: string;
 };
 
 export type PartialInput = AnyObj & {

--- a/src/lib/marshal/partial/types.ts
+++ b/src/lib/marshal/partial/types.ts
@@ -22,6 +22,7 @@ export type PartialData<A extends MaybeWithAnnotation = unknown> = A & {
   environment: string;
   updated_at: string;
   created_at: string;
+  sha?: string;
 };
 
 export type PartialInput = AnyObj & {

--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -21,6 +21,7 @@ type ResourceData<A extends WithAnnotation> =
   | MessageTypeData<A>
   | GuideData<A>;
 
+// sha and updated_at fields change too frequently, so we exclude them from resource JSON files
 const REMOVED_READONLY_FIELDS = ["sha", "updated_at"];
 
 export const prepareResourceJson = (

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -137,7 +137,7 @@ export type WorkflowData<A extends MaybeWithAnnotation = unknown> = A & {
   trigger_data_json_schema?: Record<string, any>;
   created_at: string;
   updated_at: string;
-  sha?: string;
+  sha: string;
 };
 
 export type WorkflowInput = AnyObj & {

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -137,6 +137,7 @@ export type WorkflowData<A extends MaybeWithAnnotation = unknown> = A & {
   trigger_data_json_schema?: Record<string, any>;
   created_at: string;
   updated_at: string;
+  sha?: string;
 };
 
 export type WorkflowInput = AnyObj & {

--- a/test/commands/guide/push.test.ts
+++ b/test/commands/guide/push.test.ts
@@ -30,12 +30,13 @@ const mockGuideData: GuideData<WithAnnotation> = {
       schema_key: "banner",
       schema_semver: "0.0.1",
       schema_variant_key: "default",
-      fields: [],
+      values: {},
     },
   ],
   updated_at: "2022-12-31T12:00:00.000000Z",
   created_at: "2022-12-31T12:00:00.000000Z",
   environment: "development",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {},
     readonly_fields: [
@@ -45,6 +46,7 @@ const mockGuideData: GuideData<WithAnnotation> = {
       "environment",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -30,12 +30,13 @@ const mockEmailLayoutData: EmailLayoutData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-09-29T19:08:04.129228Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       html_layout: { default: true, file_ext: "html" },
       text_layout: { default: true, file_ext: "txt" },
     },
-    readonly_fields: ["environment", "key", "created_at", "updated_at"],
+    readonly_fields: ["environment", "key", "created_at", "updated_at", "sha"],
   },
 };
 

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -142,7 +142,6 @@ describe("commands/layout/push", () => {
             key: "default",
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-09-29T19:08:04.129228Z",
           },
         });
       });

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -192,6 +192,48 @@ describe("commands/message-type/push", () => {
           );
         },
       );
+
+    setupWithStub({ data: { message_type: mockMessageTypeData } })
+      .stdout()
+      .command(["message-type push", "banner"])
+      .it(
+        "writes the upserted message type data into message_type.json",
+        () => {
+          const abspath = path.resolve(sandboxDir, messageTypeJsonFile);
+          const messageTypeJson = fs.readJsonSync(abspath);
+
+          expect(messageTypeJson).to.eql({
+            name: "Banner",
+            description: "My little banner",
+            variants: [
+              {
+                key: "default",
+                name: "Default",
+                fields: [
+                  {
+                    type: "text",
+                    key: "title",
+                    label: "Title",
+                    settings: {
+                      required: true,
+                      default: "",
+                    },
+                  },
+                ],
+              },
+            ],
+            "preview@": "preview.html",
+            __readonly: {
+              key: "banner",
+              valid: true,
+              owner: "user",
+              environment: "development",
+              semver: "0.0.1",
+              created_at: "2023-09-18T18:32:18.398053Z",
+            },
+          });
+        },
+      );
   });
 
   describe("given a message_type.json file with syntax errors", () => {

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -42,6 +42,7 @@ const mockMessageTypeData: MessageTypeData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-10-02T19:24:48.714630Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       preview: { default: true, file_ext: "html" },
@@ -54,6 +55,7 @@ const mockMessageTypeData: MessageTypeData<WithAnnotation> = {
       "semver",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -33,6 +33,7 @@ const mockPartialData: PartialData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-09-29T19:08:04.129228Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       content: { default: true, file_ext: "txt" },
@@ -44,6 +45,7 @@ const mockPartialData: PartialData<WithAnnotation> = {
       "valid",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -151,7 +151,6 @@ describe("commands/partial/push", () => {
             key: "default",
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-09-29T19:08:04.129228Z",
           },
         });
       });

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -37,12 +37,13 @@ const mockEmailLayoutData: EmailLayoutData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-09-29T19:08:04.129228Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       html_layout: { default: true, file_ext: "html" },
       text_layout: { default: true, file_ext: "txt" },
     },
-    readonly_fields: ["environment", "key", "created_at", "updated_at"],
+    readonly_fields: ["environment", "key", "created_at", "updated_at", "sha"],
   },
 };
 
@@ -65,6 +66,7 @@ const mockPartialData: PartialData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-09-29T19:08:04.129228Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       content: { default: true, file_ext: "txt" },
@@ -76,6 +78,7 @@ const mockPartialData: PartialData<WithAnnotation> = {
       "valid",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };
@@ -88,6 +91,7 @@ const mockWorkflowData: WorkflowData<WithAnnotation> = {
   steps: [],
   created_at: "2022-12-31T12:00:00.000000Z",
   updated_at: "2022-12-31T12:00:00.000000Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {},
     readonly_fields: [
@@ -97,6 +101,7 @@ const mockWorkflowData: WorkflowData<WithAnnotation> = {
       "valid",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -22,6 +22,7 @@ const mockWorkflowData: WorkflowData<WithAnnotation> = {
   steps: [],
   created_at: "2022-12-31T12:00:00.000000Z",
   updated_at: "2022-12-31T12:00:00.000000Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {},
     readonly_fields: [
@@ -31,6 +32,7 @@ const mockWorkflowData: WorkflowData<WithAnnotation> = {
       "valid",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -139,7 +139,6 @@ describe("commands/workflow/push", () => {
             active: false,
             valid: false,
             created_at: "2022-12-31T12:00:00.000000Z",
-            updated_at: "2022-12-31T12:00:00.000000Z",
           },
         });
       });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -4,6 +4,7 @@ import {
   buildEmailLayoutDirBundle,
   EmailLayoutData,
 } from "@/lib/marshal/email-layout";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
@@ -25,6 +26,15 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
 };
 
 describe("lib/marshal/layout/processor", () => {
+  describe("prepareResourceJson", () => {
+    // TODO
+
+    it("removes the __annotation field", () => {
+      const emailLayoutJson = prepareResourceJson(remoteEmailLayout);
+      expect(emailLayoutJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildEmailLayoutDirBundle", () => {
     describe("given a fetched layout that has not been pulled before", () => {
       const result = buildEmailLayoutDirBundle(remoteEmailLayout);

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -35,6 +35,7 @@ describe("lib/marshal/layout/processor", () => {
       expect(emailLayoutJson.environment).to.equal(undefined);
       expect(emailLayoutJson.created_at).to.equal(undefined);
       expect(emailLayoutJson.updated_at).to.equal(undefined);
+      expect(emailLayoutJson.sha).to.equal(undefined);
 
       expect(emailLayoutJson.__readonly).to.eql({
         key: "default",

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -41,7 +41,6 @@ describe("lib/marshal/layout/processor", () => {
             key: "default",
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
           },
         },
       });
@@ -73,7 +72,6 @@ describe("lib/marshal/layout/processor", () => {
               key: "default",
               environment: "development",
               created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
             },
           },
         });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -28,7 +28,18 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
 describe("lib/marshal/layout/processor", () => {
   describe("prepareResourceJson", () => {
     it("moves over email layout's readonly fields under __readonly field", () => {
-      // TODO
+      const emailLayoutJson = prepareResourceJson(remoteEmailLayout);
+
+      expect(emailLayoutJson.key).to.equal(undefined);
+      expect(emailLayoutJson.environment).to.equal(undefined);
+      expect(emailLayoutJson.created_at).to.equal(undefined);
+      expect(emailLayoutJson.updated_at).to.equal(undefined);
+
+      expect(emailLayoutJson.__readonly).to.eql({
+        key: "default",
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+      });
     });
 
     it("removes the __annotation field", () => {

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -16,12 +16,13 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-10-02T19:24:48.714630Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       html_layout: { default: true, file_ext: "html" },
       text_layout: { default: true, file_ext: "txt" },
     },
-    readonly_fields: ["key", "environment", "created_at", "updated_at"],
+    readonly_fields: ["key", "environment", "created_at", "updated_at", "sha"],
   },
 };
 

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -27,7 +27,9 @@ const remoteEmailLayout: EmailLayoutData<WithAnnotation> = {
 
 describe("lib/marshal/layout/processor", () => {
   describe("prepareResourceJson", () => {
-    // TODO
+    it("moves over email layout's readonly fields under __readonly field", () => {
+      // TODO
+    });
 
     it("removes the __annotation field", () => {
       const emailLayoutJson = prepareResourceJson(remoteEmailLayout);

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import { buildGuideDirBundle, GuideData } from "@/lib/marshal/guide";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteGuide: GuideData<WithAnnotation> = {
@@ -43,6 +44,15 @@ const remoteGuide: GuideData<WithAnnotation> = {
 };
 
 describe("lib/marshal/guide/processor", () => {
+  describe("prepareResourceJson", () => {
+    // TODO
+
+    it("removes the __annotation field", () => {
+      const guideJson = prepareResourceJson(remoteGuide);
+      expect(guideJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildGuideDirBundle", () => {
     describe("given a fetched guide that has not been pulled before", () => {
       const result = buildGuideDirBundle(remoteGuide);

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -56,6 +56,7 @@ describe("lib/marshal/guide/processor", () => {
       expect(guideJson.environment).to.equal(undefined);
       expect(guideJson.created_at).to.equal(undefined);
       expect(guideJson.updated_at).to.equal(undefined);
+      expect(guideJson.sha).to.equal(undefined);
 
       expect(guideJson.__readonly).to.eql({
         key: "success-banner",

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -45,7 +45,9 @@ const remoteGuide: GuideData<WithAnnotation> = {
 
 describe("lib/marshal/guide/processor", () => {
   describe("prepareResourceJson", () => {
-    // TODO
+    it("moves over guide's readonly fields under __readonly field", () => {
+      // TODO
+    });
 
     it("removes the __annotation field", () => {
       const guideJson = prepareResourceJson(remoteGuide);

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -74,7 +74,6 @@ describe("lib/marshal/guide/processor", () => {
             active: true,
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
           },
         },
       });

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -46,7 +46,22 @@ const remoteGuide: GuideData<WithAnnotation> = {
 describe("lib/marshal/guide/processor", () => {
   describe("prepareResourceJson", () => {
     it("moves over guide's readonly fields under __readonly field", () => {
-      // TODO
+      const guideJson = prepareResourceJson(remoteGuide);
+
+      expect(guideJson.key).to.equal(undefined);
+      expect(guideJson.active).to.equal(undefined);
+      expect(guideJson.valid).to.equal(undefined);
+      expect(guideJson.environment).to.equal(undefined);
+      expect(guideJson.created_at).to.equal(undefined);
+      expect(guideJson.updated_at).to.equal(undefined);
+
+      expect(guideJson.__readonly).to.eql({
+        key: "success-banner",
+        active: true,
+        valid: true,
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+      });
     });
 
     it("removes the __annotation field", () => {

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -30,6 +30,7 @@ const remoteGuide: GuideData<WithAnnotation> = {
   ],
   updated_at: "2023-10-02T19:24:48.714630Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {},
     readonly_fields: [
@@ -39,6 +40,7 @@ const remoteGuide: GuideData<WithAnnotation> = {
       "environment",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -53,7 +53,9 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
 
 describe("lib/marshal/message-typel/processor", () => {
   describe("prepareResourceJson", () => {
-    // TODO
+    it("moves over message type's readonly fields under __readonly field", () => {
+      // TODO
+    });
 
     it("removes the __annotation field", () => {
       const messageTypeJson = prepareResourceJson(remoteMessageType);

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -65,6 +65,7 @@ describe("lib/marshal/message-typel/processor", () => {
       expect(messageTypeJson.semver).to.equal(undefined);
       expect(messageTypeJson.created_at).to.equal(undefined);
       expect(messageTypeJson.updated_at).to.equal(undefined);
+      expect(messageTypeJson.sha).to.equal(undefined);
 
       expect(messageTypeJson.__readonly).to.eql({
         key: "banner",

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -85,7 +85,6 @@ describe("lib/marshal/message-typel/processor", () => {
             environment: "development",
             semver: "0.0.1",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
           },
         },
       });
@@ -133,7 +132,6 @@ describe("lib/marshal/message-typel/processor", () => {
               environment: "development",
               semver: "0.0.1",
               created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
             },
           },
         });

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -35,6 +35,7 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-10-02T19:24:48.714630Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       preview: { default: true, file_ext: "html" },
@@ -47,6 +48,7 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
       "semver",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -4,6 +4,7 @@ import {
   buildMessageTypeDirBundle,
   MessageTypeData,
 } from "@/lib/marshal/message-type";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remoteMessageType: MessageTypeData<WithAnnotation> = {
@@ -51,6 +52,15 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
 };
 
 describe("lib/marshal/message-typel/processor", () => {
+  describe("prepareResourceJson", () => {
+    // TODO
+
+    it("removes the __annotation field", () => {
+      const messageTypeJson = prepareResourceJson(remoteMessageType);
+      expect(messageTypeJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildMessageTypeDirBundle", () => {
     describe("given a fetched message type that has not been pulled before", () => {
       const result = buildMessageTypeDirBundle(remoteMessageType);

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -54,7 +54,24 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
 describe("lib/marshal/message-typel/processor", () => {
   describe("prepareResourceJson", () => {
     it("moves over message type's readonly fields under __readonly field", () => {
-      // TODO
+      const messageTypeJson = prepareResourceJson(remoteMessageType);
+
+      expect(messageTypeJson.key).to.equal(undefined);
+      expect(messageTypeJson.valid).to.equal(undefined);
+      expect(messageTypeJson.owner).to.equal(undefined);
+      expect(messageTypeJson.environment).to.equal(undefined);
+      expect(messageTypeJson.semver).to.equal(undefined);
+      expect(messageTypeJson.created_at).to.equal(undefined);
+      expect(messageTypeJson.updated_at).to.equal(undefined);
+
+      expect(messageTypeJson.__readonly).to.eql({
+        key: "banner",
+        valid: true,
+        owner: "user",
+        environment: "development",
+        semver: "0.0.1",
+        created_at: "2023-09-18T18:32:18.398053Z",
+      });
     });
 
     it("removes the __annotation field", () => {

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -19,6 +19,7 @@ const remotePartial: PartialData<WithAnnotation> = {
   environment: "development",
   updated_at: "2023-10-02T19:24:48.714630Z",
   created_at: "2023-09-18T18:32:18.398053Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {
       content: { default: true, file_ext: "txt" },
@@ -30,6 +31,7 @@ const remotePartial: PartialData<WithAnnotation> = {
       "environment",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -37,7 +37,22 @@ const remotePartial: PartialData<WithAnnotation> = {
 describe("lib/marshal/partial/processor", () => {
   describe("prepareResourceJson", () => {
     it("moves over partial's readonly fields under __readonly field", () => {
-      // TODO
+      const partialJson = prepareResourceJson(remotePartial);
+
+      expect(partialJson.key).to.equal(undefined);
+      expect(partialJson.valid).to.equal(undefined);
+      expect(partialJson.type).to.equal(undefined);
+      expect(partialJson.environment).to.equal(undefined);
+      expect(partialJson.created_at).to.equal(undefined);
+      expect(partialJson.updated_at).to.equal(undefined);
+
+      expect(partialJson.__readonly).to.eql({
+        key: "default",
+        valid: true,
+        type: PartialType.Html,
+        environment: "development",
+        created_at: "2023-09-18T18:32:18.398053Z",
+      });
     });
 
     it("removes the __annotation field", () => {

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -47,6 +47,7 @@ describe("lib/marshal/partial/processor", () => {
       expect(partialJson.environment).to.equal(undefined);
       expect(partialJson.created_at).to.equal(undefined);
       expect(partialJson.updated_at).to.equal(undefined);
+      expect(partialJson.sha).to.equal(undefined);
 
       expect(partialJson.__readonly).to.eql({
         key: "default",

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -36,7 +36,9 @@ const remotePartial: PartialData<WithAnnotation> = {
 
 describe("lib/marshal/partial/processor", () => {
   describe("prepareResourceJson", () => {
-    // TODO
+    it("moves over partial's readonly fields under __readonly field", () => {
+      // TODO
+    });
 
     it("removes the __annotation field", () => {
       const partialJson = prepareResourceJson(remotePartial);

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -51,7 +51,6 @@ describe("lib/marshal/partial/processor", () => {
             type: PartialType.Html,
             environment: "development",
             created_at: "2023-09-18T18:32:18.398053Z",
-            updated_at: "2023-10-02T19:24:48.714630Z",
           },
         },
       });
@@ -80,7 +79,6 @@ describe("lib/marshal/partial/processor", () => {
               type: PartialType.Html,
               environment: "development",
               created_at: "2023-09-18T18:32:18.398053Z",
-              updated_at: "2023-10-02T19:24:48.714630Z",
             },
           },
         });

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -5,6 +5,7 @@ import {
   PartialData,
   PartialType,
 } from "@/lib/marshal/partial";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
 import { WithAnnotation } from "@/lib/marshal/shared/types";
 
 const remotePartial: PartialData<WithAnnotation> = {
@@ -34,6 +35,15 @@ const remotePartial: PartialData<WithAnnotation> = {
 };
 
 describe("lib/marshal/partial/processor", () => {
+  describe("prepareResourceJson", () => {
+    // TODO
+
+    it("removes the __annotation field", () => {
+      const partialJson = prepareResourceJson(remotePartial);
+      expect(partialJson.__annotation).to.equal(undefined);
+    });
+  });
+
   describe("buildPartialDirBundle", () => {
     describe("given a fetched partial that has not been pulled before", () => {
       const result = buildPartialDirBundle(remotePartial);

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -184,7 +184,6 @@ describe("lib/marshal/workflow/processor", () => {
         active: false,
         valid: false,
         created_at: "2022-12-31T12:00:00.000000Z",
-        updated_at: "2022-12-31T12:00:00.000000Z",
       });
     });
 
@@ -361,7 +360,6 @@ describe("lib/marshal/workflow/processor", () => {
               active: false,
               valid: false,
               created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
@@ -400,7 +398,6 @@ describe("lib/marshal/workflow/processor", () => {
             active: false,
             valid: false,
             created_at: "2022-12-31T12:00:00.000000Z",
-            updated_at: "2022-12-31T12:00:00.000000Z",
           },
         };
 
@@ -498,7 +495,6 @@ describe("lib/marshal/workflow/processor", () => {
               active: false,
               valid: false,
               created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
@@ -610,7 +606,6 @@ describe("lib/marshal/workflow/processor", () => {
               active: false,
               valid: false,
               created_at: "2022-12-31T12:00:00.000000Z",
-              updated_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("email_1/settings/pre_content.txt")]: "{{ foo }}",

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -179,6 +179,7 @@ describe("lib/marshal/workflow/processor", () => {
       expect(workflowJson.valid).to.equal(undefined);
       expect(workflowJson.created_at).to.equal(undefined);
       expect(workflowJson.updated_at).to.equal(undefined);
+      expect(workflowJson.sha).to.equal(undefined);
 
       expect(workflowJson.__readonly).to.eql({
         key: "new-comment",

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -174,7 +174,6 @@ describe("lib/marshal/workflow/processor", () => {
 
       expect(workflowJson.key).to.equal(undefined);
       expect(workflowJson.active).to.equal(undefined);
-      expect(workflowJson.active).to.equal(undefined);
       expect(workflowJson.valid).to.equal(undefined);
       expect(workflowJson.created_at).to.equal(undefined);
       expect(workflowJson.updated_at).to.equal(undefined);

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -154,6 +154,7 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
   ],
   created_at: "2022-12-31T12:00:00.000000Z",
   updated_at: "2022-12-31T12:00:00.000000Z",
+  sha: "<SOME_SHA>",
   __annotation: {
     extractable_fields: {},
     readonly_fields: [
@@ -163,6 +164,7 @@ const remoteWorkflow: WorkflowData<WithAnnotation> = {
       "valid",
       "created_at",
       "updated_at",
+      "sha",
     ],
   },
 };


### PR DESCRIPTION
### Description

This PR updates the CLI so that when we store the serialized representations of resources, we remove the `sha` and `updated_at` properties from `__readonly`.

### Tasks

[KNO-8764](https://linear.app/knock/issue/KNO-8764/cli-remove-readonly-properties-from-serialized-resources)
