### PR TITLE
feat(KNO-13695): add skip-delay as flag to run workflow

### DIFF
--- a/src/commands/workflow/run.ts
+++ b/src/commands/workflow/run.ts
@@ -37,6 +37,9 @@ export default class WorkflowRun extends BaseCommand<typeof WorkflowRun> {
       summary:
         "When enabled, channels in this workflow generate messages but don't send them to the downstream provider.",
     }),
+    "skip-delay": Flags.boolean({
+      summary: "When enabled, delay steps in this workflow will be skipped",
+    }),
   };
 
   static args = {

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -160,6 +160,7 @@ export default class ApiV1 {
     });
     const settings = prune({
       sandbox_mode: flags["sandbox-mode"],
+      skip_delay: flags["skip-delay"],
     });
     const data = prune({
       recipients: flags.recipients,

--- a/test/commands/workflow/run.test.ts
+++ b/test/commands/workflow/run.test.ts
@@ -340,4 +340,33 @@ describe("commands/workflow/run", () => {
         );
       });
   });
+
+  describe("given skip-delay flag", () => {
+    setupWithStub({ data: { workflow_run_id: "run-123" } })
+      .stdout()
+      .command([
+        "workflow run",
+        "workflow-x",
+        "--recipients",
+        "alice",
+        "--skip-delay",
+      ])
+      .it("calls apiV1 runWorkflow with expected props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.runWorkflow as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                workflowKey: "workflow-x",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+                recipients: ["alice"],
+                "skip-delay": true,
+              }),
+          ),
+        );
+      });
+  });
 });


### PR DESCRIPTION
### Description
add support to run workflows with new settings.sandbox_mode param

### Usage
```
knock workflow run my-workflow \
  --recipients recipient-id \
  --skip-delay
```

<img width="1647" height="418" alt="Screenshot 2026-06-15 at 5 28 19 PM" src="https://github.com/user-attachments/assets/a766c808-50b0-47ad-bc33-d99fc345c5d4" />

