### PR TITLE
fix: strip volatile fields from audience root when not annotated as readonly

### DIFF
--- a/src/lib/marshal/shared/helpers.isomorphic.ts
+++ b/src/lib/marshal/shared/helpers.isomorphic.ts
@@ -41,9 +41,15 @@ export const prepareResourceJson = (
   const [readonly, remainder] = split(resource, readonlyFields);
 
   const filteredReadonlyFields = omit(readonly, REMOVED_READONLY_FIELDS);
+  // Also strip volatile fields from the remainder, since some resources (e.g.
+  // audiences) return these fields without annotating them as readonly.
+  const filteredRemainder = omit(remainder, REMOVED_READONLY_FIELDS);
 
   // Move remaining read only fields under the dedicated field "__readonly".
-  const resourceJson = { ...remainder, __readonly: filteredReadonlyFields };
+  const resourceJson = {
+    ...filteredRemainder,
+    __readonly: filteredReadonlyFields,
+  };
 
   // Append the $schema property to the resource JSON if it is provided.
   if ($schema) {


### PR DESCRIPTION
## Summary

Follow-up to #762. That PR excluded `environment` and `created_at` from the serialized `__readonly` block to stop noisy diffs when pulling on a branch — but audiences still ended up with `environment` and `created_at` at the **root** of `audience.json`, so the diffs remained noisy for that resource type.

## Root cause

The real bug is server-side: the audience API response's `__annotation.readonly_fields` does not include `environment` or `created_at` (unlike workflows, partials, layouts, message types, guides, and reusable steps, which do annotate these as readonly). In `prepareResourceJson`, fields not listed in `readonly_fields` bypass the split and remain at the top level of the serialized JSON.

PR #762's filter only stripped `REMOVED_READONLY_FIELDS` from the `readonly` half of the split — the `remainder` half was untouched. For audiences, `environment`/`created_at` land in `remainder` and survive as top-level keys.

**The audience API response should annotate these fields as readonly, matching other resource types.** That's the proper fix and should be tracked separately. This PR is a CLI-side defensive patch so users aren't blocked by noisy diffs in the meantime.

## Fix

In `src/lib/marshal/shared/helpers.isomorphic.ts`, also `omit` `REMOVED_READONLY_FIELDS` from the `remainder` before assembling the resource JSON. This guarantees `sha`, `updated_at`, `environment`, `created_at` are stripped regardless of whether the server annotates them as readonly.

## Tests

Added `test/lib/marshal/audience/processor.test.ts` with a regression test that simulates the actual audience API response (only `key` annotated as readonly) and asserts the volatile fields are still stripped from the root.

All 777 tests pass. Lint and typecheck clean.

## Test plan

- [x] Existing audience tests pass
- [x] New regression test covers the unannotated-readonly case
- [x] Full suite green
- [x] `yarn check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)