### PR TITLE
feat(source): add `source get` command

### DIFF
--- a/src/commands/source/get.ts
+++ b/src/commands/source/get.ts
@@ -12,7 +12,6 @@ import {
   formatMappingStatus,
   formatPreprocessScript,
   formatSettingValue,
-  SOURCE_SETTINGS_DISPLAY,
 } from "@/lib/marshal/source/helpers";
 
 export default class SourceGet extends BaseCommand<typeof SourceGet> {
@@ -130,11 +129,28 @@ export default class SourceGet extends BaseCommand<typeof SourceGet> {
   ): void {
     const { settings, mappings } = envSettings;
 
+    /*
+     * A curated subset of the open-ended `settings` object, in display order;
+     * the full object is always available via `--json`.
+     */
     const settingsRows = [
-      ...SOURCE_SETTINGS_DISPLAY.map(({ key, label }) => ({
-        key: label,
-        value: formatSettingValue(settings[key]),
-      })),
+      { key: "Endpoint", value: formatSettingValue(settings.endpoint) },
+      {
+        key: "Event type path",
+        value: formatSettingValue(settings.event_type_path),
+      },
+      {
+        key: "Timestamp path",
+        value: formatSettingValue(settings.timestamp_path),
+      },
+      {
+        key: "Idempotency key path",
+        value: formatSettingValue(settings.idempotency_key_path),
+      },
+      {
+        key: "Enforce verification",
+        value: formatSettingValue(settings.enforce_verification),
+      },
       {
         key: "Preprocess script",
         value: formatPreprocessScript(settings),

--- a/src/commands/source/get.ts
+++ b/src/commands/source/get.ts
@@ -1,0 +1,174 @@
+import { Args, Flags, ux } from "@oclif/core";
+
+import * as ApiV1 from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import { formatDateTime } from "@/lib/helpers/date";
+import { ApiError } from "@/lib/helpers/error";
+import { formatErrorRespMessage, isSuccessResp } from "@/lib/helpers/request";
+import { spinner } from "@/lib/helpers/ux";
+import { SourceEnvironmentSettings } from "@/lib/marshal/source";
+import {
+  formatMappingStatus,
+  formatPreprocessScript,
+  formatSettingValue,
+  SOURCE_SETTINGS_DISPLAY,
+} from "@/lib/marshal/source/helpers";
+
+export default class SourceGet extends BaseCommand<typeof SourceGet> {
+  static summary = "Display a single source from an environment.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+  };
+
+  static args = {
+    sourceKey: Args.string({
+      required: true,
+    }),
+  };
+
+  static enableJsonFlag = true;
+
+  async run(): Promise<ApiV1.GetSourceResp | void> {
+    spinner.start("‣ Loading");
+
+    const { source } = await this.loadSource();
+
+    spinner.stop();
+
+    const { flags } = this.props;
+    if (flags.json) return source;
+
+    this.render(source);
+  }
+
+  private async loadSource(): Promise<{
+    source: ApiV1.GetSourceResp;
+  }> {
+    const sourceResp = await this.apiV1.getSource(this.props);
+
+    if (!isSuccessResp(sourceResp)) {
+      const message = formatErrorRespMessage(sourceResp);
+      ux.error(new ApiError(message));
+    }
+
+    return {
+      source: sourceResp.data,
+    };
+  }
+
+  render(source: ApiV1.GetSourceResp): void {
+    const { sourceKey } = this.props.args;
+
+    const scope = formatCommandScope(this.props.flags);
+    this.log(`‣ Showing source \`${sourceKey}\` in ${scope}\n`);
+
+    /*
+     * Source table
+     */
+
+    const rows = [
+      {
+        key: "Name",
+        value: source.name,
+      },
+      {
+        key: "Key",
+        value: source.key,
+      },
+      {
+        key: "Description",
+        value: source.description || "-",
+      },
+      {
+        key: "Custom image URL",
+        value: source.custom_image_url || "-",
+      },
+      {
+        key: "Created at",
+        value: formatDateTime(source.created_at),
+      },
+      {
+        key: "Updated at",
+        value: formatDateTime(source.updated_at),
+      },
+    ];
+
+    ux.table(rows, {
+      key: {
+        header: "Source",
+        minWidth: 24,
+      },
+      value: {
+        header: "",
+        minWidth: 24,
+      },
+    });
+
+    this.log("");
+
+    /*
+     * Per-environment settings
+     */
+
+    const envSettings = source.environment_settings ?? {};
+
+    for (const slug of Object.keys(envSettings)) {
+      this.renderEnvironmentSettings(slug, envSettings[slug]);
+    }
+  }
+
+  private renderEnvironmentSettings(
+    slug: string,
+    envSettings: SourceEnvironmentSettings,
+  ): void {
+    const { settings, mappings } = envSettings;
+
+    this.log(`Environment: \`${slug}\`\n`);
+
+    const settingsRows = [
+      ...SOURCE_SETTINGS_DISPLAY.map(({ key, label }) => ({
+        key: label,
+        value: formatSettingValue(settings[key]),
+      })),
+      {
+        key: "Preprocess script",
+        value: formatPreprocessScript(settings),
+      },
+    ];
+
+    ux.table(settingsRows, {
+      key: {
+        header: "Settings",
+        minWidth: 24,
+      },
+      value: {
+        header: "",
+        minWidth: 24,
+      },
+    });
+
+    this.log("");
+
+    if (mappings.length > 0) {
+      ux.table(mappings, {
+        event_type: {
+          header: "Event type",
+        },
+        action_type: {
+          header: "Action type",
+        },
+        status: {
+          header: "Status",
+          get: (mapping) => formatMappingStatus(mapping),
+        },
+      });
+
+      this.log("");
+    }
+  }
+}

--- a/src/commands/source/get.ts
+++ b/src/commands/source/get.ts
@@ -20,7 +20,6 @@ export default class SourceGet extends BaseCommand<typeof SourceGet> {
 
   static flags = {
     environment: Flags.string({
-      default: "development",
       summary: "The environment to use.",
     }),
   };
@@ -64,8 +63,11 @@ export default class SourceGet extends BaseCommand<typeof SourceGet> {
   render(source: ApiV1.GetSourceResp): void {
     const { sourceKey } = this.props.args;
 
-    const scope = formatCommandScope(this.props.flags);
-    this.log(`‣ Showing source \`${sourceKey}\` in ${scope}\n`);
+    const { environment } = this.props.flags;
+    const scope = environment
+      ? ` in ${formatCommandScope({ environment })}`
+      : "";
+    this.log(`‣ Showing source \`${sourceKey}\`${scope}\n`);
 
     /*
      * Source table
@@ -128,8 +130,6 @@ export default class SourceGet extends BaseCommand<typeof SourceGet> {
   ): void {
     const { settings, mappings } = envSettings;
 
-    this.log(`Environment: \`${slug}\`\n`);
-
     const settingsRows = [
       ...SOURCE_SETTINGS_DISPLAY.map(({ key, label }) => ({
         key: label,
@@ -143,7 +143,7 @@ export default class SourceGet extends BaseCommand<typeof SourceGet> {
 
     ux.table(settingsRows, {
       key: {
-        header: "Settings",
+        header: `Settings (${slug})`,
         minWidth: 24,
       },
       value: {

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -529,6 +529,18 @@ export default class ApiV1 {
     return this.get("/sources", { params });
   }
 
+  async getSource<A extends MaybeWithAnnotation>({
+    args,
+    flags,
+  }: Props): Promise<AxiosResponse<GetSourceResp<A>>> {
+    const params = prune({
+      environment: flags.environment,
+      annotate: flags.annotate,
+    });
+
+    return this.get(`/sources/${args.sourceKey}`, { params });
+  }
+
   async validateGuide(
     { flags }: Props,
     guide: Guide.GuideInput,
@@ -759,5 +771,8 @@ export type ActivateGuideResp = {
 
 export type ListSourceResp<A extends MaybeWithAnnotation = unknown> =
   PaginatedResp<Source.SourceData<A>>;
+
+export type GetSourceResp<A extends MaybeWithAnnotation = unknown> =
+  Source.SourceData<A>;
 
 export type ListBranchResp = PaginatedResp<Branch>;

--- a/src/lib/marshal/source/helpers.ts
+++ b/src/lib/marshal/source/helpers.ts
@@ -1,21 +1,5 @@
 import { SourceEventActionMapping, SourceSettings } from "./types";
 
-/*
- * The common `settings` fields to surface in the source detail view, in
- * display order. The settings object is open-ended, so this is a curated
- * subset; the full object is always available via `--json`.
- */
-export const SOURCE_SETTINGS_DISPLAY: Array<{
-  key: keyof SourceSettings;
-  label: string;
-}> = [
-  { key: "endpoint", label: "Endpoint" },
-  { key: "event_type_path", label: "Event type path" },
-  { key: "timestamp_path", label: "Timestamp path" },
-  { key: "idempotency_key_path", label: "Idempotency key path" },
-  { key: "enforce_verification", label: "Enforce verification" },
-];
-
 export const formatSettingValue = (value: unknown): string => {
   if (value === undefined || value === null || value === "") return "-";
   if (typeof value === "boolean") return value ? "Yes" : "No";

--- a/src/lib/marshal/source/helpers.ts
+++ b/src/lib/marshal/source/helpers.ts
@@ -1,0 +1,30 @@
+import { SourceEventActionMapping, SourceSettings } from "./types";
+
+/*
+ * The common `settings` fields to surface in the source detail view, in
+ * display order. The settings object is open-ended, so this is a curated
+ * subset; the full object is always available via `--json`.
+ */
+export const SOURCE_SETTINGS_DISPLAY: Array<{
+  key: keyof SourceSettings;
+  label: string;
+}> = [
+  { key: "endpoint", label: "Endpoint" },
+  { key: "event_type_path", label: "Event type path" },
+  { key: "timestamp_path", label: "Timestamp path" },
+  { key: "idempotency_key_path", label: "Idempotency key path" },
+  { key: "enforce_verification", label: "Enforce verification" },
+];
+
+export const formatSettingValue = (value: unknown): string => {
+  if (value === undefined || value === null || value === "") return "-";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
+};
+
+export const formatPreprocessScript = (settings: SourceSettings): string =>
+  settings.preprocess_script ? settings.preprocess_script.language : "-";
+
+export const formatMappingStatus = (
+  mapping: SourceEventActionMapping,
+): string => (mapping.active ? "Active" : "Inactive");

--- a/src/lib/marshal/source/index.ts
+++ b/src/lib/marshal/source/index.ts
@@ -1,1 +1,2 @@
+export * from "./helpers";
 export * from "./types";

--- a/test/commands/source/get.test.ts
+++ b/test/commands/source/get.test.ts
@@ -36,7 +36,6 @@ describe("commands/source/get", () => {
               }) &&
               isEqual(flags, {
                 "service-token": "valid-token",
-                environment: "development",
               }),
           ),
         );
@@ -87,7 +86,7 @@ describe("commands/source/get", () => {
       .it("displays the source and its environment settings", (ctx) => {
         expect(ctx.stdout).to.contain("Showing source `my-source`");
         expect(ctx.stdout).to.contain("my-source");
-        expect(ctx.stdout).to.contain("Environment: `development`");
+        expect(ctx.stdout).to.contain("Settings (development)");
         expect(ctx.stdout).to.contain("Endpoint");
         expect(ctx.stdout).to.contain(
           "https://api.knock.app/integrations/receive/abc123",

--- a/test/commands/source/get.test.ts
+++ b/test/commands/source/get.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@oclif/test";
+import { isEqual } from "lodash";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+
+describe("commands/source/get", () => {
+  describe("given no source key arg", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .command(["source get"])
+      .exit(2)
+      .it("exits with status 2");
+  });
+
+  describe("given a source key arg, and no flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "getSource", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.source(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["source get", "foo"])
+      .it("calls apiV1 getSource with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getSource as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                sourceKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "development",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a source key arg, and flags", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "getSource", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.source(),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["source get", "foo", "--environment", "staging"])
+      .it("calls apiV1 getSource with correct props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.getSource as any,
+          sinon.match(
+            ({ args, flags }) =>
+              isEqual(args, {
+                sourceKey: "foo",
+              }) &&
+              isEqual(flags, {
+                "service-token": "valid-token",
+                environment: "staging",
+              }),
+          ),
+        );
+      });
+  });
+
+  describe("given a source in response", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "getSource", (stub) =>
+        stub.resolves(
+          factory.resp({
+            data: factory.source({ key: "my-source" }),
+          }),
+        ),
+      )
+      .stdout()
+      .command(["source get", "my-source"])
+      .it("displays the source and its environment settings", (ctx) => {
+        expect(ctx.stdout).to.contain("Showing source `my-source`");
+        expect(ctx.stdout).to.contain("my-source");
+        expect(ctx.stdout).to.contain("Environment: `development`");
+        expect(ctx.stdout).to.contain("Endpoint");
+        expect(ctx.stdout).to.contain(
+          "https://api.knock.app/integrations/receive/abc123",
+        );
+      });
+  });
+
+  describe("given a source key that does not exist", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "getSource", (stub) =>
+        stub.resolves(
+          factory.resp({
+            status: 404,
+            statusText: "Not found",
+            data: {
+              code: "resource_missing",
+              message: "The resource you requested does not exist",
+              status: 404,
+              type: "api_error",
+            },
+          }),
+        ),
+      )
+      .stdout()
+      .command(["source get", "foo"])
+      .catch("The resource you requested does not exist")
+      .it("throws an error for resource not found");
+  });
+});


### PR DESCRIPTION
### Description

Adds a `knock source get <KEY>` command to show an existing source config.

Note, the code here was mostly generated but spot checked.

### Screenshots

<img width="1306" height="1446" alt="CleanShot 2026-06-26 at 18 10 15@2x" src="https://github.com/user-attachments/assets/bd9a225c-37ad-4e7f-95b5-4332a766dc37" />

