### PR TITLE
chore: show workflow and guide tags

### DIFF
--- a/src/commands/guide/get.ts
+++ b/src/commands/guide/get.ts
@@ -13,6 +13,7 @@ import {
   formatActivationRules,
   formatStatusWithSchedule,
   formatStep,
+  formatTags,
 } from "@/lib/marshal/guide/helpers";
 
 export default class GuideGet extends BaseCommand<typeof GuideGet> {
@@ -100,6 +101,10 @@ export default class GuideGet extends BaseCommand<typeof GuideGet> {
       {
         key: "Description",
         value: guide.description || "-",
+      },
+      {
+        key: "Tags",
+        value: formatTags(guide, { emptyDisplay: "-" }),
       },
       {
         key: "Content",

--- a/src/commands/guide/list.ts
+++ b/src/commands/guide/list.ts
@@ -13,7 +13,10 @@ import {
   paramsForPageAction,
 } from "@/lib/helpers/page";
 import { withSpinner } from "@/lib/helpers/request";
-import { formatStatusWithSchedule } from "@/lib/marshal/guide/helpers";
+import {
+  formatStatusWithSchedule,
+  formatTags,
+} from "@/lib/marshal/guide/helpers";
 
 export default class GuideList extends BaseCommand<typeof GuideList> {
   static summary = "Display all guides for an environment.";
@@ -84,6 +87,10 @@ export default class GuideList extends BaseCommand<typeof GuideList> {
       description: {
         header: "Description",
         get: (entry) => entry.description || "-",
+      },
+      tags: {
+        header: "Tags",
+        get: (entry) => formatTags(entry, { truncateAfter: 3 }),
       },
       updated_at: {
         header: "Updated at",

--- a/src/commands/workflow/get.ts
+++ b/src/commands/workflow/get.ts
@@ -114,6 +114,10 @@ export default class WorkflowGet extends BaseCommand<typeof WorkflowGet> {
         value: Workflow.formatCategories(workflow, { emptyDisplay: "-" }),
       },
       {
+        key: "Tags",
+        value: Workflow.formatTags(workflow, { emptyDisplay: "-" }),
+      },
+      {
         key: "Created at",
         value: formatDateTime(workflow.created_at),
       },

--- a/src/commands/workflow/list.ts
+++ b/src/commands/workflow/list.ts
@@ -83,6 +83,10 @@ export default class WorkflowList extends BaseCommand<typeof WorkflowList> {
         header: "Categories",
         get: (entry) => Workflow.formatCategories(entry, { truncateAfter: 3 }),
       },
+      tags: {
+        header: "Tags",
+        get: (entry) => Workflow.formatTags(entry, { truncateAfter: 3 }),
+      },
       steps: {
         header: "Steps",
         get: (entry) => {

--- a/src/lib/marshal/guide/helpers.ts
+++ b/src/lib/marshal/guide/helpers.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 
 import { ux } from "@oclif/core";
 import * as fs from "fs-extra";
-import { startCase } from "lodash";
+import { startCase, take } from "lodash";
 import {
   FetchingJSONSchemaStore,
   InputData,
@@ -50,6 +50,29 @@ export const formatActivationRules = (
   return rules
     .map(({ directive, pathname }) => `${directive} ${pathname}`)
     .join(", ");
+};
+
+/*
+ * Returns a formatted string of guide tags.
+ */
+type FormatTagsOpts = {
+  truncateAfter?: number;
+  emptyDisplay?: string;
+};
+
+export const formatTags = (
+  guide: GuideData,
+  opts: FormatTagsOpts = {},
+): string => {
+  const { tags } = guide;
+  const { truncateAfter: limit, emptyDisplay = "" } = opts;
+
+  if (!tags) return emptyDisplay;
+
+  const count = tags.length;
+  if (!limit || limit >= count) return tags.join(", ");
+
+  return take(tags, limit).join(", ") + ` (+ ${count - limit} more)`;
 };
 
 export const guideJsonPath = (guideDirCtx: GuideDirContext): string =>

--- a/src/lib/marshal/guide/types.ts
+++ b/src/lib/marshal/guide/types.ts
@@ -29,6 +29,7 @@ export type GuideData<A extends MaybeWithAnnotation = unknown> = A & {
   channel_key: string | null;
   type: string | null;
   semver: string | null;
+  tags?: string[];
   active_from?: string | null;
   active_until?: string | null;
   target_audience_key?: string | null;

--- a/src/lib/marshal/workflow/helpers.ts
+++ b/src/lib/marshal/workflow/helpers.ts
@@ -58,26 +58,38 @@ export const isWorkflowDir = async (dirPath: string): Promise<boolean> =>
   Boolean(await lsWorkflowJson(dirPath));
 
 /*
- * Returns a formatted string of workflow categories.
+ * Returns a formatted string of workflow categories or tags.
  */
-type FormatCategoriesOpts = {
+type FormatListOpts = {
   truncateAfter?: number;
   emptyDisplay?: string;
 };
 
 export const formatCategories = (
   workflow: WorkflowData,
-  opts: FormatCategoriesOpts = {},
+  opts: FormatListOpts = {},
+): string => formatStringList(workflow.categories, opts);
+
+/*
+ * Returns a formatted string of workflow tags.
+ */
+export const formatTags = (
+  workflow: WorkflowData,
+  opts: FormatListOpts = {},
+): string => formatStringList(workflow.tags, opts);
+
+const formatStringList = (
+  items: string[] | undefined,
+  opts: FormatListOpts = {},
 ): string => {
-  const { categories } = workflow;
   const { truncateAfter: limit, emptyDisplay = "" } = opts;
 
-  if (!categories) return emptyDisplay;
+  if (!items) return emptyDisplay;
 
-  const count = categories.length;
-  if (!limit || limit >= count) return categories.join(", ");
+  const count = items.length;
+  if (!limit || limit >= count) return items.join(", ");
 
-  return take(categories, limit).join(", ") + ` (+ ${count - limit} more)`;
+  return take(items, limit).join(", ") + ` (+ ${count - limit} more)`;
 };
 
 /*

--- a/src/lib/marshal/workflow/types.ts
+++ b/src/lib/marshal/workflow/types.ts
@@ -140,6 +140,7 @@ export type WorkflowData<A extends MaybeWithAnnotation = unknown> = A & {
   active: boolean;
   valid: boolean;
   categories?: string[];
+  tags?: string[];
   description?: string;
   steps: WorkflowStepData<A>[];
   trigger_data_json_schema?: Record<string, any>;


### PR DESCRIPTION
### Description

Display tags on workflows or guides, if present. Support for resource "tags" has been recently added in: https://github.com/knocklabs/control/pull/9261