### PR TITLE
chore: add audience to --resource-type flag options

### DIFF
--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -7,6 +7,7 @@ import { KnockEnv } from "@/lib/helpers/const";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { promptToConfirm } from "@/lib/helpers/ux";
+import { ALL_RESOURCE_TYPES } from "@/lib/resources";
 
 export default class Commit extends BaseCommand<typeof Commit> {
   static summary =
@@ -30,14 +31,7 @@ export default class Commit extends BaseCommand<typeof Commit> {
     "resource-type": Flags.string({
       summary:
         "Commit only changes for the given resource type. Can be used alone or together with --resource-id.",
-      options: [
-        "email_layout",
-        "guide",
-        "message_type",
-        "partial",
-        "translation",
-        "workflow",
-      ],
+      options: ALL_RESOURCE_TYPES,
     }),
     "resource-id": Flags.string({
       summary:

--- a/src/commands/commit/list.ts
+++ b/src/commands/commit/list.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/helpers/page";
 import { withSpinner } from "@/lib/helpers/request";
 import { formatCommitAuthor } from "@/lib/marshal/commit";
+import { ALL_RESOURCE_TYPES } from "@/lib/resources";
 
 export default class CommitList extends BaseCommand<typeof CommitList> {
   static summary = "Display all commits in an environment";
@@ -33,14 +34,7 @@ export default class CommitList extends BaseCommand<typeof CommitList> {
       summary:
         "Filter commits by resource type. Can be used alone or together with resource-id. Use multiple --resource-type flags for multiple values.",
       multiple: true,
-      options: [
-        "email_layout",
-        "guide",
-        "message_type",
-        "partial",
-        "translation",
-        "workflow",
-      ],
+      options: ALL_RESOURCE_TYPES,
     }),
     "resource-id": Flags.string({
       summary:


### PR DESCRIPTION
### Description

Accept "audience" for --resource-type flag in the commit index and commit list commands. 

It is already accepted in the backend: https://github.com/knocklabs/control/blob/373f869d90038743de6f83757726ac9562652e7a/backend/lib/control/marshal/schemas/commit/commit_schema.ex#L10-L18