### PR TITLE
feat: add resource type and id filtering to commits

### DIFF
--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -26,15 +26,33 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
         "Show only promoted or unpromoted changes between the given environment and the subsequent environment.",
       allowNo: true,
     }),
+    "resource-type": Flags.string({
+      summary: "Filter commits by resource type. Must be used together with resource-id.",
+      options: ["email_layout", "guide", "message_type", "partial", "translation", "workflow"],
+    }),
+    "resource-id": Flags.string({
+      summary: "Filter commits by resource identifier. Must be used together with resource-type. For most resources, this will be the resource key. In the case of translations, this will be the locale code and namespace, separated by a /. For example, en/courses or en.",
+    }),
     ...pageFlags,
   };
 
   static enableJsonFlag = true;
 
   async run(): Promise<ApiV1.ListCommitResp | void> {
+    // Validate that resource-type and resource-id are used together
+    const { flags } = this.props;
+    const hasResourceType = Boolean(flags["resource-type"]);
+    const hasResourceId = Boolean(flags["resource-id"]);
+    
+    if (hasResourceType !== hasResourceId) {
+      this.error(
+        "The --resource-type and --resource-id flags must be used together. " +
+        "You cannot use one without the other."
+      );
+    }
+
     const resp = await this.request();
 
-    const { flags } = this.props;
     if (flags.json) return resp.data;
 
     this.render(resp.data);

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -27,11 +27,20 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       allowNo: true,
     }),
     "resource-type": Flags.string({
-      summary: "Filter commits by resource type. Must be used together with resource-id.",
-      options: ["email_layout", "guide", "message_type", "partial", "translation", "workflow"],
+      summary:
+        "Filter commits by resource type. Must be used together with resource-id.",
+      options: [
+        "email_layout",
+        "guide",
+        "message_type",
+        "partial",
+        "translation",
+        "workflow",
+      ],
     }),
     "resource-id": Flags.string({
-      summary: "Filter commits by resource identifier. Must be used together with resource-type. For most resources, this will be the resource key. In the case of translations, this will be the locale code and namespace, separated by a /. For example, en/courses or en.",
+      summary:
+        "Filter commits by resource identifier. Must be used together with resource-type. For most resources, this will be the resource key. In the case of translations, this will be the locale code and namespace, separated by a /. For example, en/courses or en.",
     }),
     ...pageFlags,
   };
@@ -43,11 +52,11 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
     const { flags } = this.props;
     const hasResourceType = Boolean(flags["resource-type"]);
     const hasResourceId = Boolean(flags["resource-id"]);
-    
+
     if (hasResourceType !== hasResourceId) {
       this.error(
         "The --resource-type and --resource-id flags must be used together. " +
-        "You cannot use one without the other."
+          "You cannot use one without the other.",
       );
     }
 

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -136,6 +136,8 @@ export default class ApiV1 {
     const params = prune({
       environment: flags.environment,
       promoted: flags.promoted,
+      resource_type: flags["resource-type"],
+      resource_id: flags["resource-id"],
       ...toPageParams(flags),
     });
 

--- a/test/commands/commit/list.test.ts
+++ b/test/commands/commit/list.test.ts
@@ -54,6 +54,10 @@ describe("commands/commit/list", () => {
         "--after",
         "xyz",
         "--json",
+        "--resource-type",
+        "email_layout",
+        "--resource-id",
+        "123",
       ])
       .it("calls apiV1 listCommits with correct props", () => {
         sinon.assert.calledWith(
@@ -68,6 +72,8 @@ describe("commands/commit/list", () => {
                 limit: 5,
                 after: "xyz",
                 json: true,
+                "resource-type": "email_layout",
+                "resource-id": "123",
               }),
           ),
         );
@@ -183,5 +189,21 @@ describe("commands/commit/list", () => {
           sinon.assert.calledOnce(KnockApiV1.prototype.listCommits as any);
         });
     });
+  });
+
+  describe("given a resource-type but not resource-id", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .command(["commit list", "--resource-type", "email_layout"])
+      .exit(2)
+      .it("exits with status 2");
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .command(["commit list", "--resource-id", "123"])
+      .exit(2)
+      .it("exits with status 2");
   });
 });


### PR DESCRIPTION
### Description

This PR introduces two new filtering parameters, `resource_type` and `resource_id`, to the `knock commit list` command.

**What:**
- Added `--resource-type` (enum: `email_layout`, `guide`, `message_type`, `partial`, `translation`, `workflow`) and `--resource-id` (string) flags to `src/commands/commit/list.ts`.
- Implemented validation to ensure both flags are used together; an error is thrown if only one is provided.
- Updated `src/lib/api-v1.ts` to pass these new parameters (`resource_type`, `resource_id`) to the `listCommits` API method.

**Why:**
- To enable users to filter the list of commits by a specific resource type and identifier, enhancing the command's utility for targeted commit inspection.

**How:**
- Flags were defined with appropriate types and descriptions in the command definition.
- A conditional check was added in the `run()` method to enforce the co-dependency of `resource_type` and `resource_id`.
- The API client was modified to include these new parameters in the request payload for the `listCommits` endpoint.

### Tasks
KNO-9201

