### PR TITLE
chore(KNO-9938): add branch flag to commit command

### DIFF
--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -31,9 +31,11 @@ export default class Commit extends BaseCommand<typeof Commit> {
   async run(): Promise<void> {
     const { flags } = this.props;
 
+    const scope = formatCommandScope(flags);
+
     // Confirm first as we are about to commit changes to go live in the
     // development environment, unless forced.
-    const prompt = "Commit all changes in the development environment?";
+    const prompt = `Commit all changes in the ${scope}?`;
     const input = flags.force || (await promptToConfirm(prompt));
     if (!input) return;
 
@@ -41,7 +43,6 @@ export default class Commit extends BaseCommand<typeof Commit> {
       this.apiV1.commitAllChanges(this.props),
     );
 
-    const scope = formatCommandScope(flags);
     this.log(`‣ Successfully committed all changes in ${scope}`);
   }
 }

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -2,7 +2,9 @@ import { Flags } from "@oclif/core";
 
 import * as ApiV1 from "@/lib/api-v1";
 import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
 import { KnockEnv } from "@/lib/helpers/const";
+import * as CustomFlags from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { promptToConfirm } from "@/lib/helpers/ux";
 
@@ -16,6 +18,7 @@ export default class Commit extends BaseCommand<typeof Commit> {
       default: KnockEnv.Development,
       options: [KnockEnv.Development],
     }),
+    branch: CustomFlags.branch,
     "commit-message": Flags.string({
       summary: "Use the given value as the commit message.",
       char: "m",
@@ -38,8 +41,7 @@ export default class Commit extends BaseCommand<typeof Commit> {
       this.apiV1.commitAllChanges(this.props),
     );
 
-    this.log(
-      `‣ Successfully committed all changes in \`${flags.environment}\` environment`,
-    );
+    const scope = formatCommandScope(flags);
+    this.log(`‣ Successfully committed all changes in ${scope}`);
   }
 }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -182,6 +182,7 @@ export default class ApiV1 {
   }: Props): Promise<AxiosResponse<CommitAllChangesResp>> {
     const params = prune({
       environment: flags.environment,
+      branch: flags.branch,
       commit_message: flags["commit-message"],
     });
 

--- a/test/commands/commit/index.test.ts
+++ b/test/commands/commit/index.test.ts
@@ -29,4 +29,36 @@ describe("commands/commit/index", () => {
         ),
       );
     });
+
+  describe("given a branch flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "commitAllChanges", (stub) =>
+        stub.resolves(factory.resp({ data: "success" })),
+      )
+      .stub(enquirer.prototype, "prompt", (stub) =>
+        stub.onFirstCall().resolves({ input: "y" }),
+      )
+      .stdout()
+      .command([
+        "commit",
+        "-m",
+        "commit all the changes!",
+        "--branch",
+        "my-feature-branch-123",
+      ])
+      .it("calls apiV1 commitAllChanges with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.commitAllChanges as any,
+          sinon.match(({ flags }) =>
+            isEqual(flags, {
+              "service-token": "valid-token",
+              environment: "development",
+              branch: "my-feature-branch-123",
+              "commit-message": "commit all the changes!",
+            }),
+          ),
+        );
+      });
+  });
 });


### PR DESCRIPTION
### Description

This PR adds an optional `--branch` flag to the `knock commit` command. This flag will remain hidden until we release branching to GA.

### Tasks

[KNO-9938](https://linear.app/knock/issue/KNO-9938/cli-add-branch-flag-to-commit-command)