### PR TITLE
chore(KNO-9916): add branch flag to message type commands

### DIFF
--- a/src/commands/message-type/get.ts
+++ b/src/commands/message-type/get.ts
@@ -2,8 +2,10 @@ import { Args, Flags, ux } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { formatDateTime } from "@/lib/helpers/date";
 import { ApiError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
 import { spinner } from "@/lib/helpers/ux";
 
@@ -18,6 +20,7 @@ export default class MessageTypeGet extends BaseCommand<typeof MessageTypeGet> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
@@ -67,8 +70,9 @@ export default class MessageTypeGet extends BaseCommand<typeof MessageTypeGet> {
     const qualifier =
       env === "development" && !commitedOnly ? "(including uncommitted)" : "";
 
+    const scope = formatCommandScope(this.props.flags);
     this.log(
-      `‣ Showing in-app message type \`${messageTypeKey}\` in \`${env}\` environment ${qualifier}\n`,
+      `‣ Showing in-app message type \`${messageTypeKey}\` in ${scope} ${qualifier}\n`,
     );
 
     /*

--- a/src/commands/message-type/list.ts
+++ b/src/commands/message-type/list.ts
@@ -3,7 +3,9 @@ import { AxiosResponse } from "axios";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { formatDate } from "@/lib/helpers/date";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
 import {
   maybePromptPageAction,
@@ -25,6 +27,7 @@ export default class MessageTypeList extends BaseCommand<
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
@@ -60,8 +63,9 @@ export default class MessageTypeList extends BaseCommand<
     const qualifier =
       env === "development" && !committedOnly ? "(including uncommitted)" : "";
 
+    const scope = formatCommandScope(this.props.flags);
     this.log(
-      `‣ Showing ${entries.length} in-app message types in \`${env}\` environment ${qualifier}\n`,
+      `‣ Showing ${entries.length} in-app message types in ${scope} ${qualifier}\n`,
     );
 
     /*

--- a/src/commands/message-type/pull.ts
+++ b/src/commands/message-type/pull.ts
@@ -4,6 +4,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { ApiError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
@@ -36,6 +37,7 @@ export default class MessageTypePull extends BaseCommand<
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary:
         "Whether to pull all in-app message types from the specified environment.",
@@ -103,8 +105,9 @@ export default class MessageTypePull extends BaseCommand<
     await MessageType.writeMessageTypeDirFromData(dirContext, resp.data);
 
     const action = dirContext.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath}`,
+      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath} using ${scope}`,
     );
   }
 
@@ -172,8 +175,9 @@ export default class MessageTypePull extends BaseCommand<
     spinner.stop();
 
     const action = targetDirCtx.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} the message types directory at ${targetDirCtx.abspath}`,
+      `‣ Successfully ${action} the message types directory at ${targetDirCtx.abspath} using ${scope}`,
     );
   }
 

--- a/src/commands/message-type/push.ts
+++ b/src/commands/message-type/push.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from "@oclif/core";
 
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -29,6 +30,7 @@ export default class MessageTypePush extends BaseCommand<
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to push all message types from the target directory.",
     }),
@@ -127,8 +129,9 @@ export default class MessageTypePush extends BaseCommand<
     const messageTypeKeys = messageTypes.map((w) => w.key);
     const actioned = flags.commit ? "pushed and committed" : "pushed";
 
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${actioned} ${messageTypes.length} message type(s):\n` +
+      `‣ Successfully ${actioned} ${messageTypes.length} message type(s) to ${scope}:\n` +
         indentString(messageTypeKeys.join("\n"), 4),
     );
   }

--- a/src/commands/message-type/validate.ts
+++ b/src/commands/message-type/validate.ts
@@ -2,6 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand, { Props } from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -28,6 +29,7 @@ export default class MessageTypeValidate extends BaseCommand<
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary:
         "Whether to validate all message types from the target directory.",
@@ -84,8 +86,9 @@ export default class MessageTypeValidate extends BaseCommand<
 
     // 3. Display a success message.
     const messageTypeKeys = messageTypes.map((w) => w.key);
+    const scope = formatCommandScope(this.props.flags);
     this.log(
-      `‣ Successfully validated ${messageTypes.length} message type(s):\n` +
+      `‣ Successfully validated ${messageTypes.length} message type(s) using ${scope}:\n` +
         indentString(messageTypeKeys.join("\n"), 4),
     );
   }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -396,6 +396,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ListMessageTypeResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
       annotate: flags.annotate,
       ...toPageParams(flags),
@@ -410,6 +411,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<GetMessageTypeResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
     });
@@ -423,6 +425,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<UpsertMessageTypeResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
@@ -438,6 +441,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<ValidateMessageTypeResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
     });
     const data = { message_type: messageType };
 

--- a/test/commands/message-type/get.test.ts
+++ b/test/commands/message-type/get.test.ts
@@ -52,6 +52,39 @@ describe("commands/message-type/get", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getMessageType", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.messageType(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["message-type get", "foo", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 getMessageType with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                messageTypeKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given a message type key arg, and flags", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/message-type/list.test.ts
+++ b/test/commands/message-type/list.test.ts
@@ -37,6 +37,30 @@ describe("commands/message-type/list", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listMessageTypes", (stub) =>
+        stub.resolves(emptyEntriesResp),
+      )
+      .stdout()
+      .command(["message-type list", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 listMessageTypes with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listMessageTypes as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given flags", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/message-type/pull.test.ts
+++ b/test/commands/message-type/pull.test.ts
@@ -93,6 +93,34 @@ describe("commands/message-type/pull", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    setupWithGetMessageTypeStub({ key: "modal" })
+      .stdout()
+      .command([
+        "message-type pull",
+        "modal",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 getMessageType with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getMessageType as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                messageTypeKey: "modal",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+                annotate: true,
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given a --all flag", () => {
     setupWithListMessageTypesStub({ key: "card" }, { key: "banner" })
       .stdout()

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -236,6 +236,53 @@ describe("commands/message-type/push", () => {
           });
         },
       );
+
+    describe("given a branch flag", () => {
+      setupWithStub({ data: { message_type: mockMessageTypeData } })
+        .stdout()
+        .command([
+          "message-type push",
+          "banner",
+          "--branch",
+          "my-feature-branch-123",
+        ])
+        .it("calls apiV1 upsertMessageType with expected params", () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.upsertMessageType as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { messageTypeKey: "banner" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  branch: "my-feature-branch-123",
+                  annotate: true,
+                }),
+            ),
+            sinon.match((messageType) =>
+              isEqual(messageType, {
+                key: "banner",
+                name: "Banner",
+                description: "My little banner",
+                variants: [
+                  {
+                    key: "default",
+                    name: "Default",
+                    fields: [
+                      {
+                        type: "text",
+                        key: "title",
+                        label: "Title",
+                      },
+                    ],
+                  },
+                ],
+                preview: "<div>{{ title }}</div>",
+              }),
+            ),
+          );
+        });
+    });
   });
 
   describe("given a message_type.json file with syntax errors", () => {

--- a/test/commands/message-type/validate.test.ts
+++ b/test/commands/message-type/validate.test.ts
@@ -62,6 +62,37 @@ describe("commands/message-type/validate (a single message type)", () => {
           ),
         );
       });
+
+    describe("given a branch flag", () => {
+      setupWithStub()
+        .stdout()
+        .command([
+          "message-type validate",
+          "card",
+          "--branch",
+          "my-feature-branch-123",
+        ])
+        .it("calls apiV1 validateMessageType with expected params", () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.validateMessageType as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { messageTypeKey: "card" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  branch: "my-feature-branch-123",
+                }),
+            ),
+            sinon.match((messageType) =>
+              isEqual(messageType, {
+                key: "card",
+                name: "Card",
+              }),
+            ),
+          );
+        });
+    });
   });
 
   describe("given a message_type.json file with syntax errors", () => {


### PR DESCRIPTION
### Description

This PR adds an optional `--branch` flag to `knock message-type` commands. This flag will remain hidden until we release branching to GA.

### Tasks

[KNO-9916](https://linear.app/knock/issue/KNO-9916/cli-add-branch-flag-to-message-type-commands)