### PR TITLE
feat(mapi): add OpenAPI loader, resolver, request/curl/render libs

### DIFF
--- a/src/lib/mapi/curl-generator.ts
+++ b/src/lib/mapi/curl-generator.ts
@@ -1,0 +1,78 @@
+import type { HttpMethod } from "./types";
+
+export type CurlRequest = {
+  method: HttpMethod;
+  url: string;
+  /** Full URL including origin (for curl). */
+  absoluteUrl: string;
+  params: Record<string, unknown>;
+  data?: unknown;
+  headers: Record<string, string>;
+};
+
+function escapeShellSingleQuotes(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((k) => k.toLowerCase() === "authorization");
+}
+
+function buildQueryString(params: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        parts.push(
+          `${encodeURIComponent(k)}=${encodeURIComponent(String(item))}`,
+        );
+      }
+    } else {
+      parts.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+    }
+  }
+
+  return parts.length > 0 ? `?${parts.join("&")}` : "";
+}
+
+/**
+ * Generate a curl command using `$KNOCK_SERVICE_TOKEN` as the bearer placeholder.
+ */
+export function generateCurl(req: CurlRequest): string {
+  const qs = buildQueryString(req.params);
+  const urlWithQs = escapeShellSingleQuotes(`${req.absoluteUrl}${qs}`);
+
+  const parts: string[] = [
+    "curl",
+    "-sS",
+    "-X",
+    req.method.toUpperCase(),
+    urlWithQs,
+  ];
+
+  if (!hasAuthorizationHeader(req.headers)) {
+    parts.push(
+      "-H",
+      escapeShellSingleQuotes("Authorization: Bearer $KNOCK_SERVICE_TOKEN"),
+    );
+  }
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    parts.push("-H", escapeShellSingleQuotes(`${name}: ${value}`));
+  }
+
+  if (req.data !== undefined) {
+    if (!req.headers["Content-Type"] && !req.headers["content-type"]) {
+      parts.push(
+        "-H",
+        escapeShellSingleQuotes("Content-Type: application/json"),
+      );
+    }
+
+    const json = JSON.stringify(req.data);
+    parts.push("-d", escapeShellSingleQuotes(json));
+  }
+
+  return parts.join(" ");
+}

--- a/src/lib/mapi/endpoint-resolver.ts
+++ b/src/lib/mapi/endpoint-resolver.ts
@@ -1,0 +1,357 @@
+import type {
+  Endpoint,
+  HttpMethod,
+  OpenApiDocument,
+  OpenApiOperationObject,
+  OpenApiParameterObject,
+  OpenApiPathItemObject,
+  OpenApiSchemaObject,
+  ParamSpec,
+  ResolvedBodySchema,
+} from "./types";
+
+const HTTP_METHODS: HttpMethod[] = ["get", "put", "post", "delete", "patch"];
+
+function resolveRef(
+  doc: OpenApiDocument,
+  ref: string,
+): OpenApiSchemaObject | undefined {
+  if (!ref.startsWith("#/")) return undefined;
+  const parts = ref.slice(2).split("/");
+  let cur: unknown = doc as unknown as Record<string, unknown>;
+  for (const p of parts) {
+    if (cur && typeof cur === "object" && p in cur) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return undefined;
+    }
+  }
+
+  return cur as OpenApiSchemaObject;
+}
+
+function resolveSchema(
+  doc: OpenApiDocument,
+  schema?: OpenApiSchemaObject,
+  depth = 0,
+): OpenApiSchemaObject | undefined {
+  if (!schema || depth > 20) return schema;
+  if (schema.$ref) {
+    const resolved = resolveRef(doc, schema.$ref);
+    return resolveSchema(doc, resolved, depth + 1);
+  }
+
+  if (schema.allOf?.length === 1) {
+    return resolveSchema(doc, schema.allOf[0], depth + 1);
+  }
+
+  return schema;
+}
+
+function schemaToBodyResolved(
+  doc: OpenApiDocument,
+  schema?: OpenApiSchemaObject,
+): ResolvedBodySchema | undefined {
+  const s = resolveSchema(doc, schema);
+  if (!s || s.type !== "object" || !s.properties) {
+    // Some request bodies use allOf merged objects; shallow merge first allOf
+    if (s?.allOf?.length) {
+      const merged: ResolvedBodySchema = {
+        required: [],
+        properties: {},
+        description: s.description,
+      };
+      for (const part of s.allOf) {
+        const r = schemaToBodyResolved(doc, part);
+        if (r) {
+          Object.assign(merged.properties, r.properties);
+          merged.required.push(...r.required);
+          merged.description = merged.description ?? r.description;
+        }
+      }
+
+      if (Object.keys(merged.properties).length > 0) return merged;
+    }
+
+    return undefined;
+  }
+
+  return {
+    description: s.description,
+    required: s.required ?? [],
+    properties: s.properties,
+  };
+}
+
+function normalizeParam(
+  doc: OpenApiDocument,
+  p: OpenApiParameterObject,
+): ParamSpec | undefined {
+  if (p.in !== "path" && p.in !== "query") return undefined;
+  return {
+    name: p.name,
+    in: p.in,
+    required: Boolean(p.required),
+    description: p.description,
+    schema: p.schema ? resolveSchema(doc, p.schema) : undefined,
+  };
+}
+
+function collectParameters(
+  doc: OpenApiDocument,
+  pathItem: OpenApiPathItemObject,
+  op: OpenApiOperationObject,
+): { pathParams: ParamSpec[]; queryParams: ParamSpec[] } {
+  const pathParams: ParamSpec[] = [];
+  const queryParams: ParamSpec[] = [];
+  const rawParams = [
+    ...((pathItem.parameters as OpenApiParameterObject[] | undefined) ?? []),
+    ...(op.parameters ?? []),
+  ];
+  const seen = new Set<string>();
+  for (const raw of rawParams) {
+    let p = raw as OpenApiParameterObject & { $ref?: string };
+    if (p.$ref) {
+      const ref = p.$ref;
+      const resolved = resolveRef(doc, ref) as
+        | OpenApiParameterObject
+        | undefined;
+      if (!resolved) continue;
+      p = resolved;
+    }
+
+    const spec = normalizeParam(doc, p);
+    if (!spec) continue;
+    const dedupeKey = `${spec.in}:${spec.name}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    if (spec.in === "path") pathParams.push(spec);
+    else queryParams.push(spec);
+  }
+
+  return { pathParams, queryParams };
+}
+
+function operationBodySchema(
+  doc: OpenApiDocument,
+  op: OpenApiOperationObject,
+): ResolvedBodySchema | undefined {
+  const body = op.requestBody;
+  if (!body?.content) return undefined;
+  const json = body.content["application/json"];
+  if (!json?.schema) return undefined;
+  return schemaToBodyResolved(doc, json.schema);
+}
+
+function operationIdFor(
+  op: OpenApiOperationObject,
+  method: HttpMethod,
+  path: string,
+): string {
+  if (op.operationId) return op.operationId;
+  const seg = path.replace(/^\//, "").replace(/[{}]/g, "").replace(/\//g, "_");
+  return `${method}_${seg}`;
+}
+
+/**
+ * Flatten OpenAPI paths into a list of endpoints.
+ */
+export function listEndpoints(doc: OpenApiDocument): Endpoint[] {
+  const paths = doc.paths ?? {};
+  const out: Endpoint[] = [];
+  for (const [pathKey, pathItem] of Object.entries(paths)) {
+    if (!pathItem) continue;
+    for (const method of HTTP_METHODS) {
+      const op = pathItem[method] as OpenApiOperationObject | undefined;
+      if (!op) continue;
+      const { pathParams, queryParams } = collectParameters(doc, pathItem, op);
+      out.push({
+        method,
+        path: pathKey.startsWith("/") ? pathKey : `/${pathKey}`,
+        operationId: operationIdFor(op, method, pathKey),
+        summary: op.summary ?? op.operationId ?? pathKey,
+        description: op.description,
+        tags: op.tags ?? [],
+        pathParams,
+        queryParams,
+        bodySchema: operationBodySchema(doc, op),
+      });
+    }
+  }
+
+  return out;
+}
+
+/** Ensure path starts with /v1 */
+export function normalizeEndpointPath(input: string): string {
+  let p = input.trim();
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p === "/v1" || p.startsWith("/v1/")) return p;
+  // "/whoami" -> "/v1/whoami"
+  return `/v1${p}`;
+}
+
+function pathTemplateSegments(template: string): string[] {
+  return template.replace(/\/$/, "").split("/").filter(Boolean);
+}
+
+function decodePathSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
+function matchPathTemplate(
+  template: string,
+  concrete: string,
+): Record<string, string> | undefined {
+  const tSeg = pathTemplateSegments(template);
+  const cSeg = pathTemplateSegments(concrete);
+  if (tSeg.length !== cSeg.length) return undefined;
+  const params: Record<string, string> = {};
+  for (const [i, element] of tSeg.entries()) {
+    const ts = element!;
+    const cs = cSeg[i]!;
+    if (ts.startsWith("{") && ts.endsWith("}")) {
+      const decoded = decodePathSegment(cs);
+      if (decoded === undefined) return undefined;
+      params[ts.slice(1, -1)] = decoded;
+    } else if (ts !== cs) {
+      return undefined;
+    }
+  }
+
+  return params;
+}
+
+export function findEndpointsByOperationId(
+  endpoints: Endpoint[],
+  operationId: string,
+): Endpoint[] {
+  const exact = endpoints.filter((e) => e.operationId === operationId);
+  if (exact.length > 0) return exact;
+  const lower = operationId.toLowerCase();
+  return endpoints.filter((e) => e.operationId.toLowerCase() === lower);
+}
+
+export function findEndpointsByPathAndMethod(
+  endpoints: Endpoint[],
+  userPath: string,
+  method?: HttpMethod,
+): Endpoint[] {
+  const normalized = normalizeEndpointPath(userPath);
+  const matches: Endpoint[] = [];
+  for (const e of endpoints) {
+    if (method && e.method !== method) continue;
+    if (e.path === normalized) {
+      matches.push(e);
+      continue;
+    }
+
+    const m = matchPathTemplate(e.path, normalized);
+    if (m) matches.push(e);
+  }
+
+  return matches;
+}
+
+export type ResolveEndpointResult =
+  | { ok: true; endpoint: Endpoint; pathParamValues: Record<string, string> }
+  | { ok: false; reason: "ambiguous"; candidates: Endpoint[] }
+  | { ok: false; reason: "not_found"; message: string };
+
+/**
+ * Resolve user token (operationId or URL path) to a single endpoint.
+ */
+export function resolveEndpoint(
+  doc: OpenApiDocument,
+  token: string,
+  method?: HttpMethod,
+): ResolveEndpointResult {
+  const endpoints = listEndpoints(doc);
+  const trimmed = token.trim();
+
+  if (!trimmed.includes("/")) {
+    const byId = findEndpointsByOperationId(endpoints, trimmed);
+    if (byId.length === 1) {
+      return {
+        ok: true,
+        endpoint: byId[0]!,
+        pathParamValues: {},
+      };
+    }
+
+    if (byId.length > 1) {
+      return { ok: false, reason: "ambiguous", candidates: byId };
+    }
+  }
+
+  const normalized = normalizeEndpointPath(trimmed);
+  const byPath = findEndpointsByPathAndMethod(endpoints, normalized, method);
+  if (byPath.length === 1) {
+    const endpoint = byPath[0]!;
+    const values =
+      endpoint.path === normalized
+        ? {}
+        : matchPathTemplate(endpoint.path, normalized) ?? {};
+    return { ok: true, endpoint, pathParamValues: values };
+  }
+
+  if (byPath.length > 1) {
+    return { ok: false, reason: "ambiguous", candidates: byPath };
+  }
+
+  if (!trimmed.includes("/")) {
+    return {
+      ok: false,
+      reason: "not_found",
+      message: `Unknown operationId or path: ${trimmed}`,
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "not_found",
+    message: `No operation matches path ${normalized}${
+      method ? ` with method ${method.toUpperCase()}` : ""
+    }`,
+  };
+}
+
+/** Short endpoint listing for help text (from cached OpenAPI). */
+export function formatEndpointsHelpLines(
+  endpoints: Endpoint[],
+  maxLines = 40,
+): string {
+  const byTag = new Map<string, Endpoint[]>();
+  for (const e of endpoints) {
+    const tag = e.tags[0] ?? "Other";
+    if (!byTag.has(tag)) byTag.set(tag, []);
+    byTag.get(tag)!.push(e);
+  }
+
+  const lines: string[] = [
+    "ENDPOINTS (from cached OpenAPI; run `knock mapi ls` for the authoritative list):",
+  ];
+  let count = 0;
+  for (const [tag, eps] of [...byTag.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    lines.push(`  [${tag}]`);
+    for (const e of eps.sort((a, b) => a.path.localeCompare(b.path))) {
+      if (count >= maxLines) {
+        lines.push("  … (truncated; run `knock mapi ls` for the full list)");
+        return lines.join("\n");
+      }
+
+      lines.push(
+        `    ${e.method.toUpperCase().padEnd(6)} ${e.path}  ${e.operationId}`,
+      );
+      count++;
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/mapi/interactive.ts
+++ b/src/lib/mapi/interactive.ts
@@ -1,0 +1,104 @@
+import enquirer from "enquirer";
+
+import { listEndpoints } from "./endpoint-resolver";
+import type { Endpoint, FieldInput, OpenApiDocument } from "./types";
+
+function endpointKey(e: Endpoint): string {
+  return `${e.method.toUpperCase()} ${e.path}`;
+}
+
+export type InteractiveResult = {
+  endpoint: Endpoint;
+  fields: FieldInput[];
+};
+
+/**
+ * Interactive picker: choose an endpoint, then prompt for required path/query params.
+ */
+export async function runInteractiveMapi(
+  doc: OpenApiDocument,
+): Promise<InteractiveResult | undefined> {
+  const endpoints = listEndpoints(doc).sort((a, b) => {
+    const pa = `${a.method} ${a.path}`;
+    const pb = `${b.method} ${b.path}`;
+    return pa.localeCompare(pb);
+  });
+
+  const byKey = new Map<string, Endpoint>();
+  for (const e of endpoints) {
+    byKey.set(endpointKey(e), e);
+  }
+
+  let picked: Endpoint;
+  try {
+    const ans = await enquirer.prompt<{ ep: string }>({
+      type: "autocomplete",
+      name: "ep",
+      message: "Select a Management API endpoint",
+      choices: endpoints.map((e) => ({
+        name: `${e.method.toUpperCase().padEnd(6)} ${e.path} — ${e.summary}`,
+        value: endpointKey(e),
+      })),
+      limit: 15,
+      // enquirer autocomplete supports `limit`; types are incomplete
+    } as never);
+    picked = byKey.get(ans.ep)!;
+    if (!picked) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  const fields: FieldInput[] = [];
+
+  for (const p of picked.pathParams) {
+    const initial = "";
+    try {
+      // Sequential prompts; order matters.
+      // eslint-disable-next-line no-await-in-loop
+      const ans = await enquirer.prompt<{ v: string }>({
+        type: "input",
+        name: "v",
+        message: `Path param ${p.name}${
+          p.description ? ` (${p.description})` : ""
+        }`,
+        initial,
+        validate: (v) => (v.trim().length > 0 ? true : "Required"),
+      });
+      fields.push({ key: p.name, value: ans.v.trim(), raw: false });
+    } catch {
+      return undefined;
+    }
+  }
+
+  for (const q of picked.queryParams) {
+    if (!q.required) continue;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const ans = await enquirer.prompt<{ v: string }>({
+        type: "input",
+        name: "v",
+        message: `Query param ${q.name}${
+          q.description ? ` (${q.description})` : ""
+        }`,
+        validate: (v) => (v.trim().length > 0 ? true : "Required"),
+      });
+      fields.push({ key: q.name, value: ans.v.trim(), raw: false });
+    } catch {
+      return undefined;
+    }
+  }
+
+  try {
+    const go = await enquirer.prompt<{ ok: boolean }>({
+      type: "confirm",
+      name: "ok",
+      message: `Send ${picked.method.toUpperCase()} ${picked.path}?`,
+      initial: true,
+    });
+    if (!go.ok) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  return { endpoint: picked, fields };
+}

--- a/src/lib/mapi/openapi-loader.ts
+++ b/src/lib/mapi/openapi-loader.ts
@@ -1,0 +1,145 @@
+import * as path from "node:path";
+
+import axios from "axios";
+import * as fsExtra from "fs-extra";
+
+import { isTestEnv } from "@/lib/helpers/const";
+import { openApiSpecUrl } from "@/lib/urls";
+
+import type { CachedOpenApiDocument, OpenApiDocument } from "./types";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function cacheFileName(apiOrigin: string): string {
+  const safe = Buffer.from(apiOrigin, "utf8")
+    .toString("base64url")
+    .replace(/=/g, "");
+  return `mapi-openapi-${safe}.json`;
+}
+
+function cachePath(cacheDir: string, apiOrigin: string): string {
+  return path.join(cacheDir, cacheFileName(apiOrigin));
+}
+
+export type LoadOpenApiOptions = {
+  apiOrigin: string;
+  cacheDir: string;
+  refresh: boolean;
+  /** If set, called when network fetch fails but stale cache is used. */
+  onStaleCache?: (message: string) => void;
+};
+
+export type LoadOpenApiResult = {
+  spec: OpenApiDocument;
+  fromCache: boolean;
+  stale?: boolean;
+};
+
+async function fetchSpec(apiOrigin: string): Promise<OpenApiDocument> {
+  const url = openApiSpecUrl(apiOrigin);
+  const resp = await axios.get<OpenApiDocument>(url, {
+    timeout: 60_000,
+    validateStatus: (s) => s === 200,
+    headers: { Accept: "application/json" },
+  });
+  return resp.data;
+}
+
+async function readFreshCache(
+  file: string,
+  apiOrigin: string,
+): Promise<OpenApiDocument | undefined> {
+  try {
+    if (!(await fsExtra.pathExists(file))) return undefined;
+    const cached = (await fsExtra.readJSON(file)) as CachedOpenApiDocument;
+    const valid =
+      cached?.spec && cached?.fetchedAt && cached?.apiOrigin === apiOrigin;
+    if (!valid) return undefined;
+    const age = Date.now() - new Date(cached.fetchedAt).getTime();
+    if (age < 0 || age >= CACHE_TTL_MS) return undefined;
+    return cached.spec;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readStaleCache(
+  file: string,
+  apiOrigin: string,
+): Promise<OpenApiDocument | undefined> {
+  try {
+    if (!(await fsExtra.pathExists(file))) return undefined;
+    const cached = (await fsExtra.readJSON(file)) as CachedOpenApiDocument;
+    if (cached?.spec && cached?.apiOrigin === apiOrigin) return cached.spec;
+  } catch {
+    /* ignore */
+  }
+
+  return undefined;
+}
+
+/**
+ * Read a previously cached OpenAPI document from disk (for help text). No TTL check.
+ */
+export function readCachedOpenApiForHelp(
+  cacheDir: string,
+  apiOrigin: string,
+): OpenApiDocument | undefined {
+  try {
+    const file = cachePath(cacheDir, apiOrigin);
+    if (!fsExtra.pathExistsSync(file)) return undefined;
+    const cached = fsExtra.readJSONSync(file) as CachedOpenApiDocument;
+    if (cached?.spec && cached?.apiOrigin === apiOrigin) return cached.spec;
+  } catch {
+    /* ignore */
+  }
+
+  return undefined;
+}
+
+/**
+ * Load OpenAPI spec from cache and/or network.
+ * In test env, skips reading/writing the on-disk cache; each run fetches the spec over the
+ * network (use nock in tests).
+ */
+export async function loadOpenApiDocument(
+  opts: LoadOpenApiOptions,
+): Promise<LoadOpenApiResult> {
+  const { apiOrigin, cacheDir, refresh, onStaleCache } = opts;
+  const file = cachePath(cacheDir, apiOrigin);
+
+  if (!isTestEnv && !refresh) {
+    const fresh = await readFreshCache(file, apiOrigin);
+    if (fresh) return { spec: fresh, fromCache: true };
+  }
+
+  try {
+    const spec = await fetchSpec(apiOrigin);
+    if (!isTestEnv) {
+      await fsExtra.ensureDir(cacheDir);
+      const payload: CachedOpenApiDocument = {
+        fetchedAt: new Date().toISOString(),
+        apiOrigin,
+        spec,
+      };
+      await fsExtra.writeJSON(file, payload, { spaces: 0 });
+    }
+
+    return { spec, fromCache: false };
+  } catch (error) {
+    if (!isTestEnv && !refresh) {
+      const staleSpec = await readStaleCache(file, apiOrigin);
+      if (staleSpec) {
+        onStaleCache?.(
+          "Could not refresh OpenAPI spec; using cached copy. Try again with --refresh.",
+        );
+        return { spec: staleSpec, fromCache: true, stale: true };
+      }
+    }
+
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to load OpenAPI spec from ${openApiSpecUrl(apiOrigin)}: ${msg}`,
+    );
+  }
+}

--- a/src/lib/mapi/request-builder.ts
+++ b/src/lib/mapi/request-builder.ts
@@ -1,0 +1,204 @@
+import * as fs from "fs-extra";
+
+import { parseJson, tryJsonParse } from "@/lib/helpers/json";
+
+import type { Endpoint, FieldInput, HttpMethod } from "./types";
+
+export type { FieldInput };
+
+/** Warn once per repeated `key` (CLI order: last value wins). */
+export function warnOnDuplicateFieldKeys(
+  fields: FieldInput[],
+  warn: (message: string) => void,
+): void {
+  const seen = new Set<string>();
+  for (const f of fields) {
+    if (seen.has(f.key)) {
+      warn(`Duplicate field key "${f.key}"; last value wins.`);
+    }
+
+    seen.add(f.key);
+  }
+}
+
+export type BuiltRequest = {
+  method: HttpMethod;
+  url: string;
+  params: Record<string, unknown>;
+  data?: unknown;
+  headers: Record<string, string>;
+};
+
+async function parseFieldValue(value: string, raw: boolean): Promise<unknown> {
+  if (raw) return value;
+  const t = value.trim();
+  if (t === "true") return true;
+  if (t === "false") return false;
+  if (t === "null") return null;
+  if (/^-?\d+(\.\d+)?$/.test(t)) {
+    const n = Number(t);
+    if (!Number.isNaN(n)) return n;
+  }
+
+  if (t.startsWith("@")) {
+    const filePath = t.slice(1);
+    const content = await fs.readFile(filePath, "utf8");
+    const parsed = tryJsonParse(content.trim());
+    return parsed;
+  }
+
+  return tryJsonParse(t);
+}
+
+async function parseFieldArgs(
+  fields: FieldInput[],
+): Promise<Record<string, unknown>> {
+  const pairs = await Promise.all(
+    fields.map(
+      async (f) =>
+        [f.key, await parseFieldValue(f.value, f.raw)] as [string, unknown],
+    ),
+  );
+  return Object.fromEntries(pairs);
+}
+
+export function parseHeaderPair(h: string): { name: string; value: string } {
+  const idx = h.indexOf(":");
+  if (idx < 0) {
+    throw new Error(`Invalid header "${h}": expected "Name: value"`);
+  }
+
+  const name = h.slice(0, idx).trim();
+  const value = h.slice(idx + 1).trim();
+  if (!name) throw new Error(`Invalid header "${h}": empty name`);
+  return { name, value };
+}
+
+async function readInputBody(inputPath: string): Promise<unknown> {
+  const raw =
+    inputPath === "-"
+      ? await readStdin()
+      : await fs.readFile(inputPath, "utf8");
+
+  const text = raw.toString().trim();
+  if (!text) return undefined;
+  const [parsed, errors] = parseJson(text);
+  if (errors.length > 0 || parsed === undefined) {
+    throw new Error(errors[0]?.message ?? "Invalid JSON in --input");
+  }
+
+  return parsed;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (c) => chunks.push(c as Buffer));
+    process.stdin.on("end", () =>
+      resolve(Buffer.concat(chunks).toString("utf8")),
+    );
+    process.stdin.on("error", reject);
+  });
+}
+
+/**
+ * Substitute `{param}` segments in a path template. Values must be encoded.
+ */
+export function buildUrlPath(
+  template: string,
+  pathParams: Record<string, unknown>,
+): string {
+  let url = template;
+  for (const [name, val] of Object.entries(pathParams)) {
+    const encoded =
+      val === undefined || val === null ? "" : encodeURIComponent(String(val));
+    url = url.replace(`{${name}}`, encoded);
+  }
+
+  if (/{[^}]+}/.test(url)) {
+    const missing = url.match(/{([^}]+)}/g)?.join(", ") ?? "";
+    throw new Error(`Missing path parameter(s) for template: ${missing}`);
+  }
+
+  return url;
+}
+
+export type BuildRequestOptions = {
+  endpoint: Endpoint;
+  /** Values extracted from matching a path template (e.g. workflow_key). */
+  pathParamDefaults: Record<string, string>;
+  fields: FieldInput[];
+  headers: string[];
+  inputPath?: string;
+  methodOverride?: HttpMethod;
+};
+
+export async function buildRequest(
+  opts: BuildRequestOptions,
+): Promise<BuiltRequest> {
+  const {
+    endpoint,
+    pathParamDefaults,
+    fields,
+    headers: headerList,
+    inputPath,
+    methodOverride,
+  } = opts;
+
+  const headerMap: Record<string, string> = {};
+  for (const h of headerList) {
+    const { name, value } = parseHeaderPair(h);
+    headerMap[name] = value;
+  }
+
+  const merged = await parseFieldArgs(fields);
+  const pathValues: Record<string, unknown> = { ...pathParamDefaults };
+  for (const p of endpoint.pathParams) {
+    if (p.name in merged) {
+      pathValues[p.name] = merged[p.name];
+    }
+  }
+
+  const url = buildUrlPath(endpoint.path, pathValues);
+
+  const params: Record<string, unknown> = {};
+  for (const q of endpoint.queryParams) {
+    if (q.name in merged) {
+      params[q.name] = merged[q.name];
+    }
+  }
+
+  const pathNames = new Set(endpoint.pathParams.map((p) => p.name));
+  const queryNames = new Set(endpoint.queryParams.map((q) => q.name));
+  const bodyKeys = new Set<string>();
+  for (const key of Object.keys(merged)) {
+    if (pathNames.has(key) || queryNames.has(key)) continue;
+    bodyKeys.add(key);
+  }
+
+  const method = methodOverride ?? endpoint.method;
+
+  let data: unknown;
+  if (inputPath) {
+    data = await readInputBody(inputPath);
+  } else if (bodyKeys.size > 0) {
+    if (method === "get") {
+      for (const k of bodyKeys) {
+        params[k] = merged[k];
+      }
+    } else {
+      data = {};
+      for (const k of bodyKeys) {
+        (data as Record<string, unknown>)[k] = merged[k];
+      }
+    }
+  }
+
+  return {
+    method,
+    url,
+    params,
+    data,
+    headers: headerMap,
+  };
+}

--- a/src/lib/mapi/response-renderer.ts
+++ b/src/lib/mapi/response-renderer.ts
@@ -1,0 +1,188 @@
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+
+import type { HttpMethod } from "./types";
+
+/** Guard against infinite pagination loops from a stuck cursor. */
+export const MAP_PAGINATION_MAX_PAGES = 1000;
+
+export type RenderOptions = {
+  raw: boolean;
+  include: boolean;
+  silent: boolean;
+  verbose: boolean;
+  log: (msg?: string, ...args: unknown[]) => void;
+  logToStderr: (msg?: string, ...args: unknown[]) => void;
+};
+
+function formatHeaders(headers: AxiosResponse["headers"]): string {
+  if (!headers || typeof headers !== "object") return "";
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    lines.push(`${k}: ${Array.isArray(v) ? v.join(", ") : String(v)}`);
+  }
+
+  return lines.join("\n");
+}
+
+function stringifyBody(data: unknown, raw: boolean): string {
+  if (data === undefined || data === "") return "";
+  if (typeof data === "string") return raw ? data : data;
+  try {
+    return raw ? JSON.stringify(data) : JSON.stringify(data, null, 2);
+  } catch {
+    return String(data);
+  }
+}
+
+export function renderResponse(resp: AxiosResponse, opts: RenderOptions): void {
+  if (opts.verbose) {
+    opts.logToStderr(`← ${resp.status} ${resp.statusText}`);
+    opts.logToStderr(formatHeaders(resp.headers));
+  }
+
+  if (opts.include) {
+    opts.log(`${resp.status} ${resp.statusText}`);
+    const h = formatHeaders(resp.headers);
+    if (h) opts.log(h);
+    opts.log("");
+  }
+
+  if (opts.silent) return;
+  const body = resp.data;
+  if (body === undefined || body === null || body === "") return;
+  if (typeof body === "string") {
+    opts.log(opts.raw ? body : body);
+    return;
+  }
+
+  opts.log(stringifyBody(body, opts.raw));
+}
+
+export type PaginatedRequest = {
+  method: HttpMethod;
+  url: string;
+  params: Record<string, unknown>;
+  data?: unknown;
+  headers: Record<string, string>;
+};
+
+function isPaginatedShape(data: unknown): data is {
+  entries: unknown[];
+  page_info?: { after?: string | null; before?: string | null };
+} {
+  if (!data || typeof data !== "object") return false;
+  const d = data as Record<string, unknown>;
+  return Array.isArray(d.entries) && d.page_info !== undefined;
+}
+
+/**
+ * Execute request, optionally following `page_info.after` and merging `entries`.
+ */
+export async function requestWithOptionalPagination(
+  client: AxiosInstance,
+  req: PaginatedRequest,
+  paginate: boolean,
+  opts: RenderOptions,
+): Promise<AxiosResponse> {
+  if (!paginate) {
+    const config: AxiosRequestConfig = {
+      method: req.method,
+      url: req.url,
+      params: pruneParams(req.params),
+      data: req.data,
+      headers: req.headers,
+    };
+    if (opts.verbose) {
+      opts.logToStderr(`→ ${req.method.toUpperCase()} ${req.url}`);
+      opts.logToStderr(JSON.stringify({ params: req.params, data: req.data }));
+    }
+
+    return client.request(config);
+  }
+
+  const allEntries: unknown[] = [];
+  let params = { ...req.params };
+  let page = 0;
+  let firstPaginatedBody: Record<string, unknown> | undefined;
+
+  const stripPaginationFields = (
+    obj: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    const rest = { ...obj };
+    delete rest.entries;
+    delete rest.page_info;
+    return rest;
+  };
+
+  for (;;) {
+    const config: AxiosRequestConfig = {
+      method: req.method,
+      url: req.url,
+      params: pruneParams(params),
+      data: req.data,
+      headers: req.headers,
+    };
+    if (opts.verbose) {
+      opts.logToStderr(
+        `→ ${req.method.toUpperCase()} ${req.url} (page ${page})`,
+      );
+      opts.logToStderr(JSON.stringify({ params, data: req.data }));
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await client.request(config);
+    const data = resp.data;
+
+    if (!isPaginatedShape(data)) {
+      if (page === 0 && opts.verbose) {
+        opts.logToStderr(
+          "Response is not paginated (missing entries/page_info); returning single response.",
+        );
+      }
+
+      return resp;
+    }
+
+    if (page === 0) {
+      firstPaginatedBody = { ...(data as Record<string, unknown>) };
+    }
+
+    allEntries.push(...data.entries);
+    const after = data.page_info?.after;
+    if (!after) {
+      const lastObj = data as Record<string, unknown>;
+      const firstExtras = firstPaginatedBody
+        ? stripPaginationFields(firstPaginatedBody)
+        : {};
+      const lastExtras = stripPaginationFields(lastObj);
+      return {
+        ...resp,
+        data: {
+          ...lastExtras,
+          ...firstExtras,
+          entries: allEntries,
+          page_info: data.page_info ?? {},
+        },
+      };
+    }
+
+    if (page + 1 >= MAP_PAGINATION_MAX_PAGES) {
+      throw new Error(
+        `--paginate: exceeded maximum of ${MAP_PAGINATION_MAX_PAGES} pages (cursor may be stuck).`,
+      );
+    }
+
+    params = { ...params, after };
+    page += 1;
+  }
+}
+
+function pruneParams(p: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(p)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+
+  return out;
+}

--- a/src/lib/mapi/types.ts
+++ b/src/lib/mapi/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Minimal OpenAPI 3.x shapes used by the mapi command.
+ * Kept loose where the resolver only needs structural access.
+ */
+
+export type HttpMethod = "get" | "put" | "post" | "delete" | "patch";
+
+export type OpenApiSchemaObject = {
+  type?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchemaObject>;
+  required?: string[];
+  items?: OpenApiSchemaObject;
+  $ref?: string;
+  anyOf?: OpenApiSchemaObject[];
+  oneOf?: OpenApiSchemaObject[];
+  allOf?: OpenApiSchemaObject[];
+  nullable?: boolean;
+  enum?: unknown[];
+  example?: unknown;
+};
+
+export type OpenApiParameterObject = {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  required?: boolean;
+  description?: string;
+  schema?: OpenApiSchemaObject;
+};
+
+export type OpenApiRequestBodyObject = {
+  description?: string;
+  required?: boolean;
+  content?: Record<
+    string,
+    {
+      schema?: OpenApiSchemaObject;
+    }
+  >;
+};
+
+export type OpenApiOperationObject = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenApiParameterObject[];
+  requestBody?: OpenApiRequestBodyObject;
+  responses?: Record<string, unknown>;
+};
+
+export type OpenApiPathItemObject = Partial<
+  Record<
+    HttpMethod | "parameters",
+    OpenApiOperationObject | OpenApiParameterObject[]
+  >
+>;
+
+export type OpenApiDocument = {
+  openapi?: string;
+  info?: { title?: string; version?: string };
+  paths?: Record<string, OpenApiPathItemObject>;
+  components?: {
+    schemas?: Record<string, OpenApiSchemaObject>;
+    parameters?: Record<string, OpenApiParameterObject>;
+  };
+};
+
+export type CachedOpenApiDocument = {
+  fetchedAt: string;
+  apiOrigin: string;
+  spec: OpenApiDocument;
+};
+
+export type ParamSpec = {
+  name: string;
+  in: "path" | "query";
+  required: boolean;
+  description?: string;
+  schema?: OpenApiSchemaObject;
+};
+
+/** Resolved body schema for help / prompts (shallow property list). */
+export type ResolvedBodySchema = {
+  description?: string;
+  required: string[];
+  properties: Record<string, OpenApiSchemaObject>;
+};
+
+export type Endpoint = {
+  method: HttpMethod;
+  path: string;
+  operationId: string;
+  summary: string;
+  description?: string;
+  tags: string[];
+  pathParams: ParamSpec[];
+  queryParams: ParamSpec[];
+  bodySchema?: ResolvedBodySchema;
+};
+
+export type FieldInput = {
+  key: string;
+  value: string;
+  raw: boolean;
+};

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -2,6 +2,10 @@ export const DEFAULT_DASHBOARD_URL = "https://dashboard.knock.app";
 export const DEFAULT_AUTH_URL = "https://signin.knock.app";
 export const DEFAULT_API_URL = "https://control.knock.app";
 
+/** URL for the Management API OpenAPI document (unauthenticated). */
+export const openApiSpecUrl = (apiOrigin: string): string =>
+  `${apiOrigin.replace(/\/$/, "")}/v1/openapi`;
+
 export const authSuccessUrl = (dashboardUrl: string): string =>
   `${dashboardUrl}/auth/oauth/cli`;
 

--- a/test/lib/mapi/curl-generator.test.ts
+++ b/test/lib/mapi/curl-generator.test.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+
+import { generateCurl } from "@/lib/mapi/curl-generator";
+
+describe("lib/mapi/curl-generator", () => {
+  it("generates curl with bearer placeholder and query string", () => {
+    const line = generateCurl({
+      method: "get",
+      url: "/v1/workflows",
+      absoluteUrl: "https://control.knock.app/v1/workflows",
+      params: { environment: "development", limit: 10 },
+      headers: {},
+    });
+    expect(line).to.include("-X GET");
+    expect(line).to.include("Bearer $KNOCK_SERVICE_TOKEN");
+    expect(line).to.include("environment=development");
+    expect(line).to.include("limit=10");
+  });
+
+  it("includes JSON body and Content-Type", () => {
+    const line = generateCurl({
+      method: "put",
+      url: "/v1/workflows/x/run",
+      absoluteUrl: "https://control.knock.app/v1/workflows/x/run",
+      params: { environment: "development" },
+      data: { recipients: ["u1"] },
+      headers: {},
+    });
+    expect(line).to.include("-X PUT");
+    expect(line).to.include("-d");
+    expect(line).to.include("recipients");
+  });
+
+  it("does not add bearer placeholder when Authorization header is set", () => {
+    const line = generateCurl({
+      method: "get",
+      url: "/v1/whoami",
+      absoluteUrl: "https://control.knock.app/v1/whoami",
+      params: {},
+      headers: { Authorization: "Bearer custom" },
+    });
+    expect(line).to.include("Bearer custom");
+    expect(line).to.not.include("$KNOCK_SERVICE_TOKEN");
+    const authHeaders = line.match(/Authorization:/g);
+    expect(authHeaders?.length).to.equal(1);
+  });
+});

--- a/test/lib/mapi/endpoint-resolver.test.ts
+++ b/test/lib/mapi/endpoint-resolver.test.ts
@@ -1,0 +1,68 @@
+import * as path from "node:path";
+
+import { expect } from "chai";
+import * as fs from "fs-extra";
+
+import {
+  findEndpointsByOperationId,
+  listEndpoints,
+  normalizeEndpointPath,
+  resolveEndpoint,
+} from "@/lib/mapi/endpoint-resolver";
+import type { OpenApiDocument } from "@/lib/mapi/types";
+
+describe("lib/mapi/endpoint-resolver", () => {
+  let doc: OpenApiDocument;
+
+  before(async () => {
+    const p = path.resolve(
+      __dirname,
+      "../../support/fixtures/mapi-openapi.json",
+    );
+    doc = (await fs.readJSON(p)) as OpenApiDocument;
+  });
+
+  it("listEndpoints flattens operations", () => {
+    const eps = listEndpoints(doc);
+    expect(eps.some((e) => e.operationId === "getWhoami")).to.equal(true);
+    expect(eps.some((e) => e.operationId === "runWorkflow")).to.equal(true);
+  });
+
+  it("normalizeEndpointPath adds v1 prefix", () => {
+    expect(normalizeEndpointPath("whoami")).to.equal("/v1/whoami");
+    expect(normalizeEndpointPath("/v1/whoami")).to.equal("/v1/whoami");
+  });
+
+  it("resolveEndpoint finds by operationId", () => {
+    const r = resolveEndpoint(doc, "getWhoami");
+    expect(r.ok).to.equal(true);
+    if (r.ok) {
+      expect(r.endpoint.path).to.equal("/v1/whoami");
+      expect(r.endpoint.method).to.equal("get");
+    }
+  });
+
+  it("resolveEndpoint finds by path template and extracts path params", () => {
+    const r = resolveEndpoint(doc, "/v1/workflows/wf-1/run");
+    expect(r.ok).to.equal(true);
+    if (r.ok) {
+      expect(r.endpoint.operationId).to.equal("runWorkflow");
+      expect(r.pathParamValues.workflow_key).to.equal("wf-1");
+    }
+  });
+
+  it("findEndpointsByOperationId is case-insensitive fallback", () => {
+    const eps = listEndpoints(doc);
+    const found = findEndpointsByOperationId(eps, "getwhoami");
+    expect(found.length).to.equal(1);
+    expect(found[0]!.operationId).to.equal("getWhoami");
+  });
+
+  it("resolveEndpoint does not throw on invalid percent-encoding in path", () => {
+    const r = resolveEndpoint(doc, "/v1/resource/bad%ZZ");
+    expect(r.ok).to.equal(false);
+    if (!r.ok) {
+      expect(r.reason).to.equal("not_found");
+    }
+  });
+});

--- a/test/lib/mapi/request-builder.test.ts
+++ b/test/lib/mapi/request-builder.test.ts
@@ -1,0 +1,109 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { expect } from "chai";
+import * as fs from "fs-extra";
+
+import { resolveEndpoint } from "@/lib/mapi/endpoint-resolver";
+import {
+  buildRequest,
+  parseHeaderPair,
+  warnOnDuplicateFieldKeys,
+} from "@/lib/mapi/request-builder";
+import type { OpenApiDocument } from "@/lib/mapi/types";
+
+describe("lib/mapi/request-builder", () => {
+  let doc: OpenApiDocument;
+
+  before(async () => {
+    const p = path.resolve(
+      __dirname,
+      "../../support/fixtures/mapi-openapi.json",
+    );
+    doc = (await fs.readJSON(p)) as OpenApiDocument;
+  });
+
+  it("parseHeaderPair parses Name: value", () => {
+    expect(parseHeaderPair("Content-Type: application/json")).to.deep.equal({
+      name: "Content-Type",
+      value: "application/json",
+    });
+  });
+
+  it("buildRequest splits path, query, and body", async () => {
+    const resolved = resolveEndpoint(doc, "/v1/workflows/wf-1/run");
+    expect(resolved.ok).to.equal(true);
+    if (!resolved.ok) return;
+
+    const built = await buildRequest({
+      endpoint: resolved.endpoint,
+      pathParamDefaults: resolved.pathParamValues,
+      fields: [
+        { key: "environment", value: "development", raw: false },
+        { key: "recipients", value: '["u1"]', raw: false },
+      ],
+      headers: [],
+    });
+
+    expect(built.url).to.equal("/v1/workflows/wf-1/run");
+    expect(built.params).to.deep.equal({ environment: "development" });
+    expect(built.data).to.deep.equal({ recipients: ["u1"] });
+  });
+
+  it("-F typed boolean and number", async () => {
+    const resolved = resolveEndpoint(doc, "listWorkflows");
+    expect(resolved.ok).to.equal(true);
+    if (!resolved.ok) return;
+
+    const built = await buildRequest({
+      endpoint: resolved.endpoint,
+      pathParamDefaults: {},
+      fields: [
+        { key: "environment", value: "staging", raw: false },
+        { key: "flag", value: "true", raw: false },
+        { key: "n", value: "42", raw: false },
+      ],
+      headers: [],
+    });
+    expect(built.params).to.deep.include({
+      environment: "staging",
+      flag: true,
+      n: 42,
+    });
+  });
+
+  it("@file reads JSON from disk", async () => {
+    const tmp = path.join(os.tmpdir(), `knock-mapi-test-${Date.now()}.json`);
+    await fs.writeJSON(tmp, ["a"]);
+
+    const resolved = resolveEndpoint(doc, "/v1/workflows/wf-1/run");
+    expect(resolved.ok).to.equal(true);
+    if (!resolved.ok) return;
+
+    const built = await buildRequest({
+      endpoint: resolved.endpoint,
+      pathParamDefaults: resolved.pathParamValues,
+      fields: [
+        { key: "environment", value: "development", raw: false },
+        { key: "recipients", value: `@${tmp}`, raw: false },
+      ],
+      headers: [],
+    });
+
+    expect(built.data).to.deep.equal({ recipients: ["a"] });
+    await fs.remove(tmp);
+  });
+
+  it("warnOnDuplicateFieldKeys warns for repeated keys", () => {
+    const msgs: string[] = [];
+    warnOnDuplicateFieldKeys(
+      [
+        { key: "a", value: "1", raw: false },
+        { key: "a", value: "2", raw: false },
+      ],
+      (m) => msgs.push(m),
+    );
+    expect(msgs.length).to.equal(1);
+    expect(msgs[0]).to.include("a");
+  });
+});

--- a/test/lib/mapi/response-renderer.test.ts
+++ b/test/lib/mapi/response-renderer.test.ts
@@ -1,0 +1,58 @@
+import type { AxiosInstance } from "axios";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import {
+  MAP_PAGINATION_MAX_PAGES,
+  requestWithOptionalPagination,
+} from "@/lib/mapi/response-renderer";
+
+function noopLog(): void {
+  /* noop */
+}
+
+describe("lib/mapi/response-renderer", () => {
+  it("requestWithOptionalPagination stops after MAP_PAGINATION_MAX_PAGES stuck cursor", async () => {
+    const client = {
+      request: sinon.stub().callsFake(async () => ({
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        data: {
+          entries: [1],
+          page_info: { after: "stuck-cursor" },
+        },
+      })),
+    } as unknown as AxiosInstance;
+
+    const opts = {
+      raw: false,
+      include: false,
+      silent: true,
+      verbose: false,
+      log: noopLog,
+      logToStderr: noopLog,
+    };
+
+    try {
+      await requestWithOptionalPagination(
+        client,
+        {
+          method: "get",
+          url: "/v1/items",
+          params: {},
+          headers: {},
+        },
+        true,
+        opts,
+      );
+      expect.fail("expected pagination guard error");
+    } catch (error) {
+      expect((error as Error).message).to.match(/--paginate: exceeded maximum/);
+    }
+
+    expect((client.request as sinon.SinonStub).callCount).to.equal(
+      MAP_PAGINATION_MAX_PAGES,
+    );
+  });
+});

--- a/test/support/fixtures/mapi-openapi.json
+++ b/test/support/fixtures/mapi-openapi.json
@@ -1,0 +1,97 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Knock Management API (mAPI)", "version": "1.0" },
+  "paths": {
+    "/v1/whoami": {
+      "get": {
+        "operationId": "getWhoami",
+        "summary": "Verify scope",
+        "tags": ["Accounts"],
+        "parameters": [],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/v1/workflows": {
+      "get": {
+        "operationId": "listWorkflows",
+        "summary": "List workflows",
+        "tags": ["Workflows"],
+        "parameters": [
+          {
+            "name": "environment",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/v1/workflows/{workflow_key}/run": {
+      "put": {
+        "operationId": "runWorkflow",
+        "summary": "Run a workflow",
+        "tags": ["Workflows"],
+        "parameters": [
+          {
+            "name": "workflow_key",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "recipients": { "type": "array" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/v1/ambiguous-methods": {
+      "get": {
+        "operationId": "ambiguousGet",
+        "summary": "Get ambiguous",
+        "tags": ["Test"],
+        "parameters": [],
+        "responses": { "200": { "description": "OK" } }
+      },
+      "post": {
+        "operationId": "ambiguousPost",
+        "summary": "Post ambiguous",
+        "tags": ["Test"],
+        "parameters": [],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/v1/resource/{id}": {
+      "delete": {
+        "operationId": "deleteResource",
+        "summary": "Delete resource",
+        "tags": ["Test"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "204": { "description": "No Content" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Stack context

This stack adds `knock mapi` / `knock mapi ls`: a generic way to call Knock Management API endpoints from the CLI using the published OpenAPI spec. This PR is **1 of 2** and contains only the reusable library + unit tests (no oclif commands).

## What

- `src/lib/mapi/*`: OpenAPI load/cache, endpoint resolution, request building (`-F` / `@file`), curl generation, response rendering + optional pagination, interactive prompts
- `openApiSpecUrl` helper on `src/lib/urls.ts`
- Unit tests under `test/lib/mapi/` and fixture `test/support/fixtures/mapi-openapi.json`

## Why

Splitting the stack keeps the first review focused on parsing, HTTP shape, and safety (e.g. path matching, pagination merge) without oclif wiring. The follow-up PR adds the commands and integration tests.

## How to verify

```bash
yarn run lint && yarn run format.check && yarn run type.check
NODE_ENV=test yarn mocha "test/lib/mapi/**/*.test.ts"
```
