### PR TITLE
feat(KNO-9790): add branch delete command

### DIFF
--- a/src/commands/branch/delete.ts
+++ b/src/commands/branch/delete.ts
@@ -1,6 +1,7 @@
-import { Args, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 
 import BaseCommand from "@/lib/base-command";
+import { CustomArgs } from "@/lib/helpers/arg";
 import { withSpinnerV2 } from "@/lib/helpers/request";
 import { promptToConfirm } from "@/lib/helpers/ux";
 
@@ -11,8 +12,9 @@ export default class BranchDelete extends BaseCommand<typeof BranchDelete> {
   static summary = "Deletes an existing branch with the given slug.";
 
   static args = {
-    slug: Args.string({
+    slug: CustomArgs.slugArg({
       required: true,
+      description: "The slug of the branch to delete",
     }),
   };
 

--- a/test/commands/branch/delete.test.ts
+++ b/test/commands/branch/delete.test.ts
@@ -68,6 +68,30 @@ describe("commands/branch/delete", () => {
       );
   });
 
+  describe("given an argument containing mixed casing and whitespace", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockMgmt.prototype, "delete", (stub) => stub.resolves())
+      .command(["branch delete", " Mixed Case   With Whitespace ", "--force"])
+      .it("slugifies input before calling knockMgmt.delete", () => {
+        sinon.assert.calledWith(
+          KnockMgmt.prototype.delete as any,
+          "/v1/branches/mixed-case-with-whitespace",
+        );
+      });
+  });
+
+  describe("given an invalid branch slug", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .command(
+        // Attempts to pass in whitespace as the slug
+        ["branch delete", " "],
+      )
+      .catch(/Invalid slug provided/)
+      .it("throws an error");
+  });
+
   describe("given no service token", () => {
     test
       .command(["branch delete", "test-branch"])


### PR DESCRIPTION
### Description

This PR adds a new command `knock branch delete <slug>` that deletes a branch with the given slug.

This command will remain hidden until branching is released in GA.

### Tasks

[KNO-9790](https://linear.app/knock/issue/KNO-9790/cli-add-branch-delete-command)

### Screenshots

https://www.loom.com/share/9814eda1aad64c258b03ba36b85a7952?sid=94f80021-3ed6-4204-b1e3-51d3ab22148a
