### PR TITLE
fix: increase login timeout from 60s to 5 minutes

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { browser } from "./helpers/browser";
 import { authErrorUrl, authSuccessUrl } from "./urls";
 
 const DEFAULT_TIMEOUT = 5000;
+const LOGIN_TIMEOUT = 5 * 60 * 1000;
 
 export type AuthenticatedSession = {
   accessToken: string;
@@ -207,9 +208,9 @@ export async function waitForAccessToken(
 
   const timeout = setTimeout(() => {
     cleanupAndReject(
-      `authentication timed out after ${DEFAULT_TIMEOUT / 1000} seconds`,
+      `authentication timed out after ${LOGIN_TIMEOUT / 1000} seconds`,
     );
-  }, 60_000);
+  }, LOGIN_TIMEOUT);
 
   function cleanupAndReject(message: string) {
     cleanup();


### PR DESCRIPTION
### Description
The browser-based `knock login` flow previously timed out after 60 seconds, which is often too short for users to complete authentication in their browser. Additionally, the timeout error message reported the wrong duration because it interpolated `DEFAULT_TIMEOUT` (5s, used for network fetches) rather than the actual wait timeout.

This change introduces a dedicated `LOGIN_TIMEOUT` constant set to 5 minutes, uses it for both the `setTimeout` duration and the timeout message so they can no longer drift apart, and leaves `DEFAULT_TIMEOUT` untouched for the per-request fetch timeouts.

### Tasks
N/A

Made with [Cursor](https://cursor.com)