### PR TITLE
chore(KNO-9919): add branch flag to workflow commands

### DIFF
--- a/src/commands/workflow/activate.ts
+++ b/src/commands/workflow/activate.ts
@@ -2,6 +2,8 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { booleanStr } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { promptToConfirm } from "@/lib/helpers/ux";
@@ -26,6 +28,7 @@ with \`false\` in order to deactivate it.
       required: true,
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     status: booleanStr({
       default: true,
       summary: "The workflow active status to set.",
@@ -46,7 +49,8 @@ with \`false\` in order to deactivate it.
 
     // 1. Confirm before activating or deactivating the workflow, unless forced.
     const action = flags.status ? "Activate" : "Deactivate";
-    const prompt = `${action} \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment?`;
+    const scope = formatCommandScope(flags);
+    const prompt = `${action} \`${args.workflowKey}\` workflow in ${scope}?`;
     const input = flags.force || (await promptToConfirm(prompt));
     if (!input) return;
 
@@ -61,7 +65,7 @@ with \`false\` in order to deactivate it.
 
     const actioned = flags.status ? "activated" : "deactivated";
     this.log(
-      `‣ Successfully ${actioned} \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment`,
+      `‣ Successfully ${actioned} \`${args.workflowKey}\` workflow in ${scope}`,
     );
   }
 }

--- a/src/commands/workflow/generate-types.ts
+++ b/src/commands/workflow/generate-types.ts
@@ -2,6 +2,7 @@ import { Flags } from "@oclif/core";
 import * as fs from "fs-extra";
 
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { ApiError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -24,6 +25,7 @@ export default class WorkflowGenerateTypes extends BaseCommand<
       summary: "Select the environment to generate types for.",
       default: KnockEnv.Development,
     }),
+    branch: CustomFlags.branch,
     "output-file": CustomFlags.filePath({
       summary:
         "The output file to write the generated types to. We currently support .ts, .rb, .go, .py files only. Your file extension will determine the target language for the generated types.",
@@ -70,8 +72,9 @@ export default class WorkflowGenerateTypes extends BaseCommand<
     // 3. Write the generated types to the output file.
     await fs.writeFile(flags["output-file"].abspath, result.lines.join("\n"));
 
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully generated types for ${workflowsWithValidTypes.length} workflow(s) and wrote them to ${flags["output-file"].abspath}`,
+      `‣ Successfully generated types for ${workflowsWithValidTypes.length} workflow(s) using ${scope} and wrote them to ${flags["output-file"].abspath}`,
     );
   }
 

--- a/src/commands/workflow/list.ts
+++ b/src/commands/workflow/list.ts
@@ -3,7 +3,9 @@ import { AxiosResponse } from "axios";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { formatDate } from "@/lib/helpers/date";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
 import {
   maybePromptPageAction,
@@ -21,6 +23,7 @@ export default class WorkflowList extends BaseCommand<typeof WorkflowList> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     "hide-uncommitted-changes": Flags.boolean({
       summary: "Hide any uncommitted changes.",
     }),
@@ -56,8 +59,9 @@ export default class WorkflowList extends BaseCommand<typeof WorkflowList> {
     const qualifier =
       env === "development" && !commitedOnly ? "(including uncommitted)" : "";
 
+    const scope = formatCommandScope(this.props.flags);
     this.log(
-      `‣ Showing ${entries.length} workflows in \`${env}\` environment ${qualifier}\n`,
+      `‣ Showing ${entries.length} workflows in ${scope} ${qualifier}\n`,
     );
 
     /*

--- a/src/commands/workflow/pull.ts
+++ b/src/commands/workflow/pull.ts
@@ -4,6 +4,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { ApiError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { merge } from "@/lib/helpers/object.isomorphic";
@@ -31,6 +32,7 @@ export default class WorkflowPull extends BaseCommand<typeof WorkflowPull> {
       default: "development",
       summary: "The environment to use.",
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to pull all workflows from the specified environment.",
     }),
@@ -98,8 +100,9 @@ export default class WorkflowPull extends BaseCommand<typeof WorkflowPull> {
     await Workflow.writeWorkflowDirFromData(dirContext, resp.data);
 
     const action = dirContext.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath}`,
+      `‣ Successfully ${action} \`${dirContext.key}\` at ${dirContext.abspath} using ${scope}`,
     );
   }
 
@@ -166,8 +169,9 @@ export default class WorkflowPull extends BaseCommand<typeof WorkflowPull> {
     spinner.stop();
 
     const action = targetDirCtx.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${action} the workflows directory at ${targetDirCtx.abspath}`,
+      `‣ Successfully ${action} the workflows directory at ${targetDirCtx.abspath} using ${scope}`,
     );
   }
 

--- a/src/commands/workflow/push.ts
+++ b/src/commands/workflow/push.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from "@oclif/core";
 
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -24,6 +25,7 @@ export default class WorkflowPush extends BaseCommand<typeof WorkflowPush> {
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to push all workflows from the target directory.",
     }),
@@ -117,8 +119,9 @@ export default class WorkflowPush extends BaseCommand<typeof WorkflowPush> {
     const workflowKeys = workflows.map((w) => w.key);
     const actioned = flags.commit ? "pushed and committed" : "pushed";
 
+    const scope = formatCommandScope(flags);
     this.log(
-      `‣ Successfully ${actioned} ${workflows.length} workflow(s):\n` +
+      `‣ Successfully ${actioned} ${workflows.length} workflow(s) to ${scope}:\n` +
         indentString(workflowKeys.join("\n"), 4),
     );
   }

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -2,6 +2,8 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { jsonStr, maybeJsonStr, maybeJsonStrAsList } from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
@@ -14,6 +16,7 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       default: "development",
       summary: "The environment in which to run the workflow",
     }),
+    branch: CustomFlags.branch,
     recipients: maybeJsonStrAsList({
       required: true,
       aliases: ["recipient"],
@@ -46,9 +49,8 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       { action: "‣ Running" },
     );
 
-    this.log(
-      `‣ Successfully ran \`${args.workflowKey}\` workflow in \`${flags.environment}\` environment`,
-    );
+    const scope = formatCommandScope(flags);
+    this.log(`‣ Successfully ran \`${args.workflowKey}\` workflow in ${scope}`);
     this.log(indentString(`Workflow run id: ${resp.data.workflow_run_id}`, 4));
   }
 }

--- a/src/commands/workflow/validate.ts
+++ b/src/commands/workflow/validate.ts
@@ -2,6 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand, { Props } from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
 import { formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
@@ -24,6 +25,7 @@ export default class WorkflowValidate extends BaseCommand<
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     all: Flags.boolean({
       summary: "Whether to validate all workflows from the target directory.",
     }),
@@ -76,8 +78,9 @@ export default class WorkflowValidate extends BaseCommand<
 
     // 3. Display a success message.
     const workflowKeys = workflows.map((w) => w.key);
+    const scope = formatCommandScope(this.props.flags);
     this.log(
-      `‣ Successfully validated ${workflows.length} workflow(s):\n` +
+      `‣ Successfully validated ${workflows.length} workflow(s) using ${scope}:\n` +
         indentString(workflowKeys.join("\n"), 4),
     );
   }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -78,6 +78,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ListWorkflowResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
       ...toPageParams(flags),
@@ -92,6 +93,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<GetWorkflowResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       hide_uncommitted_changes: flags["hide-uncommitted-changes"],
     });
@@ -105,6 +107,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<UpsertWorkflowResp<A>>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
@@ -120,6 +123,7 @@ export default class ApiV1 {
   ): Promise<AxiosResponse<ValidateWorkflowResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
     });
     const data = { workflow };
 
@@ -134,6 +138,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ActivateWorkflowResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       status: flags.status,
     });
 
@@ -146,6 +151,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<ActivateWorkflowResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
     });
     const data = prune({
       recipients: flags.recipients,

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -7,3 +7,11 @@ export const authSuccessUrl = (dashboardUrl: string): string =>
 
 export const authErrorUrl = (dashboardUrl: string, error: string): string =>
   `${dashboardUrl}/auth/oauth/cli?error=${error}`;
+
+export const viewWorkflowUrl = (
+  dashboardUrl: string,
+  accountSlug: string,
+  envOrBranchSlug: string,
+  workflowKey: string,
+): string =>
+  `${dashboardUrl}/${accountSlug}/${envOrBranchSlug.toLowerCase()}/workflows/${workflowKey}`;

--- a/test/commands/workflow/activate.test.ts
+++ b/test/commands/workflow/activate.test.ts
@@ -87,4 +87,34 @@ describe("commands/workflow/activate", () => {
         );
       });
   });
+
+  describe("given a branch flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow activate",
+        "workflow-x",
+        "--environment",
+        "staging",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 activateWorkflow with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.activateWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "staging",
+                branch: "my-feature-branch-123",
+                status: true,
+              }),
+          ),
+        );
+      });
+  });
 });

--- a/test/commands/workflow/get.test.ts
+++ b/test/commands/workflow/get.test.ts
@@ -93,6 +93,39 @@ describe("commands/workflow/get", () => {
       });
   });
 
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "whoami", (stub) =>
+        stub.resolves(factory.resp({ data: whoami })),
+      )
+      .stub(KnockApiV1.prototype, "getWorkflow", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.workflow(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["workflow get", "foo", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 getWorkflow with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given a workflow key that does not exist", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/workflow/list.test.ts
+++ b/test/commands/workflow/list.test.ts
@@ -187,4 +187,28 @@ describe("commands/workflow/list", () => {
         });
     });
   });
+
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listWorkflows", (stub) =>
+        stub.resolves(emptyWorkflowsListResp),
+      )
+      .stdout()
+      .command(["workflow list", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 listWorkflows with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listWorkflows as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+              }),
+          ),
+        );
+      });
+  });
 });

--- a/test/commands/workflow/pull.test.ts
+++ b/test/commands/workflow/pull.test.ts
@@ -139,6 +139,34 @@ describe("commands/workflow/pull", () => {
       );
   });
 
+  describe("given a branch flag", () => {
+    setupWithGetWorkflowStub({ key: "workflow-x" })
+      .stdout()
+      .command([
+        "workflow pull",
+        "workflow-x",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 getWorkflow with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+                annotate: true,
+              }),
+          ),
+        );
+      });
+  });
+
   describe("given both a workflow key arg and a --all flag", () => {
     test
       .env({ KNOCK_SERVICE_TOKEN: "valid-token" })

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -306,4 +306,34 @@ describe("commands/workflow/push", () => {
         );
       });
   });
+
+  describe("given a branch flag", () => {
+    beforeEach(() => {
+      const abspath = path.resolve(sandboxDir, "foo/workflow.json");
+      fs.outputJsonSync(abspath, { name: "Foo", key: "foo" });
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub({ data: { workflow: mockWorkflowData } })
+      .stdout()
+      .command(["workflow push", "foo", "--branch", "my-feature-branch-123"])
+      .it("calls apiV1 upsertWorkflow with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.upsertWorkflow as any,
+          sinon.match(({ args, flags }) => {
+            return (
+              args.workflowKey === "foo" &&
+              flags["service-token"] === "valid-token" &&
+              flags.environment === "development" &&
+              flags.branch === "my-feature-branch-123" &&
+              flags.annotate === true
+            );
+          }),
+          sinon.match(
+            (workflow) => workflow.key === "foo" && workflow.name === "Foo",
+          ),
+        );
+      });
+  });
 });

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -281,4 +281,34 @@ describe("commands/workflow/run", () => {
         },
       );
   });
+
+  describe("given a branch flag", () => {
+    setupWithStub({ data: { workflow: factory.workflow() } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--recipients",
+        "alice",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 runWorkflow with expected params", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.runWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                branch: "my-feature-branch-123",
+                recipients: ["alice"],
+              }),
+          ),
+        );
+      });
+  });
 });


### PR DESCRIPTION
### Description

This PR adds an optional `--branch` flag to `knock workflow` commands. This flag will remain hidden until we release branching to GA.

### Tasks

[KNO-9919](https://linear.app/knock/issue/KNO-9919/cli-add-branch-flag-to-workflow-commands)