### PR TITLE
chore(KNO-9917): add branch flag to partial commands

### DIFF
--- a/src/commands/partial/get.ts
+++ b/src/commands/partial/get.ts
@@ -2,8 +2,10 @@ import { Args, Flags, ux } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { formatDateTime } from "@/lib/helpers/date";
 import { ApiError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
 import { spinner } from "@/lib/helpers/ux";
 
@@ -15,6 +17,7 @@ export default class PartialGet extends BaseCommand<typeof PartialGet> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
@@ -64,9 +67,8 @@ export default class PartialGet extends BaseCommand<typeof PartialGet> {
     const qualifier =
       env === "development" && !commitedOnly ? "(including uncommitted)" : "";
 
-    this.log(
-      `‣ Showing partial \`${partialKey}\` in \`${env}\` environment ${qualifier}\n`,
-    );
+    const scope = formatCommandScope(this.props.flags);
+    this.log(`‣ Showing partial \`${partialKey}\` in ${scope} ${qualifier}\n`);
 
     /*
      * Partial table

--- a/src/commands/partial/list.ts
+++ b/src/commands/partial/list.ts
@@ -3,7 +3,9 @@ import { AxiosResponse } from "axios";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { formatDate } from "@/lib/helpers/date";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
 import {
   maybePromptPageAction,
@@ -20,6 +22,7 @@ export default class PartialList extends BaseCommand<typeof PartialList> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
@@ -55,9 +58,8 @@ export default class PartialList extends BaseCommand<typeof PartialList> {
     const qualifier =
       env === "development" && !committedOnly ? "(including uncommitted)" : "";
 
-    this.log(
-      `‣ Showing ${entries.length} partials in \`${env}\` environment ${qualifier}\n`,
-    );
+    const scope = formatCommandScope(this.props.flags);
+    this.log(`‣ Showing ${entries.length} partials in ${scope} ${qualifier}\n`);
 
     /*
      * Partials list table

--- a/src/commands/partial/pull.ts
+++ b/src/commands/partial/pull.ts
@@ -4,6 +4,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { ApiError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
@@ -90,8 +91,9 @@ export default class PartialPull extends BaseCommand<typeof PartialPull> {
     await Partial.writePartialDirFromData(dirContext, resp.data);
 
     const action = dirContext.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath}`,
+      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath} from ${scope}`,
     );
   }
 
@@ -117,8 +119,9 @@ export default class PartialPull extends BaseCommand<typeof PartialPull> {
     spinner.stop();
 
     const action = targetDirCtx.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} the partials directory at ${targetDirCtx.abspath}`,
+      `‣ Successfully ${action} the partials directory at ${targetDirCtx.abspath} from ${scope}`,
     );
   }
 

--- a/src/commands/partial/pull.ts
+++ b/src/commands/partial/pull.ts
@@ -31,6 +31,7 @@ export default class PartialPull extends BaseCommand<typeof PartialPull> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to pull all partials from the specified environment.",
     }),

--- a/src/commands/partial/pull.ts
+++ b/src/commands/partial/pull.ts
@@ -93,7 +93,7 @@ export default class PartialPull extends BaseCommand<typeof PartialPull> {
     const action = dirContext.exists ? "updated" : "created";
     const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath} from ${scope}`,
+      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath} using ${scope}`,
     );
   }
 
@@ -121,7 +121,7 @@ export default class PartialPull extends BaseCommand<typeof PartialPull> {
     const action = targetDirCtx.exists ? "updated" : "created";
     const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} the partials directory at ${targetDirCtx.abspath} from ${scope}`,
+      `‣ Successfully ${action} the partials directory at ${targetDirCtx.abspath} using ${scope}`,
     );
   }
 

--- a/src/commands/partial/push.ts
+++ b/src/commands/partial/push.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from "@oclif/core";
 
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -24,6 +25,7 @@ export default class PartialPush extends BaseCommand<typeof PartialPush> {
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to push all partials from the target directory.",
     }),
@@ -121,8 +123,9 @@ export default class PartialPush extends BaseCommand<typeof PartialPush> {
     const partialKeys = partials.map((l) => l.key);
     const actioned = flags.commit ? "pushed and committed" : "pushed";
 
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${actioned} ${partials.length} partial(s):\n` +
+      `‣ Successfully ${actioned} ${partials.length} partial(s) to ${scope}:\n` +
         indentString(partialKeys.join("\n"), 4),
     );
   }

--- a/src/commands/partial/validate.ts
+++ b/src/commands/partial/validate.ts
@@ -80,7 +80,7 @@ export default class PartialValidate extends BaseCommand<
     const partialKeys = partials.map((p) => p.key);
     const scope = formatCommandScope({ ...this.props.flags });
     this.log(
-      `‣ Successfully validated ${partials.length} partial(s) in ${scope}:\n` +
+      `‣ Successfully validated ${partials.length} partial(s) using ${scope}:\n` +
         indentString(partialKeys.join("\n"), 4),
     );
   }

--- a/src/commands/partial/validate.ts
+++ b/src/commands/partial/validate.ts
@@ -2,6 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand, { Props } from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -24,6 +25,7 @@ export default class PartialValidate extends BaseCommand<
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to validate all partials from the target directory.",
     }),
@@ -76,8 +78,9 @@ export default class PartialValidate extends BaseCommand<
 
     // 3. Display a success message.
     const partialKeys = partials.map((p) => p.key);
+    const scope = formatCommandScope({ ...this.props.flags });
     this.log(
-      `‣ Successfully validated ${partials.length} partial(s):\n` +
+      `‣ Successfully validated ${partials.length} partial(s) in ${scope}:\n` +
         indentString(partialKeys.join("\n"), 4),
     );
   }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -331,6 +331,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ListPartialResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
       annotate: flags.annotate,
       ...toPageParams(flags),
@@ -345,6 +346,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<GetPartialResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
     });
@@ -358,6 +360,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<UpsertPartialResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
@@ -373,6 +376,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<ValidatePartialResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
     });
     const data = { partial };
 

--- a/test/commands/partial/get.test.ts
+++ b/test/commands/partial/get.test.ts
@@ -93,6 +93,39 @@ describe("commands/partial/get", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getPartial", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.partial(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["partial get", "foo", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 getPartial with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getPartial as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                partialKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given a partial key that does not exist", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/partial/list.test.ts
+++ b/test/commands/partial/list.test.ts
@@ -72,6 +72,30 @@ describe("commands/partial/list", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listPartials", (stub) =>
+        stub.resolves(emptyPartialsListResp),
+      )
+      .stdout()
+      .command(["partial list", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 listPartials with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listPartials as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given a list of partials in response", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/partial/pull.test.ts
+++ b/test/commands/partial/pull.test.ts
@@ -139,6 +139,34 @@ describe("commands/partial/pull", () => {
       );
   });
 
+  describe("given a branch flag", () => {
+    setupWithGetPartialStub({ key: "partial-x" })
+      .stdout()
+      .command([
+        "partial pull",
+        "partial-x",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 getPartial with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getPartial as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                partialKey: "partial-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+                annotate: true,
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given both a partial key arg and a --all flag", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -134,6 +134,38 @@ describe("commands/partial/push", () => {
         );
       });
 
+    describe("given a branch flag", () => {
+      setupWithStub({ data: { partial: mockPartialData } })
+        .stdout()
+        .command([
+          "partial push",
+          "default",
+          "--branch",
+          "my-feature-branch-123",
+        ])
+        .it("calls apiV1 upsertPartial with expected params", () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.upsertPartial as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { partialKey: "default" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  branch: "my-feature-branch-123",
+                  annotate: true,
+                }),
+            ),
+            sinon.match((partial) =>
+              isEqual(partial, {
+                key: "default",
+                name: "Default",
+              }),
+            ),
+          );
+        });
+    });
+
     setupWithStub({ data: { partial: mockPartialData } })
       .stdout()
       .command(["partial push", "default"])

--- a/test/commands/partial/validate.test.ts
+++ b/test/commands/partial/validate.test.ts
@@ -61,6 +61,37 @@ describe("commands/partial/validate (a single partial)", () => {
           ),
         );
       });
+
+    describe("given a branch flag", () => {
+      setupWithStub()
+        .stdout()
+        .command([
+          "partial validate",
+          "default",
+          "--branch",
+          "my-feature-branch-123",
+        ])
+        .it("calls apiV1 validatePartial with expected params", () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.validatePartial as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { partialKey: "default" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  branch: "my-feature-branch-123",
+                }),
+            ),
+            sinon.match((partial) =>
+              isEqual(partial, {
+                key: "default",
+                name: "Default",
+              }),
+            ),
+          );
+        });
+    });
   });
 
   describe("given a partial.json file, with syntax errors", () => {


### PR DESCRIPTION
### Description

This PR adds an optional `--branch` flag to `knock partial` commands. This flag will remain hidden until we release branching to GA.

### Tasks

[KNO-9917](https://linear.app/knock/issue/KNO-9917/cli-add-branch-flag-to-partial-commands)
