### PR TITLE
feat: exclude environment and created_at from serialized __readonly fields

### DIFF
--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -25,8 +25,13 @@ type ResourceData<A extends WithAnnotation> =
   | GuideData<A>
   | ReusableStepData<A>;
 
-// sha and updated_at fields change too frequently, so we exclude them from resource JSON files
-const REMOVED_READONLY_FIELDS = ["sha", "updated_at"];
+// Volatile fields that change per-branch or over time, excluded to avoid noisy diffs
+const REMOVED_READONLY_FIELDS = [
+  "sha",
+  "updated_at",
+  "environment",
+  "created_at",
+];
 
 export const prepareResourceJson = (
   resource: ResourceData<WithAnnotation>,

--- a/test/commands/audience/push.test.ts
+++ b/test/commands/audience/push.test.ts
@@ -164,8 +164,6 @@ describe("commands/audience/push", () => {
           description: "This is a default audience",
           __readonly: {
             key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         });
       });

--- a/test/commands/layout/push.test.ts
+++ b/test/commands/layout/push.test.ts
@@ -199,8 +199,6 @@ describe("commands/layout/push", () => {
           "text_layout@": "text_layout.txt",
           __readonly: {
             key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         });
       });

--- a/test/commands/message-type/push.test.ts
+++ b/test/commands/message-type/push.test.ts
@@ -270,9 +270,7 @@ describe("commands/message-type/push", () => {
               key: "banner",
               valid: true,
               owner: "user",
-              environment: "development",
               semver: "0.0.1",
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           });
         },

--- a/test/commands/partial/push.test.ts
+++ b/test/commands/partial/push.test.ts
@@ -209,8 +209,6 @@ describe("commands/partial/push", () => {
             valid: true,
             type: "html",
             key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         });
       });

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -166,7 +166,6 @@ describe("commands/workflow/push", () => {
             key: "new-comment",
             active: false,
             valid: false,
-            created_at: "2022-12-31T12:00:00.000000Z",
           },
         });
       });

--- a/test/lib/marshal/email-layout/processor.test.ts
+++ b/test/lib/marshal/email-layout/processor.test.ts
@@ -39,8 +39,6 @@ describe("lib/marshal/layout/processor", () => {
 
       expect(emailLayoutJson.__readonly).to.eql({
         key: "default",
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
       });
     });
 
@@ -64,8 +62,6 @@ describe("lib/marshal/layout/processor", () => {
           "text_layout@": "text_layout.txt",
           __readonly: {
             key: "default",
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         },
       });
@@ -95,8 +91,6 @@ describe("lib/marshal/layout/processor", () => {
             "text_layout@": "text_layout.txt",
             __readonly: {
               key: "default",
-              environment: "development",
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           },
         });

--- a/test/lib/marshal/guide/processor.test.ts
+++ b/test/lib/marshal/guide/processor.test.ts
@@ -62,8 +62,6 @@ describe("lib/marshal/guide/processor", () => {
         key: "success-banner",
         active: true,
         valid: true,
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
       });
     });
 
@@ -102,8 +100,6 @@ describe("lib/marshal/guide/processor", () => {
             key: "success-banner",
             valid: true,
             active: true,
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         },
       });

--- a/test/lib/marshal/message-type/processor.test.ts
+++ b/test/lib/marshal/message-type/processor.test.ts
@@ -71,9 +71,7 @@ describe("lib/marshal/message-type/processor", () => {
         key: "banner",
         valid: true,
         owner: "user",
-        environment: "development",
         semver: "0.0.1",
-        created_at: "2023-09-18T18:32:18.398053Z",
       });
     });
 
@@ -114,9 +112,7 @@ describe("lib/marshal/message-type/processor", () => {
             key: "banner",
             valid: true,
             owner: "user",
-            environment: "development",
             semver: "0.0.1",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         },
       });
@@ -161,9 +157,7 @@ describe("lib/marshal/message-type/processor", () => {
               key: "banner",
               valid: true,
               owner: "user",
-              environment: "development",
               semver: "0.0.1",
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           },
         });

--- a/test/lib/marshal/partial/processor.test.ts
+++ b/test/lib/marshal/partial/processor.test.ts
@@ -53,8 +53,6 @@ describe("lib/marshal/partial/processor", () => {
         key: "default",
         valid: true,
         type: PartialType.Html,
-        environment: "development",
-        created_at: "2023-09-18T18:32:18.398053Z",
       });
     });
 
@@ -79,8 +77,6 @@ describe("lib/marshal/partial/processor", () => {
             key: "default",
             valid: true,
             type: PartialType.Html,
-            environment: "development",
-            created_at: "2023-09-18T18:32:18.398053Z",
           },
         },
       });
@@ -107,8 +103,6 @@ describe("lib/marshal/partial/processor", () => {
               key: "default",
               valid: true,
               type: PartialType.Html,
-              environment: "development",
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           },
         });

--- a/test/lib/marshal/reusable-step/processor.test.ts
+++ b/test/lib/marshal/reusable-step/processor.test.ts
@@ -39,9 +39,7 @@ describe("lib/marshal/reusable-step/processor", () => {
 
       expect(reusableStepJson.__readonly).to.eql({
         type: StepType.HttpFetch,
-        created_at: "2023-09-18T18:32:18.398053Z",
         key: "fetch-user-data",
-        environment: "development",
       });
     });
 
@@ -69,9 +67,7 @@ describe("lib/marshal/reusable-step/processor", () => {
             },
             __readonly: {
               key: "fetch-user-data",
-              environment: "development",
               type: StepType.HttpFetch,
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           },
         });
@@ -106,9 +102,7 @@ describe("lib/marshal/reusable-step/processor", () => {
             },
             __readonly: {
               key: "fetch-user-data",
-              environment: "development",
               type: StepType.HttpFetch,
-              created_at: "2023-09-18T18:32:18.398053Z",
             },
           },
         });

--- a/test/lib/marshal/workflow/processor.test.ts
+++ b/test/lib/marshal/workflow/processor.test.ts
@@ -185,7 +185,6 @@ describe("lib/marshal/workflow/processor", () => {
         key: "new-comment",
         active: false,
         valid: false,
-        created_at: "2022-12-31T12:00:00.000000Z",
       });
     });
 
@@ -361,7 +360,6 @@ describe("lib/marshal/workflow/processor", () => {
               key: "new-comment",
               active: false,
               valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
@@ -399,7 +397,6 @@ describe("lib/marshal/workflow/processor", () => {
             key: "new-comment",
             active: false,
             valid: false,
-            created_at: "2022-12-31T12:00:00.000000Z",
           },
         };
 
@@ -496,7 +493,6 @@ describe("lib/marshal/workflow/processor", () => {
               key: "new-comment",
               active: false,
               valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("sms_1/text_body.txt")]: "Hi {{ recipient.name }}.",
@@ -607,7 +603,6 @@ describe("lib/marshal/workflow/processor", () => {
               key: "new-comment",
               active: false,
               valid: false,
-              created_at: "2022-12-31T12:00:00.000000Z",
             },
           },
           [xpath("email_1/settings/pre_content.txt")]: "{{ foo }}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When pulling resources while on a branch, the `__readonly` block in every serialized resource file was being updated with branch-specific `environment` values (the branch name instead of `"development"`) and fresh `created_at` timestamps. This caused every resource file to appear changed in Git diffs, making PRs noisy and hard to review.

**Root cause:** `REMOVED_READONLY_FIELDS` in `src/lib/marshal/shared/helpers.isomorphic.ts` only excluded `sha` and `updated_at`, but `environment` and `created_at` are equally volatile.

**Fix:** Added `"environment"` and `"created_at"` to `REMOVED_READONLY_FIELDS`, consistent with the earlier removal of `sha` and `updated_at`.

Updated all affected tests across:
- 6 marshal processor tests (`email-layout`, `partial`, `guide`, `message-type`, `workflow`, `reusable-step`)
- 5 push command tests (`audience`, `layout`, `message-type`, `partial`, `workflow`)

All 771 tests pass. Lint, format, and type checks pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-12498](https://linear.app/knock/issue/KNO-12498/cli-readonly-fields-cause-noisy-diffs-when-pulling-on-branches)

<div><a href="https://cursor.com/agents/bc-91b5dcae-0eeb-467c-ba6e-3363d7029aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b5dcae-0eeb-467c-ba6e-3363d7029aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

