### PR TITLE
feat(KNO-13545): expose settings.sandbox_mode as a param

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -33,8 +33,9 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
     data: jsonStr({
       summary: "A JSON string of the data for this workflow",
     }),
-    settings: jsonStr({
-      summary: "A JSON string of settings for this workflow run.",
+    "sandbox-mode": Flags.boolean({
+      summary:
+        "When enabled, channels in this workflow generate messages but don't send them to the downstream provider.",
     }),
   };
 

--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -33,6 +33,9 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
     data: jsonStr({
       summary: "A JSON string of the data for this workflow",
     }),
+    settings: jsonStr({
+      summary: "A JSON string of settings for this workflow run.",
+    }),
   };
 
   static args = {

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -163,6 +163,7 @@ export default class ApiV1 {
       tenant: flags.tenant,
       data: flags.data,
       actor: flags.actor,
+      settings: flags.settings,
     });
     return this.put(`/workflows/${args.workflowKey}/run`, data, { params });
   }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -158,12 +158,15 @@ export default class ApiV1 {
       environment: flags.environment,
       branch: flags.branch,
     });
+    const settings = prune({
+      sandbox_mode: flags["sandbox-mode"],
+    });
     const data = prune({
       recipients: flags.recipients,
       tenant: flags.tenant,
       data: flags.data,
       actor: flags.actor,
-      settings: flags.settings,
+      ...(Object.keys(settings).length > 0 ? { settings } : {}),
     });
     return this.put(`/workflows/${args.workflowKey}/run`, data, { params });
   }

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -311,4 +311,37 @@ describe("commands/workflow/run", () => {
         );
       });
   });
+
+  describe("given a settings flag", () => {
+    setupWithStub({ data: { workflow_run_id: "run-123" } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--recipients",
+        "alice",
+        "--settings",
+        '{"sandbox_mode": true}',
+      ])
+      .it(
+        "calls apiV1 runWorkflow with expected params (settings as JSON)",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.runWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, {
+                  workflowKey: "workflow-x",
+                }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+                  environment: "development",
+                  recipients: ["alice"],
+                  settings: { sandbox_mode: true },
+                }),
+            ),
+          );
+        },
+      );
+  });
 });

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -312,7 +312,7 @@ describe("commands/workflow/run", () => {
       });
   });
 
-  describe("given a settings flag", () => {
+  describe("given a sandbox-mode flag", () => {
     setupWithStub({ data: { workflow_run_id: "run-123" } })
       .stdout()
       .command([
@@ -320,28 +320,24 @@ describe("commands/workflow/run", () => {
         "workflow-x",
         "--recipients",
         "alice",
-        "--settings",
-        '{"sandbox_mode": true}',
+        "--sandbox-mode",
       ])
-      .it(
-        "calls apiV1 runWorkflow with expected params (settings as JSON)",
-        () => {
-          sinon.assert.calledWith(
-            KnockApiV1.prototype.runWorkflow as any,
-            sinon.match(
-              ({ args, flags }) =>
-                isEqual(args, {
-                  workflowKey: "workflow-x",
-                }) &&
-                isEqual(flags, {
-                  "service-token": "valid-token",
-                  environment: "development",
-                  recipients: ["alice"],
-                  settings: { sandbox_mode: true },
-                }),
-            ),
-          );
-        },
-      );
+      .it("calls apiV1 runWorkflow with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.runWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                recipients: ["alice"],
+                "sandbox-mode": true,
+              }),
+          ),
+        );
+      });
   });
 });


### PR DESCRIPTION
### Description
add support for the new settings.sandbox_mode param in workflow trigger

### Usage
```
knock workflow run my-workflow \
  --recipients recipient-id \
  --sandbox-mode
```
<img width="1408" height="352" alt="Screenshot 2026-06-10 at 1 48 27 PM" src="https://github.com/user-attachments/assets/c69e5ab0-9c8f-4aeb-b6a0-ff98fd82f6c8" />