### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g @knocklabs/cli
 $ knock COMMAND
 running command...
 $ knock (--version)
-@knocklabs/cli/1.0.5 darwin-arm64 node-v24.13.0
+@knocklabs/cli/1.1.0 darwin-arm64 node-v24.13.0
 $ knock --help [COMMAND]
 USAGE
   $ knock COMMAND
@@ -125,7 +125,7 @@ DESCRIPTION
   Use this command with caution.
 ```
 
-_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/archive.ts)_
+_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/archive.ts)_
 
 ## `knock audience get AUDIENCEKEY`
 
@@ -146,7 +146,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/get.ts)_
+_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/get.ts)_
 
 ## `knock audience list`
 
@@ -170,7 +170,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/list.ts)_
+_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/list.ts)_
 
 ## `knock audience new`
 
@@ -195,7 +195,7 @@ FLAGS
       --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/new.ts)_
+_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/new.ts)_
 
 ## `knock audience open AUDIENCEKEY`
 
@@ -211,7 +211,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/open.ts)_
+_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/open.ts)_
 
 ## `knock audience pull [AUDIENCEKEY]`
 
@@ -232,7 +232,7 @@ FLAGS
   --service-token=<value>     [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/pull.ts)_
+_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/pull.ts)_
 
 ## `knock audience push [AUDIENCEKEY]`
 
@@ -256,7 +256,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/push.ts)_
+_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/push.ts)_
 
 ## `knock audience validate [AUDIENCEKEY]`
 
@@ -276,7 +276,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/audience/validate.ts)_
+_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/audience/validate.ts)_
 
 ## `knock branch create [SLUG]`
 
@@ -296,7 +296,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/create.ts)_
+_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/create.ts)_
 
 ## `knock branch delete SLUG`
 
@@ -314,7 +314,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/delete.ts)_
+_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/delete.ts)_
 
 ## `knock branch exit`
 
@@ -328,7 +328,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/exit.ts)_
+_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/exit.ts)_
 
 ## `knock branch list`
 
@@ -348,7 +348,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/list.ts)_
+_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/list.ts)_
 
 ## `knock branch merge SLUG`
 
@@ -367,7 +367,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/merge.ts)_
+_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/merge.ts)_
 
 ## `knock branch switch SLUG`
 
@@ -386,7 +386,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/branch/switch.ts)_
+_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/branch/switch.ts)_
 
 ## `knock channel list`
 
@@ -403,7 +403,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/channel/list.ts)_
+_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/channel/list.ts)_
 
 ## `knock commit`
 
@@ -429,7 +429,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/commit/index.ts)_
+_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/commit/index.ts)_
 
 ## `knock commit get ID`
 
@@ -446,7 +446,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/commit/get.ts)_
+_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/commit/get.ts)_
 
 ## `knock commit list`
 
@@ -478,7 +478,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/commit/list.ts)_
+_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/commit/list.ts)_
 
 ## `knock commit promote`
 
@@ -495,7 +495,7 @@ FLAGS
   --to=<value>             The destination environment to promote all changes from the preceding environment.
 ```
 
-_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/commit/promote.ts)_
+_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/commit/promote.ts)_
 
 ## `knock environment list`
 
@@ -512,7 +512,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/environment/list.ts)_
+_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/environment/list.ts)_
 
 ## `knock guide activate GUIDEKEY`
 
@@ -543,7 +543,7 @@ DESCRIPTION
   or deactivated at a later time using the --from and --until flags.
 ```
 
-_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/activate.ts)_
+_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/activate.ts)_
 
 ## `knock guide generate-types`
 
@@ -566,7 +566,7 @@ DESCRIPTION
   Generate types for all guides in an environment and write them to a file.
 ```
 
-_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/generate-types.ts)_
+_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/generate-types.ts)_
 
 ## `knock guide get GUIDEKEY`
 
@@ -587,7 +587,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/get.ts)_
+_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/get.ts)_
 
 ## `knock guide list`
 
@@ -611,7 +611,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/list.ts)_
+_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/list.ts)_
 
 ## `knock guide new`
 
@@ -635,7 +635,7 @@ FLAGS
       --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/new.ts)_
+_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/new.ts)_
 
 ## `knock guide open GUIDEKEY`
 
@@ -651,7 +651,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/open.ts)_
+_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/open.ts)_
 
 ## `knock guide pull [GUIDEKEY]`
 
@@ -672,7 +672,7 @@ FLAGS
   --service-token=<value>     [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/pull.ts)_
+_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/pull.ts)_
 
 ## `knock guide push [GUIDEKEY]`
 
@@ -696,7 +696,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/push.ts)_
+_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/push.ts)_
 
 ## `knock guide validate [GUIDEKEY]`
 
@@ -715,7 +715,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/guide/validate.ts)_
+_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/guide/validate.ts)_
 
 ## `knock help [COMMAND]`
 
@@ -735,7 +735,7 @@ DESCRIPTION
   Display help for knock.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.41/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.44/src/commands/help.ts)_
 
 ## `knock init`
 
@@ -755,7 +755,7 @@ DESCRIPTION
   resources directory.
 ```
 
-_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/init.ts)_
 
 ## `knock layout get EMAILLAYOUTKEY`
 
@@ -776,7 +776,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/get.ts)_
+_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/get.ts)_
 
 ## `knock layout list`
 
@@ -800,7 +800,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/list.ts)_
+_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/list.ts)_
 
 ## `knock layout new`
 
@@ -823,7 +823,7 @@ FLAGS
       --template=<value>       The template to use for the email layout. Should be `email-layouts/{key}`.
 ```
 
-_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/new.ts)_
+_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/new.ts)_
 
 ## `knock layout open LAYOUTKEY`
 
@@ -839,7 +839,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/open.ts)_
+_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/open.ts)_
 
 ## `knock layout pull [EMAILLAYOUTKEY]`
 
@@ -860,7 +860,7 @@ FLAGS
   --service-token=<value>     [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/pull.ts)_
+_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/pull.ts)_
 
 ## `knock layout push [EMAILLAYOUTKEY]`
 
@@ -886,7 +886,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/push.ts)_
+_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/push.ts)_
 
 ## `knock layout validate [EMAILLAYOUTKEY]`
 
@@ -906,7 +906,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/layout/validate.ts)_
+_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/layout/validate.ts)_
 
 ## `knock login`
 
@@ -920,7 +920,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/login.ts)_
 
 ## `knock logout`
 
@@ -934,7 +934,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/logout.ts)_
 
 ## `knock message-type get MESSAGETYPEKEY`
 
@@ -955,7 +955,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/get.ts)_
+_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/get.ts)_
 
 ## `knock message-type list`
 
@@ -979,7 +979,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/list.ts)_
+_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/list.ts)_
 
 ## `knock message-type new`
 
@@ -1002,7 +1002,7 @@ FLAGS
       --template=<value>       The template to use for the message type. Should be `message-types/{key}`.
 ```
 
-_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/new.ts)_
+_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/new.ts)_
 
 ## `knock message-type open MESSAGETYPEKEY`
 
@@ -1018,7 +1018,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/open.ts)_
+_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/open.ts)_
 
 ## `knock message-type pull [MESSAGETYPEKEY]`
 
@@ -1039,7 +1039,7 @@ FLAGS
   --service-token=<value>      [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/pull.ts)_
+_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/pull.ts)_
 
 ## `knock message-type push [MESSAGETYPEKEY]`
 
@@ -1065,7 +1065,7 @@ FLAGS
       --service-token=<value>      [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/push.ts)_
+_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/push.ts)_
 
 ## `knock message-type validate [MESSAGETYPEKEY]`
 
@@ -1086,7 +1086,7 @@ FLAGS
   --service-token=<value>      [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/message-type/validate.ts)_
+_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/message-type/validate.ts)_
 
 ## `knock partial get PARTIALKEY`
 
@@ -1107,7 +1107,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/get.ts)_
+_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/get.ts)_
 
 ## `knock partial list`
 
@@ -1131,7 +1131,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/list.ts)_
+_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/list.ts)_
 
 ## `knock partial new`
 
@@ -1157,7 +1157,7 @@ FLAGS
                                with --type.
 ```
 
-_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/new.ts)_
+_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/new.ts)_
 
 ## `knock partial open PARTIALKEY`
 
@@ -1173,7 +1173,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/open.ts)_
+_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/open.ts)_
 
 ## `knock partial pull [PARTIALKEY]`
 
@@ -1194,7 +1194,7 @@ FLAGS
   --service-token=<value>     [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/pull.ts)_
+_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/pull.ts)_
 
 ## `knock partial push [PARTIALKEY]`
 
@@ -1219,7 +1219,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/push.ts)_
+_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/push.ts)_
 
 ## `knock partial validate [PARTIALKEY]`
 
@@ -1239,7 +1239,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/partial/validate.ts)_
+_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/partial/validate.ts)_
 
 ## `knock pull`
 
@@ -1259,7 +1259,7 @@ FLAGS
   --service-token=<value>     [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/pull.ts)_
+_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/pull.ts)_
 
 ## `knock push`
 
@@ -1283,7 +1283,7 @@ FLAGS
       --service-token=<value>   [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/push.ts)_
 
 ## `knock translation get TRANSLATIONREF`
 
@@ -1311,7 +1311,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/translation/get.ts)_
+_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/translation/get.ts)_
 
 ## `knock translation list`
 
@@ -1335,7 +1335,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/translation/list.ts)_
+_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/translation/list.ts)_
 
 ## `knock translation pull [TRANSLATIONREF]`
 
@@ -1363,7 +1363,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to pull all translations into.
 ```
 
-_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/translation/pull.ts)_
+_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/translation/pull.ts)_
 
 ## `knock translation push [TRANSLATIONREF]`
 
@@ -1394,7 +1394,7 @@ FLAGS
       --translations-dir=<value>  The target directory path to find all translations to push.
 ```
 
-_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/translation/push.ts)_
+_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/translation/push.ts)_
 
 ## `knock translation validate [TRANSLATIONREF]`
 
@@ -1420,7 +1420,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to find all translations to validate.
 ```
 
-_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/translation/validate.ts)_
+_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/translation/validate.ts)_
 
 ## `knock whoami`
 
@@ -1437,7 +1437,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/whoami.ts)_
 
 ## `knock workflow activate WORKFLOWKEY`
 
@@ -1466,7 +1466,7 @@ DESCRIPTION
   with `false` in order to deactivate it.
 ```
 
-_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/activate.ts)_
+_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/activate.ts)_
 
 ## `knock workflow generate-types`
 
@@ -1489,7 +1489,7 @@ DESCRIPTION
   Generate types for all workflows in an environment and write them to a file.
 ```
 
-_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/generate-types.ts)_
+_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/generate-types.ts)_
 
 ## `knock workflow get WORKFLOWKEY`
 
@@ -1510,7 +1510,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/get.ts)_
+_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/get.ts)_
 
 ## `knock workflow list`
 
@@ -1534,7 +1534,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/list.ts)_
+_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/list.ts)_
 
 ## `knock workflow new`
 
@@ -1559,7 +1559,7 @@ FLAGS
       --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/new.ts)_
+_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/new.ts)_
 
 ## `knock workflow open WORKFLOWKEY`
 
@@ -1575,7 +1575,7 @@ FLAGS
   --service-token=<value>  [env: KNOCK_SERVICE_TOKEN] The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/open.ts)_
+_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/open.ts)_
 
 ## `knock workflow pull [WORKFLOWKEY]`
 
@@ -1596,7 +1596,7 @@ FLAGS
   --workflows-dir=<value>     The target directory path to pull all workflows into.
 ```
 
-_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/pull.ts)_
+_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/pull.ts)_
 
 ## `knock workflow push [WORKFLOWKEY]`
 
@@ -1620,7 +1620,7 @@ FLAGS
       --workflows-dir=<value>   The target directory path to find all workflows to push.
 ```
 
-_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/push.ts)_
+_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/push.ts)_
 
 ## `knock workflow run WORKFLOWKEY`
 
@@ -1642,7 +1642,7 @@ FLAGS
   --tenant=<value>         A tenant id for the workflow run.
 ```
 
-_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/run.ts)_
+_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/run.ts)_
 
 ## `knock workflow validate [WORKFLOWKEY]`
 
@@ -1661,5 +1661,5 @@ FLAGS
   --workflows-dir=<value>  The target directory path to find all workflows to validate.
 ```
 
-_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.0.5/src/commands/workflow/validate.ts)_
+_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.0/src/commands/workflow/validate.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/cli",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Knock CLI",
   "author": "@knocklabs",
   "bin": {


### PR DESCRIPTION
Release version bump to **v1.1.0** (minor).

Made with [Cursor](https://cursor.com)