### PR TITLE
chore(build): add "-h" to additionalHelpFlags

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "bin": "knock",
     "dirname": "knock",
     "commands": "./dist/commands",
+    "additionalHelpFlags": ["-h"],
     "plugins": [
       "@oclif/plugin-help"
     ],


### PR DESCRIPTION
This adds `-h` to the `additionalHelpFlags configuration for `oclif`.

### Description
Minor UX enhancement 🙏🏼, please feel free to disregard. 
I reflexively try `-h` on a new CLI and noticed it wasn't supported

### Todos
** List any todo items necessary before merging, if any. Delete if none. **
- [ ] Sample todo item 1
- [ ] Sample todo item 2

### Tasks
** Link to task(s) or issue(s) which this PR corresponds to. Example: [KNO-54](https://linear.app/knock/issue/KNO-54/create-a-pr-template) **

### Screenshots
** Attach any screenshots or recordings to visually illustrate the changes, as necessary. Delete if not relevant. **
