### PR TITLE
chore: support "in_app_feed" as the canonical step tag workflow new command

### DIFF
--- a/src/lib/marshal/workflow/generator.ts
+++ b/src/lib/marshal/workflow/generator.ts
@@ -116,7 +116,7 @@ const scaffoldInAppFeedChannelStep = (
   const scaffoldedStep: WorkflowStepData = {
     ref: stepRef,
     type: StepType.Channel,
-    channel_key: firstChannel ? firstChannel.key : "<IN-APP-FEED CHANNEL KEY>",
+    channel_key: firstChannel ? firstChannel.key : "<IN_APP_FEED CHANNEL KEY>",
     template: {
       action_url: "{{ vars.app_url }}",
       ["markdown_body" + FILEPATH_MARKER]: templateFilePath,
@@ -210,7 +210,7 @@ const STEP_TAGS = [
   "batch",
   "fetch",
   "email",
-  "in-app-feed",
+  "in_app_feed",
   "sms",
   "push",
   "chat",
@@ -221,7 +221,7 @@ export const StepTagChoices = {
   batch: "Batch step",
   fetch: "HTTP Fetch step",
   email: "Email channel step",
-  "in-app-feed": "In-app feed channel step",
+  in_app_feed: "In-app feed channel step",
   sms: "SMS channel step",
   push: "Push channel step",
   chat: "Chat channel step",
@@ -247,11 +247,16 @@ const stepScaffoldFuncs: Record<
 
   // Channel steps
   email: scaffoldEmailChannelStep,
-  "in-app-feed": scaffoldInAppFeedChannelStep,
+  in_app_feed: scaffoldInAppFeedChannelStep,
   sms: scaffoldSmsChannelStep,
   push: scaffoldPushChannelStep,
   chat: scaffoldChatChannelStep,
 };
+
+// Accept "in-app-feed" for backward compatibility, but normalize to the snake
+// case one as the canonical tag.
+const normalizeStepTag = (tag: string): string =>
+  tag === "in-app-feed" ? "in_app_feed" : tag;
 
 /*
  * Takes a comma seperated string of step tags, then parses and returns a list
@@ -263,7 +268,10 @@ export const parseStepsInput = (
   input: string,
   availableStepTypes: StepTag[],
 ): ParseStepsInputResult => {
-  const tags = input.split(",").filter((x) => x);
+  const tags = input
+    .split(",")
+    .filter((x) => x)
+    .map((tag) => normalizeStepTag(tag));
 
   const invalidTags = tags.filter(
     (tag) => !availableStepTypes.includes(tag as StepTag),
@@ -284,7 +292,7 @@ export const getAvailableStepTypes = (
     switch (stepTag) {
       case "email":
         return channelTypes.includes("email");
-      case "in-app-feed":
+      case "in_app_feed":
         return channelTypes.includes("in_app_feed");
       case "sms":
         return channelTypes.includes("sms");
@@ -322,17 +330,13 @@ const scaffoldWorkflowDirBundle = (
 
       switch (tag) {
         case "email":
+        case "in_app_feed":
         case "sms":
         case "push":
         case "chat":
           return stepScaffoldFuncs[tag](
             stepCount,
             get(channelsByType, tag, []),
-          );
-        case "in-app-feed":
-          return stepScaffoldFuncs[tag](
-            stepCount,
-            get(channelsByType, "in_app_feed", []),
           );
         default:
           return (stepScaffoldFuncs[tag] as StepScaffoldFunc)(stepCount);
@@ -369,6 +373,7 @@ function swapChannelReferences(
     case "email":
     case "knock-email":
       return { ...step, channel_key: channelsByType.email[0]?.key };
+    case "in_app_feed":
     case "in-app-feed":
     case "knock-in-app-feed":
     case "knock-feed":

--- a/test/commands/workflow/new.test.ts
+++ b/test/commands/workflow/new.test.ts
@@ -181,6 +181,75 @@ describe("commands/workflow/new", () => {
       );
   });
 
+  describe("given a steps flag with the canonical `in_app_feed` value", () => {
+    setupWithStub()
+      .do(() => {
+        const newCwd = path.resolve(sandboxDir, "a");
+        process.chdir(newCwd);
+      })
+      .command([
+        "workflow new",
+        "--key",
+        "my-new-workflow",
+        "--name",
+        "My New Workflow",
+        "--force",
+        "--steps",
+        "in_app_feed",
+      ])
+      .it("scaffolds an in-app feed channel step", () => {
+        const workflowJsonPath = path.resolve(
+          sandboxDir,
+          "a",
+          "my-new-workflow",
+          "workflow.json",
+        );
+
+        expect(fs.pathExistsSync(workflowJsonPath)).to.equal(true);
+
+        const workflow = fs.readJsonSync(workflowJsonPath);
+        expect(workflow.steps).to.have.lengthOf(1);
+        expect(workflow.steps[0].ref).to.equal("in_app_feed_1");
+        expect(workflow.steps[0].type).to.equal("channel");
+      });
+  });
+
+  describe("given a steps flag with the legacy `in-app-feed` value", () => {
+    setupWithStub()
+      .do(() => {
+        const newCwd = path.resolve(sandboxDir, "a");
+        process.chdir(newCwd);
+      })
+      .command([
+        "workflow new",
+        "--key",
+        "my-new-workflow",
+        "--name",
+        "My New Workflow",
+        "--force",
+        "--steps",
+        "in-app-feed",
+      ])
+      .it(
+        "normalizes the value and scaffolds an in-app feed channel step",
+        () => {
+          const workflowJsonPath = path.resolve(
+            sandboxDir,
+            "a",
+            "my-new-workflow",
+            "workflow.json",
+          );
+
+          expect(fs.pathExistsSync(workflowJsonPath)).to.equal(true);
+
+          const workflow = fs.readJsonSync(workflowJsonPath);
+          expect(workflow.steps).to.have.lengthOf(1);
+          expect(workflow.steps[0].ref).to.equal("in_app_feed_1");
+          expect(workflow.steps[0].type).to.equal("channel");
+        },
+      );
+  });
+
   describe("given a valid workflow key and a template flag", () => {
     setupWithStub()
       .command([

--- a/test/lib/marshal/workflow/generator.test.ts
+++ b/test/lib/marshal/workflow/generator.test.ts
@@ -2,7 +2,11 @@ import { Channel } from "@knocklabs/mgmt/resources/channels";
 import { expect } from "@oclif/test";
 
 import { factory, xpath } from "@/../test/support";
-import { scaffoldWorkflowDirBundle } from "@/lib/marshal/workflow/generator";
+import {
+  parseStepsInput,
+  scaffoldWorkflowDirBundle,
+  StepTag,
+} from "@/lib/marshal/workflow/generator";
 
 const channelsByType: Record<any, Channel[]> = {
   email: [factory.channel({ type: "email", key: "email-channel" })],
@@ -14,7 +18,54 @@ const channelsByType: Record<any, Channel[]> = {
   ],
 };
 
+const availableStepTypes: StepTag[] = [
+  "delay",
+  "batch",
+  "fetch",
+  "email",
+  "in_app_feed",
+  "sms",
+  "push",
+  "chat",
+];
+
 describe("lib/marshal/workflow/generator", () => {
+  describe("parseStepsInput", () => {
+    it("parses a comma separated list of step tags", () => {
+      const [tags, error] = parseStepsInput(
+        "delay,email,sms",
+        availableStepTypes,
+      );
+
+      expect(error).to.equal(undefined);
+      expect(tags).to.eql(["delay", "email", "sms"]);
+    });
+
+    it("accepts the canonical `in_app_feed` step tag", () => {
+      const [tags, error] = parseStepsInput("in_app_feed", availableStepTypes);
+
+      expect(error).to.equal(undefined);
+      expect(tags).to.eql(["in_app_feed"]);
+    });
+
+    it("normalizes the legacy hyphenated `in-app-feed` step tag to `in_app_feed`", () => {
+      const [tags, error] = parseStepsInput(
+        "delay,in-app-feed,sms",
+        availableStepTypes,
+      );
+
+      expect(error).to.equal(undefined);
+      expect(tags).to.eql(["delay", "in_app_feed", "sms"]);
+    });
+
+    it("returns an error for an invalid step tag", () => {
+      const [tags, error] = parseStepsInput("blah", availableStepTypes);
+
+      expect(tags).to.equal(undefined);
+      expect(error).to.equal("Invalid step type: blah");
+    });
+  });
+
   describe("scaffoldWorkflowDirBundle", () => {
     describe("given no steps attrs", () => {
       it("returns a bundle with scaffolded workflow.json", () => {
@@ -102,7 +153,7 @@ describe("lib/marshal/workflow/generator", () => {
               "batch",
               "fetch",
               "chat",
-              "in-app-feed",
+              "in_app_feed",
               "sms",
             ],
           },


### PR DESCRIPTION
### Description

Makes c the canonical step tag instead of the current "in-app-feed", matching the snake_case convention used by CLI. 

Normalize "in-app-feed" to "in_app_feed" for backward compatibility. 
