### PR TITLE
chore: add 7-day cooldown for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
+      exclude:
+        - '@knocklabs/*'
+        - '@telegraph/*'
     versioning-strategy: 'increase'
     labels:
       - 'dependencies'


### PR DESCRIPTION
## Summary
- Adds `cooldown.default-days: 7` to the npm dependabot config, mirroring [knocklabs/control#8356](https://github.com/knocklabs/control/pull/8356).
- Excludes `@knocklabs/*` and `@telegraph/*` so internal packages still flow through without delay.
- Reduces churn from day-zero version bumps and gives upstream regressions a week to surface before we open PRs.

