### PR TITLE
fix(kno-12980): fix liquid validation for visual blocks JSON strings

### DIFF
--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -38,9 +38,7 @@ const validateLiquidSyntaxDeep = (
       const liquidParseError = validateLiquidSyntaxDeep(item);
       if (liquidParseError) return liquidParseError;
     }
-  }
-
-  if (content && typeof content === "object") {
+  } else if (content && typeof content === "object") {
     for (const value of Object.values(content)) {
       const liquidParseError = validateLiquidSyntaxDeep(value);
       if (liquidParseError) return liquidParseError;

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -5,7 +5,6 @@ import * as fs from "fs-extra";
 import { formatErrors, JsonDataError } from "@/lib/helpers/error";
 import { ParsedJson, parseJson } from "@/lib/helpers/json";
 import { validateLiquidSyntax } from "@/lib/helpers/liquid";
-import { mapValuesDeep } from "@/lib/helpers/object.isomorphic";
 import { VISUAL_BLOCKS_JSON } from "@/lib/marshal/workflow";
 import {
   EmailLayoutDirContext,
@@ -29,18 +28,26 @@ type ReadExtractedFileResult =
 // decoded and joined into the main JSON file.
 const DECODABLE_JSON_FILES = new Set([VISUAL_BLOCKS_JSON]);
 
-const validateLiquidSyntaxDeep = (content: unknown) => {
-  let liquidParseError: ReturnType<typeof validateLiquidSyntax>;
+const validateLiquidSyntaxDeep = (
+  content: unknown,
+): ReturnType<typeof validateLiquidSyntax> => {
+  if (typeof content === "string") return validateLiquidSyntax(content);
 
-  mapValuesDeep(content, (value) => {
-    if (!liquidParseError && typeof value === "string") {
-      liquidParseError = validateLiquidSyntax(value);
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      const liquidParseError = validateLiquidSyntaxDeep(item);
+      if (liquidParseError) return liquidParseError;
     }
+  }
 
-    return value;
-  });
+  if (content && typeof content === "object") {
+    for (const value of Object.values(content)) {
+      const liquidParseError = validateLiquidSyntaxDeep(value);
+      if (liquidParseError) return liquidParseError;
+    }
+  }
 
-  return liquidParseError;
+  return undefined;
 };
 
 export const readExtractedFileSync = (

--- a/src/lib/marshal/shared/helpers.ts
+++ b/src/lib/marshal/shared/helpers.ts
@@ -5,6 +5,7 @@ import * as fs from "fs-extra";
 import { formatErrors, JsonDataError } from "@/lib/helpers/error";
 import { ParsedJson, parseJson } from "@/lib/helpers/json";
 import { validateLiquidSyntax } from "@/lib/helpers/liquid";
+import { mapValuesDeep } from "@/lib/helpers/object.isomorphic";
 import { VISUAL_BLOCKS_JSON } from "@/lib/marshal/workflow";
 import {
   EmailLayoutDirContext,
@@ -27,6 +28,20 @@ type ReadExtractedFileResult =
 // The following files are exepected to have valid json content, and should be
 // decoded and joined into the main JSON file.
 const DECODABLE_JSON_FILES = new Set([VISUAL_BLOCKS_JSON]);
+
+const validateLiquidSyntaxDeep = (content: unknown) => {
+  let liquidParseError: ReturnType<typeof validateLiquidSyntax>;
+
+  mapValuesDeep(content, (value) => {
+    if (!liquidParseError && typeof value === "string") {
+      liquidParseError = validateLiquidSyntax(value);
+    }
+
+    return value;
+  });
+
+  return liquidParseError;
+};
 
 export const readExtractedFileSync = (
   relpath: string,
@@ -53,23 +68,12 @@ export const readExtractedFileSync = (
   // Read the file and check for valid liquid syntax given it is supported
   // across all message templates and file extensions.
   const contentStr = fs.readFileSync(abspath, "utf8");
-  const liquidParseError = validateLiquidSyntax(contentStr);
-
-  if (liquidParseError) {
-    const error = new JsonDataError(
-      `points to a file that contains invalid liquid syntax (${relpath})\n\n` +
-        formatErrors([liquidParseError], { indentBy: 2 }),
-      objPathToFieldStr,
-    );
-
-    return [undefined, error];
-  }
-
-  // If the file is expected to contain decodable json, then parse the contentStr
-  // as such.
   const fileName = path.basename(abspath.toLowerCase());
   const decodable = DECODABLE_JSON_FILES.has(fileName);
 
+  // If the file is expected to contain decodable json, parse the contentStr
+  // first so Liquid inside JSON string values is validated after JSON unescapes
+  // string delimiters (e.g. \"Doc\" -> "Doc").
   const [content, jsonParseErrors] = decodable
     ? parseJson(contentStr)
     : [contentStr, []];
@@ -78,6 +82,20 @@ export const readExtractedFileSync = (
     const error = new JsonDataError(
       `points to a file with invalid content (${relpath})\n\n` +
         formatErrors(jsonParseErrors, { indentBy: 2 }),
+      objPathToFieldStr,
+    );
+
+    return [undefined, error];
+  }
+
+  const liquidParseError = decodable
+    ? validateLiquidSyntaxDeep(content)
+    : validateLiquidSyntax(contentStr);
+
+  if (liquidParseError) {
+    const error = new JsonDataError(
+      `points to a file that contains invalid liquid syntax (${relpath})\n\n` +
+        formatErrors([liquidParseError], { indentBy: 2 }),
       objPathToFieldStr,
     );
 

--- a/test/commands/workflow/validate.test.ts
+++ b/test/commands/workflow/validate.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import { factory } from "@/../test/support";
 import KnockApiV1 from "@/lib/api-v1";
 import { sandboxDir } from "@/lib/helpers/const";
-import { WORKFLOW_JSON } from "@/lib/marshal/workflow";
+import { VISUAL_BLOCKS_JSON, WORKFLOW_JSON } from "@/lib/marshal/workflow";
 
 const workflowJsonFile = "new-comment/workflow.json";
 
@@ -58,6 +58,66 @@ describe("commands/workflow/validate (a single workflow)", () => {
             isEqual(workflow, {
               key: "new-comment",
               name: "New comment",
+            }),
+          ),
+        );
+      });
+  });
+
+  describe("given a workflow with double quoted liquid args in visual blocks json", () => {
+    const visualBlocks = [
+      {
+        label: '{{ n | pluralize: "Document", "Documents" }}',
+        type: "button",
+        version: 1,
+      },
+    ];
+
+    beforeEach(() => {
+      const workflowJsonPath = path.resolve(sandboxDir, workflowJsonFile);
+      fs.outputJsonSync(workflowJsonPath, {
+        name: "New comment",
+        steps: [
+          {
+            channel_key: "email-postmark",
+            ref: "email_1",
+            template: {
+              "visual_blocks@": `email_1/${VISUAL_BLOCKS_JSON}`,
+            },
+            type: "channel",
+          },
+        ],
+      });
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "new-comment", "email_1", VISUAL_BLOCKS_JSON),
+        visualBlocks,
+      );
+
+      process.chdir(sandboxDir);
+    });
+
+    setupWithStub()
+      .stdout()
+      .command(["workflow validate", "new-comment"])
+      .it("passes decoded visual blocks to apiV1 validateWorkflow", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.validateWorkflow as any,
+          sinon.match.any,
+          sinon.match((workflow) =>
+            isEqual(workflow, {
+              key: "new-comment",
+              name: "New comment",
+              steps: [
+                {
+                  channel_key: "email-postmark",
+                  ref: "email_1",
+                  template: {
+                    "visual_blocks@": `email_1/${VISUAL_BLOCKS_JSON}`,
+                    visual_blocks: visualBlocks,
+                  },
+                  type: "channel",
+                },
+              ],
             }),
           ),
         );

--- a/test/lib/marshal/workflow/reader.test.ts
+++ b/test/lib/marshal/workflow/reader.test.ts
@@ -204,6 +204,26 @@ describe("lib/marshal/workflow/reader", () => {
       });
     });
 
+    describe("given invalid liquid as an array item in a visual blocks json template", () => {
+      it("returns an error", async () => {
+        const fileContent = JSON.stringify(["{{ invalid"]);
+
+        const filePath = path.resolve(
+          workflowDirCtx.abspath,
+          VISUAL_BLOCKS_JSON,
+        );
+        fs.outputFileSync(filePath, fileContent);
+
+        const [readContent, error] = readExtractedFileSync(
+          VISUAL_BLOCKS_JSON,
+          workflowDirCtx,
+        );
+
+        expect(readContent).to.equal(undefined);
+        expect(error).to.be.an.instanceof(JsonDataError);
+      });
+    });
+
     describe("given an invalid liquid json template", () => {
       it("returns the read template content without error", async () => {
         const fileContent = `

--- a/test/lib/marshal/workflow/reader.test.ts
+++ b/test/lib/marshal/workflow/reader.test.ts
@@ -168,6 +168,42 @@ describe("lib/marshal/workflow/reader", () => {
       });
     });
 
+    describe("given valid liquid in a visual blocks json template", () => {
+      it("validates liquid after decoding json string values", async () => {
+        const fileContent = JSON.stringify(
+          [
+            {
+              label: '{{ n | pluralize: "Document", "Documents" }}',
+              type: "button",
+              version: 1,
+            },
+          ],
+          null,
+          2,
+        );
+
+        const filePath = path.resolve(
+          workflowDirCtx.abspath,
+          VISUAL_BLOCKS_JSON,
+        );
+        fs.outputFileSync(filePath, fileContent);
+
+        const [readContent, error] = readExtractedFileSync(
+          VISUAL_BLOCKS_JSON,
+          workflowDirCtx,
+        );
+
+        expect(error).to.equal(undefined);
+        expect(readContent).to.deep.equal([
+          {
+            label: '{{ n | pluralize: "Document", "Documents" }}',
+            type: "button",
+            version: 1,
+          },
+        ]);
+      });
+    });
+
     describe("given an invalid liquid json template", () => {
       it("returns the read template content without error", async () => {
         const fileContent = `


### PR DESCRIPTION
## Description

Fixes CLI-side liquid validation for `visual_blocks.json` files that contain double-quoted liquid string arguments, such as:
```
{{ n | pluralize: "Document", "Documents" }}
```

Previously the CLI validated liquid before parsing `visual_blocks.json`, so JSON-escaped quotes were passed to the liquid parser as `\"` and caused valid templates to fail locally. This change parses decodable JSON files first, then validates liquid against decoded string values.

## Tasks
[KNO-12980](https://linear.app/knock/issue/KNO-12980/workflow-push-rejects-valid-double-quoted-liquid-string-args-inside)

Issue #772