### PR TITLE
feat(kno-9713): add reusable step marshalling support to CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest && oclif readme",
     "test": "mocha \"test/**/*.test.ts\"",
-    "version": "oclif readme && git add README.md"
+    "version": "oclif readme && git add README.md",
+    "check": "yarn run lint && yarn run format.check && yarn run type.check"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/src/lib/marshal/index.isomorphic.ts
+++ b/src/lib/marshal/index.isomorphic.ts
@@ -5,5 +5,6 @@ export { buildEmailLayoutDirBundle } from "./email-layout/processor.isomorphic";
 export { buildGuideDirBundle } from "./guide/processor.isomorphic";
 export { buildMessageTypeDirBundle } from "./message-type/processor.isomorphic";
 export { buildPartialDirBundle } from "./partial/processor.isomorphic";
+export { buildReusableStepDirBundle } from "./reusable-step/processor.isomorphic";
 export { buildTranslationDirBundle } from "./translation/processor.isomorphic";
 export { buildWorkflowDirBundle } from "./workflow/processor.isomorphic";

--- a/src/lib/marshal/reusable-step/helpers.ts
+++ b/src/lib/marshal/reusable-step/helpers.ts
@@ -1,0 +1,30 @@
+import * as path from "node:path";
+
+import * as fs from "fs-extra";
+
+import { ReusableStepDirContext } from "@/lib/run-context";
+
+import { REUSABLE_STEP_JSON } from "./processor.isomorphic";
+
+export const reusableStepJsonPath = (
+  reusableStepDirCtx: ReusableStepDirContext,
+): string => path.resolve(reusableStepDirCtx.abspath, REUSABLE_STEP_JSON);
+
+/*
+ * Evaluates whether the given directory path is a reusable step directory, by
+ * checking for the presence of a `reusable-step.json` file.
+ */
+export const isReusableStepDir = async (dirPath: string): Promise<boolean> =>
+  Boolean(await lsReusableStepJson(dirPath));
+
+/*
+ * Check for `reusable-step.json` file and return the file path if present.
+ */
+export const lsReusableStepJson = async (
+  dirPath: string,
+): Promise<string | undefined> => {
+  const reusableStepJsonPath = path.resolve(dirPath, REUSABLE_STEP_JSON);
+
+  const exists = await fs.pathExists(reusableStepJsonPath);
+  return exists ? reusableStepJsonPath : undefined;
+};

--- a/src/lib/marshal/reusable-step/index.ts
+++ b/src/lib/marshal/reusable-step/index.ts
@@ -1,0 +1,2 @@
+export * from "./processor.isomorphic";
+export * from "./types";

--- a/src/lib/marshal/reusable-step/processor.isomorphic.ts
+++ b/src/lib/marshal/reusable-step/processor.isomorphic.ts
@@ -1,0 +1,122 @@
+/*
+ * IMPORTANT:
+ *
+ * This file is suffixed with `.isomorphic` because the code in this file is
+ * meant to run not just in a nodejs environment but also in a browser. For this
+ * reason there are some restrictions for which nodejs imports are allowed in
+ * this module. See `.eslintrc.json` for more details.
+ */
+import { cloneDeep, get, has, set, unset } from "lodash";
+
+import { AnyObj } from "@/lib/helpers/object.isomorphic";
+import { ObjKeyOrArrayIdx, ObjPath } from "@/lib/helpers/object.isomorphic";
+import { FILEPATH_MARKER } from "@/lib/marshal/shared/const.isomorphic";
+import { ExtractionSettings, WithAnnotation } from "@/lib/marshal/shared/types";
+
+import { prepareResourceJson } from "../shared/helpers.isomorphic";
+import { ReusableStepData } from "./types";
+
+export const REUSABLE_STEP_JSON = "reusable_step.json";
+
+export type ReusableStepDirBundle = {
+  [relpath: string]: string;
+};
+
+/*
+ * Traverse a given reusable step data and compile extraction settings of every
+ * extractable field into a sorted map.
+ *
+ * NOTE: Currently we do NOT support content extraction at nested levels for
+ * reusable steps.
+ */
+type CompiledExtractionSettings = Map<ObjKeyOrArrayIdx[], ExtractionSettings>;
+
+const compileExtractionSettings = (
+  reusableStep: ReusableStepData<WithAnnotation>,
+): CompiledExtractionSettings => {
+  const extractableFields = get(
+    reusableStep,
+    ["__annotation", "extractable_fields"],
+    {},
+  );
+  const map: CompiledExtractionSettings = new Map();
+
+  for (const key of Object.keys(reusableStep)) {
+    // If the field we are on is extractable, then add its extraction
+    // settings to the map with the current object path.
+    if (key in extractableFields) {
+      map.set([key], extractableFields[key]);
+    }
+  }
+
+  return map;
+};
+
+/*
+ * For a given reusable step payload, this function builds a "reusable step
+ * directory bundle". This is an object which contains all the relative paths and
+ * its file content. It includes the extractable fields, which are extracted out
+ * and added to the bundle as separate files.
+ */
+export const buildReusableStepDirBundle = (
+  remoteReusableStep: ReusableStepData<WithAnnotation>,
+  localReusableStep: AnyObj = {},
+): ReusableStepDirBundle => {
+  const bundle: ReusableStepDirBundle = {};
+  const mutRemoteReusableStep = cloneDeep(remoteReusableStep);
+  // A map of extraction settings of every field in the reusable step
+  const compiledExtractionSettings = compileExtractionSettings(
+    mutRemoteReusableStep,
+  );
+
+  // Iterate through each extractable field, determine whether we need to
+  // extract the field content, and if so, perform the extraction.
+  for (const [objPathParts, extractionSettings] of compiledExtractionSettings) {
+    // If this reusable step doesn't have this field path, then we don't extract.
+    if (!has(mutRemoteReusableStep, objPathParts)) continue;
+
+    // If the field at this path is extracted in the local reusable step, then
+    // always extract; otherwise extract based on the field settings default.
+    const objPathStr = ObjPath.stringify(objPathParts);
+
+    const extractedFilePath = get(
+      localReusableStep,
+      `${objPathStr}${FILEPATH_MARKER}`,
+    );
+
+    const { default: extractByDefault, file_ext: fileExt } = extractionSettings;
+
+    if (!extractedFilePath && !extractByDefault) continue;
+
+    // By this point, we have a field where we need to extract its content.
+    const data = get(mutRemoteReusableStep, objPathParts);
+    const fileName = objPathParts.pop();
+
+    // If we have an extracted file path from the local reusable step, we use that.
+    // In the other case we use the default path.
+    const relpath =
+      typeof extractedFilePath === "string"
+        ? extractedFilePath
+        : `${fileName}.${fileExt}`;
+
+    // Perform the extraction by adding the content and its file path to the
+    // bundle for writing to the file system later. Then replace the field
+    // content with the extracted file path and mark the field as extracted
+    // with @ suffix.
+    const content =
+      typeof data === "string" ? data : JSON.stringify(data, null, 2);
+
+    set(bundle, [relpath], content);
+    set(mutRemoteReusableStep, `${objPathStr}${FILEPATH_MARKER}`, relpath);
+    unset(mutRemoteReusableStep, objPathStr);
+  }
+
+  // At this point the bundle contains all extractable files, so we finally add
+  // the reusable step JSON relative path + the file content.
+
+  return set(
+    bundle,
+    [REUSABLE_STEP_JSON],
+    prepareResourceJson(mutRemoteReusableStep),
+  );
+};

--- a/src/lib/marshal/reusable-step/types.ts
+++ b/src/lib/marshal/reusable-step/types.ts
@@ -1,0 +1,17 @@
+import type { MaybeWithAnnotation } from "../shared/types";
+import type { HttpFetchStepData, StepType } from "../workflow/types";
+
+/**
+ * This only supports HttpFetch steps for now.
+ */
+export type ReusableStepData<A extends MaybeWithAnnotation = unknown> = A & {
+  key: string;
+  name: string;
+  environment: string;
+  /** The step content for this reusable step's current version. Currently only HttpFetch is supported. */
+  settings: HttpFetchStepData["settings"];
+  type: StepType.HttpFetch;
+  created_at: string;
+  updated_at: string;
+  sha: string;
+};

--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -7,6 +7,7 @@ import { EmailLayoutData } from "../email-layout";
 import { GuideData } from "../guide";
 import { MessageTypeData } from "../message-type";
 import { PartialData } from "../partial";
+import { ReusableStepData } from "../reusable-step";
 import { WorkflowData } from "../workflow";
 
 /*
@@ -19,7 +20,8 @@ type ResourceData<A extends WithAnnotation> =
   | PartialData<A>
   | WorkflowData<A>
   | MessageTypeData<A>
-  | GuideData<A>;
+  | GuideData<A>
+  | ReusableStepData<A>;
 
 // sha and updated_at fields change too frequently, so we exclude them from resource JSON files
 const REMOVED_READONLY_FIELDS = ["sha", "updated_at"];

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -8,8 +8,10 @@ import { validateLiquidSyntax } from "@/lib/helpers/liquid";
 import { VISUAL_BLOCKS_JSON } from "@/lib/marshal/workflow";
 import {
   EmailLayoutDirContext,
+  GuideDirContext,
   MessageTypeDirContext,
   PartialDirContext,
+  ReusableStepDirContext,
   WorkflowDirContext,
 } from "@/lib/run-context";
 
@@ -32,7 +34,9 @@ export const readExtractedFileSync = (
     | WorkflowDirContext
     | EmailLayoutDirContext
     | PartialDirContext
-    | MessageTypeDirContext,
+    | MessageTypeDirContext
+    | GuideDirContext
+    | ReusableStepDirContext,
   objPathToFieldStr = "",
 ): ReadExtractedFileResult => {
   // Check if the file actually exists at the given file path.

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -92,9 +92,11 @@ type HttpFetchStepSettings = {
   body?: string;
   headers?: KeyValueBlock[];
   query_params?: KeyValueBlock[];
+  response_path?: string;
+  signing_key?: string;
 };
 
-type HttpFetchStepData = WorkflowStepBase & {
+export type HttpFetchStepData = WorkflowStepBase & {
   type: StepType.HttpFetch;
   settings: HttpFetchStepSettings;
 };

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -3,7 +3,7 @@ import type { ResourceType } from "./run-context";
 // TODO Remove this once hidden option is removed from message types / guides
 export type NonHiddenResourceType = Exclude<
   ResourceType,
-  "message_type" | "guide"
+  "message_type" | "guide" | "reusable_step"
 >;
 
 /**

--- a/src/lib/run-context/types.ts
+++ b/src/lib/run-context/types.ts
@@ -22,7 +22,8 @@ export type ResourceType =
   | "translation"
   | "partial"
   | "message_type"
-  | "guide";
+  | "guide"
+  | "reusable_step";
 
 type ResourceDirContextBase = DirContext & {
   type: ResourceType;
@@ -53,13 +54,18 @@ export type GuideDirContext = ResourceDirContextBase & {
   type: "guide";
 };
 
+export type ReusableStepDirContext = ResourceDirContextBase & {
+  type: "reusable_step";
+};
+
 export type ResourceDirContext =
   | WorkflowDirContext
   | EmailLayoutDirContext
   | TranslationDirContext
   | PartialDirContext
   | MessageTypeDirContext
-  | GuideDirContext;
+  | GuideDirContext
+  | ReusableStepDirContext;
 
 export type ResourceTarget = {
   commandId: string;

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -53,7 +53,7 @@ const remoteMessageType: MessageTypeData<WithAnnotation> = {
   },
 };
 
-describe("lib/marshal/message-typel/processor", () => {
+describe("lib/marshal/message-type/processor", () => {
   describe("prepareResourceJson", () => {
     it("moves over message type's readonly fields under __readonly field", () => {
       const messageTypeJson = prepareResourceJson(remoteMessageType);

--- a/test/lib/marshal/reusable-step/processor.test.ts
+++ b/test/lib/marshal/reusable-step/processor.test.ts
@@ -1,0 +1,118 @@
+import { expect } from "chai";
+
+import { factory } from "@/../test/support";
+import {
+  buildReusableStepDirBundle,
+  ReusableStepData,
+} from "@/lib/marshal/reusable-step";
+import { prepareResourceJson } from "@/lib/marshal/shared/helpers.isomorphic";
+import { WithAnnotation } from "@/lib/marshal/shared/types";
+import { StepType } from "@/lib/marshal/workflow/types";
+
+const remoteReusableStep: ReusableStepData<WithAnnotation> = {
+  ...factory.reusableStep({
+    created_at: "2023-09-18T18:32:18.398053Z",
+    updated_at: "2023-10-02T19:24:48.714630Z",
+  }),
+  __annotation: {
+    extractable_fields: {},
+    readonly_fields: [
+      "key",
+      "environment",
+      "type",
+      "created_at",
+      "updated_at",
+      "sha",
+    ],
+  },
+};
+
+describe("lib/marshal/reusable-step/processor", () => {
+  describe("prepareResourceJson", () => {
+    it("moves over reusable step's readonly fields under __readonly field", () => {
+      const reusableStepJson = prepareResourceJson(remoteReusableStep);
+
+      expect(reusableStepJson.type).to.equal(undefined);
+      expect(reusableStepJson.created_at).to.equal(undefined);
+      expect(reusableStepJson.updated_at).to.equal(undefined);
+      expect(reusableStepJson.sha).to.equal(undefined);
+
+      expect(reusableStepJson.__readonly).to.eql({
+        type: StepType.HttpFetch,
+        created_at: "2023-09-18T18:32:18.398053Z",
+        key: "fetch-user-data",
+        environment: "development",
+      });
+    });
+
+    it("removes the __annotation field", () => {
+      const reusableStepJson = prepareResourceJson(remoteReusableStep);
+      expect(reusableStepJson.__annotation).to.equal(undefined);
+    });
+  });
+
+  describe("buildReusableStepDirBundle", () => {
+    describe("given a fetched reusable step that has not been pulled before", () => {
+      it("returns a dir bundle with reusable-step.json", () => {
+        const result = buildReusableStepDirBundle(remoteReusableStep);
+
+        expect(result).to.eql({
+          "reusable_step.json": {
+            name: "Fetch User Data",
+            settings: {
+              url: "https://api.example.com/users/{{ recipient.id }}",
+              method: "GET",
+              headers: [
+                { key: "Authorization", value: "Bearer {{ data.api_token }}" },
+                { key: "Content-Type", value: "application/json" },
+              ],
+            },
+            __readonly: {
+              key: "fetch-user-data",
+              environment: "development",
+              type: StepType.HttpFetch,
+              created_at: "2023-09-18T18:32:18.398053Z",
+            },
+          },
+        });
+      });
+    });
+
+    describe("given a fetched reusable step with a local version available", () => {
+      it("returns a dir bundle based on a local version", () => {
+        const localReusableStep = {
+          name: "Fetch User Data",
+          settings: {
+            url: "https://api.example.com/users/{{ recipient.id }}",
+            method: "GET",
+          },
+        };
+
+        const result = buildReusableStepDirBundle(
+          remoteReusableStep,
+          localReusableStep,
+        );
+
+        expect(result).to.eql({
+          "reusable_step.json": {
+            name: "Fetch User Data",
+            settings: {
+              url: "https://api.example.com/users/{{ recipient.id }}",
+              method: "GET",
+              headers: [
+                { key: "Authorization", value: "Bearer {{ data.api_token }}" },
+                { key: "Content-Type", value: "application/json" },
+              ],
+            },
+            __readonly: {
+              key: "fetch-user-data",
+              environment: "development",
+              type: StepType.HttpFetch,
+              created_at: "2023-09-18T18:32:18.398053Z",
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -11,6 +11,7 @@ import { EmailLayoutData } from "@/lib/marshal/email-layout";
 import { GuideData } from "@/lib/marshal/guide";
 import { MessageTypeData } from "@/lib/marshal/message-type";
 import { PartialData, PartialType } from "@/lib/marshal/partial";
+import { ReusableStepData } from "@/lib/marshal/reusable-step";
 import { TranslationData } from "@/lib/marshal/translation";
 import {
   ChannelStepData,
@@ -282,6 +283,29 @@ export const authenticatedSession = (
     idToken: "test-id-token",
     expiresAt: new Date(Date.now() + 3600 * 1000),
     clientId: "test-client-id",
+    ...attrs,
+  };
+};
+
+export const reusableStep = (
+  attrs: Partial<ReusableStepData> = {},
+): ReusableStepData => {
+  return {
+    key: "fetch-user-data",
+    name: "Fetch User Data",
+    environment: "development",
+    type: StepType.HttpFetch,
+    settings: {
+      url: "https://api.example.com/users/{{ recipient.id }}",
+      method: "GET",
+      headers: [
+        { key: "Authorization", value: "Bearer {{ data.api_token }}" },
+        { key: "Content-Type", value: "application/json" },
+      ],
+    },
+    created_at: "2022-12-31T12:00:00.000000Z",
+    updated_at: "2022-12-31T12:00:00.000000Z",
+    sha: "<SOME_SHA>",
     ...attrs,
   };
 };


### PR DESCRIPTION
### Description
Added support for reusable steps in the CLI. This implementation includes:

- Core functionality for reading, writing, and processing reusable step data
- Helpers for validating and managing reusable step directories
- Support for extracting and inlining content from reusable steps
- Integration with the existing marshal system

The implementation follows the same pattern as other resource types (workflows, partials, etc.) with specialized handlers for the reusable step structure. It includes the necessary types, processors, and utilities to manage reusable steps both individually and in bulk.

### Tasks
[KNO-1234](https://linear.app/knock/issue/KNO-1234/add-reusable-step-support-to-cli)