### PR TITLE
feat(source): add `source list` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
       "partial": {
         "description": "Manage template partials."
       },
+      "source": {
+        "description": "Manage sources."
+      },
       "workflow": {
         "description": "Manage notification workflows."
       },

--- a/src/commands/source/list.ts
+++ b/src/commands/source/list.ts
@@ -18,7 +18,6 @@ export default class SourceList extends BaseCommand<typeof SourceList> {
 
   static flags = {
     environment: Flags.string({
-      default: "development",
       summary: "The environment to use.",
     }),
     ...pageFlags,
@@ -46,8 +45,11 @@ export default class SourceList extends BaseCommand<typeof SourceList> {
   async render(data: ApiV1.ListSourceResp): Promise<void> {
     const { entries } = data;
 
-    const scope = formatCommandScope(this.props.flags);
-    this.log(`‣ Showing ${entries.length} sources in ${scope}\n`);
+    const { environment } = this.props.flags;
+    const scope = environment
+      ? ` in ${formatCommandScope({ environment })}`
+      : "";
+    this.log(`‣ Showing ${entries.length} sources${scope}\n`);
 
     /*
      * Sources list table

--- a/src/commands/source/list.ts
+++ b/src/commands/source/list.ts
@@ -1,0 +1,89 @@
+import { Flags, ux } from "@oclif/core";
+import { AxiosResponse } from "axios";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import { formatDate } from "@/lib/helpers/date";
+import { merge } from "@/lib/helpers/object.isomorphic";
+import {
+  maybePromptPageAction,
+  pageFlags,
+  paramsForPageAction,
+} from "@/lib/helpers/page";
+import { withSpinner } from "@/lib/helpers/request";
+
+export default class SourceList extends BaseCommand<typeof SourceList> {
+  static summary = "Display all sources for an environment.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    ...pageFlags,
+  };
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.ListSourceResp | void> {
+    const resp = await this.request();
+
+    const { flags } = this.props;
+    if (flags.json) return resp.data;
+
+    this.render(resp.data);
+  }
+
+  async request(pageParams = {}): Promise<AxiosResponse<ApiV1.ListSourceResp>> {
+    const props = merge(this.props, { flags: { ...pageParams } });
+
+    return withSpinner<ApiV1.ListSourceResp>(() =>
+      this.apiV1.listSources(props),
+    );
+  }
+
+  async render(data: ApiV1.ListSourceResp): Promise<void> {
+    const { entries } = data;
+
+    const scope = formatCommandScope(this.props.flags);
+    this.log(`‣ Showing ${entries.length} sources in ${scope}\n`);
+
+    /*
+     * Sources list table
+     */
+
+    ux.table(entries, {
+      key: {
+        header: "Key",
+      },
+      name: {
+        header: "Name",
+      },
+      description: {
+        header: "Description",
+        get: (entry) => entry.description || "-",
+      },
+      updated_at: {
+        header: "Updated at",
+        get: (entry) => formatDate(entry.updated_at),
+      },
+    });
+
+    return this.prompt(data);
+  }
+
+  async prompt(data: ApiV1.ListSourceResp): Promise<void> {
+    const { page_info } = data;
+
+    const pageAction = await maybePromptPageAction(page_info);
+    const pageParams = pageAction && paramsForPageAction(pageAction, page_info);
+
+    if (pageParams) {
+      this.log("\n");
+
+      const resp = await this.request(pageParams);
+      return this.render(resp.data);
+    }
+  }
+}

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -16,6 +16,7 @@ import * as Guide from "@/lib/marshal/guide";
 import * as MessageType from "@/lib/marshal/message-type";
 import * as Partial from "@/lib/marshal/partial";
 import { MaybeWithAnnotation } from "@/lib/marshal/shared/types";
+import * as Source from "@/lib/marshal/source";
 import * as Translation from "@/lib/marshal/translation";
 import * as Workflow from "@/lib/marshal/workflow";
 
@@ -516,6 +517,18 @@ export default class ApiV1 {
     return this.get(`/guides/${args.guideKey}`, { params });
   }
 
+  async listSources<A extends MaybeWithAnnotation>({
+    flags,
+  }: Props): Promise<AxiosResponse<ListSourceResp<A>>> {
+    const params = prune({
+      environment: flags.environment,
+      annotate: flags.annotate,
+      ...toPageParams(flags),
+    });
+
+    return this.get("/sources", { params });
+  }
+
   async validateGuide(
     { flags }: Props,
     guide: Guide.GuideInput,
@@ -743,5 +756,8 @@ export type ActivateGuideResp = {
   guide?: Guide.GuideData;
   errors?: InputError[];
 };
+
+export type ListSourceResp<A extends MaybeWithAnnotation = unknown> =
+  PaginatedResp<Source.SourceData<A>>;
 
 export type ListBranchResp = PaginatedResp<Branch>;

--- a/src/lib/marshal/source/index.ts
+++ b/src/lib/marshal/source/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/lib/marshal/source/types.ts
+++ b/src/lib/marshal/source/types.ts
@@ -1,0 +1,55 @@
+import { AnyObj } from "@/lib/helpers/object.isomorphic";
+
+import { MaybeWithAnnotation } from "../shared/types";
+
+export type SourcePreprocessScript = {
+  source: string;
+  language: "javascript";
+};
+
+export type SourceEventActionMapping = {
+  event_type: string;
+  action_type: string;
+  action_parameters: AnyObj | null;
+  active: boolean;
+  is_deleted: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+/*
+ * The per-environment `settings` object is open-ended (the API serializes it
+ * with `additionalProperties: true`). These are the common fields, but
+ * source-type-specific fields may also be present.
+ */
+export type SourceSettings = AnyObj & {
+  endpoint?: string;
+  event_type_path?: string | null;
+  timestamp_path?: string | null;
+  idempotency_key_path?: string | null;
+  handle_identifies?: boolean | null;
+  enforce_idempotency?: boolean | null;
+  enforce_verification?: boolean;
+  preprocess_script?: SourcePreprocessScript | null;
+};
+
+export type SourceEnvironmentSettings = {
+  updated_at: string;
+  settings: SourceSettings;
+  mappings: SourceEventActionMapping[];
+};
+
+/*
+ * Source data from the API. `environment_settings` is a map keyed by
+ * environment slug; it is returned by `get`, but omitted from the lightweight
+ * summaries returned by `list`.
+ */
+export type SourceData<A extends MaybeWithAnnotation = unknown> = A & {
+  key: string;
+  name: string;
+  description: string | null;
+  custom_image_url: string | null;
+  created_at: string;
+  updated_at: string;
+  environment_settings?: Record<string, SourceEnvironmentSettings>;
+};

--- a/test/commands/source/list.test.ts
+++ b/test/commands/source/list.test.ts
@@ -30,7 +30,6 @@ describe("commands/source/list", () => {
               isEqual(args, {}) &&
               isEqual(flags, {
                 "service-token": "valid-token",
-                environment: "development",
               }),
           ),
         );
@@ -90,7 +89,7 @@ describe("commands/source/list", () => {
       .stdout()
       .command(["source list"])
       .it("displays the list of sources", (ctx) => {
-        expect(ctx.stdout).to.contain("Showing 3 sources in");
+        expect(ctx.stdout).to.contain("Showing 3 sources");
         expect(ctx.stdout).to.contain("source-1");
         expect(ctx.stdout).to.contain("source-2");
         expect(ctx.stdout).to.contain("source-3");
@@ -143,7 +142,6 @@ describe("commands/source/list", () => {
                   isEqual(args, {}) &&
                   isEqual(flags, {
                     "service-token": "valid-token",
-                    environment: "development",
                   }),
               ),
             );
@@ -156,7 +154,6 @@ describe("commands/source/list", () => {
                   isEqual(args, {}) &&
                   isEqual(flags, {
                     "service-token": "valid-token",
-                    environment: "development",
                     after: "xyz",
                   }),
               ),

--- a/test/commands/source/list.test.ts
+++ b/test/commands/source/list.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/source/list", () => {
+  const emptySourcesListResp = factory.resp({
+    data: {
+      page_info: factory.pageInfo(),
+      entries: [],
+    },
+  });
+
+  describe("given no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listSources", (stub) =>
+        stub.resolves(emptySourcesListResp),
+      )
+      .stdout()
+      .command(["source list"])
+      .it("calls apiV1 listSources with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listSources as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listSources", (stub) =>
+        stub.resolves(emptySourcesListResp),
+      )
+      .stdout()
+      .command([
+        "source list",
+        "--environment",
+        "staging",
+        "--limit",
+        "5",
+        "--after",
+        "xyz",
+      ])
+      .it("calls apiV1 listSources with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.listSources as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {}) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "staging",
+                limit: 5,
+                after: "xyz",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a list of sources in response", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "listSources", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: {
+              page_info: factory.pageInfo(),
+              entries: [
+                factory.source({ key: "source-1" }),
+                factory.source({ key: "source-2" }),
+                factory.source({ key: "source-3" }),
+              ],
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["source list"])
+      .it("displays the list of sources", (ctx) => {
+        expect(ctx.stdout).to.contain("Showing 3 sources in");
+        expect(ctx.stdout).to.contain("source-1");
+        expect(ctx.stdout).to.contain("source-2");
+        expect(ctx.stdout).to.contain("source-3");
+
+        expect(ctx.stdout).to.not.contain("source-4");
+      });
+  });
+
+  describe("given the first page of paginated sources in resp", () => {
+    const paginatedSourcesResp = factory.resp({
+      data: {
+        page_info: factory.pageInfo({
+          after: "xyz",
+        }),
+        entries: [
+          factory.source({ key: "source-1" }),
+          factory.source({ key: "source-2" }),
+          factory.source({ key: "source-3" }),
+        ],
+      },
+    });
+
+    describe("plus a next page action from the prompt input", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(KnockApiV1.prototype, "listSources", (stub) =>
+          stub.resolves(paginatedSourcesResp),
+        )
+        .stub(enquirer.prototype, "prompt", (stub) =>
+          stub
+            .onFirstCall()
+            .resolves({ input: "n" })
+            .onSecondCall()
+            .resolves({ input: "" }),
+        )
+        .stdout()
+        .command(["source list"])
+        .it(
+          "calls apiV1 listSources for the second time with page params",
+          () => {
+            const listSourcesFn = KnockApiV1.prototype.listSources as any;
+
+            sinon.assert.calledTwice(listSourcesFn);
+
+            // First call without page params.
+            sinon.assert.calledWith(
+              listSourcesFn.firstCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                  }),
+              ),
+            );
+
+            // Second call with page params to fetch the next page.
+            sinon.assert.calledWith(
+              listSourcesFn.secondCall,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    "service-token": "valid-token",
+                    environment: "development",
+                    after: "xyz",
+                  }),
+              ),
+            );
+          },
+        );
+    });
+
+    describe("plus a previous page action input from the prompt", () => {
+      test
+        .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+        .stub(KnockApiV1.prototype, "listSources", (stub) =>
+          stub.resolves(paginatedSourcesResp),
+        )
+        .stub(enquirer.prototype, "prompt", (stub) =>
+          stub.onFirstCall().resolves({ input: "p" }),
+        )
+        .stdout()
+        .command(["source list"])
+        .it("calls apiV1 listSources once for the initial page only", () => {
+          sinon.assert.calledOnce(KnockApiV1.prototype.listSources as any);
+        });
+    });
+  });
+});

--- a/test/support/factory.ts
+++ b/test/support/factory.ts
@@ -16,6 +16,7 @@ import { GuideData } from "@/lib/marshal/guide";
 import { MessageTypeData } from "@/lib/marshal/message-type";
 import { PartialData, PartialType } from "@/lib/marshal/partial";
 import { ReusableStepData } from "@/lib/marshal/reusable-step";
+import { SourceData } from "@/lib/marshal/source";
 import { TranslationData } from "@/lib/marshal/translation";
 import {
   ChannelStepData,
@@ -313,6 +314,29 @@ export const guide = (attrs: Partial<GuideData> = {}): GuideData => {
     created_at: "2022-12-31T12:00:00.000000Z",
     environment: "development",
     sha: "<SOME_SHA>",
+    ...attrs,
+  };
+};
+
+export const source = (attrs: Partial<SourceData> = {}): SourceData => {
+  return {
+    key: "my-source",
+    name: "My Source",
+    description: "A source for receiving events",
+    custom_image_url: null,
+    updated_at: "2022-12-31T12:00:00.000000Z",
+    created_at: "2022-12-31T12:00:00.000000Z",
+    environment_settings: {
+      development: {
+        updated_at: "2022-12-31T12:00:00.000000Z",
+        settings: {
+          endpoint: "https://api.knock.app/integrations/receive/abc123",
+          enforce_verification: false,
+          preprocess_script: null,
+        },
+        mappings: [],
+      },
+    },
     ...attrs,
   };
 };


### PR DESCRIPTION
### Description

Adds a `knock source list` command to display existing source configs.

Note, the code here was mostly generated but spot checked.

### Screenshots

<img width="1722" height="344" alt="CleanShot 2026-06-26 at 18 09 57@2x" src="https://github.com/user-attachments/assets/d6355bd3-f110-409f-b3f4-de3934745fcd" />

