### PR TITLE
chore: remove beta notice for dynamic audiences from audience new

### DIFF
--- a/src/commands/audience/new.ts
+++ b/src/commands/audience/new.ts
@@ -19,7 +19,7 @@ const AUDIENCE_TYPE_CHOICES = [
   { name: AudienceType.Static, message: "Static (manual membership)" },
   {
     name: AudienceType.Dynamic,
-    message: "Dynamic (rule-based membership) [Beta - requires access]",
+    message: "Dynamic (rule-based membership)",
   },
 ] as const;
 
@@ -36,8 +36,7 @@ export default class AudienceNew extends BaseCommand<typeof AudienceNew> {
       char: "k",
     }),
     type: Flags.string({
-      summary:
-        "The type of the audience (static, dynamic). Note: dynamic is in beta and requires access.",
+      summary: "The type of the audience (static, dynamic).",
       char: "t",
       options: [AudienceType.Static, AudienceType.Dynamic],
     }),


### PR DESCRIPTION
### Description

Removes the beta notice re: dynamic audience from the audience new command.