### PR TITLE
feat(KNO-13755): add schema pull and push commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
       "partial": {
         "description": "Manage template partials."
       },
+      "schema": {
+        "description": "Manage item schemas."
+      },
       "source": {
         "description": "Manage sources."
       },

--- a/src/commands/schema/pull.ts
+++ b/src/commands/schema/pull.ts
@@ -108,14 +108,22 @@ export default class SchemaPull extends BaseCommand<typeof SchemaPull> {
     const input = flags.force || (await promptToConfirm(prompt));
     if (!input) return;
 
-    const resp = await withSpinner<ListSchemaResp>(
-      () => this.apiV1.listSchemas(this.props),
-      {
-        action: "‣ Loading",
-      },
-    );
+    // Page through the list endpoint so environments with more schemas than a
+    // single page (many object collections) are pulled completely.
+    const schemas: Schema.SchemaData[] = [];
+    let after: string | undefined;
 
-    const schemas = resp.data.entries ?? [];
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const resp = await withSpinner<ListSchemaResp>(
+        () => this.apiV1.listSchemas(this.props, { after }),
+        { action: "‣ Loading" },
+      );
+
+      schemas.push(...(resp.data.entries ?? []));
+      after = resp.data.page_info?.after ?? undefined;
+    } while (after);
+
     await Schema.writeSchemasIndexDir(schemasDirCtx.abspath, schemas);
 
     const action = schemasDirCtx.exists ? "updated" : "created";

--- a/src/commands/schema/pull.ts
+++ b/src/commands/schema/pull.ts
@@ -1,0 +1,158 @@
+import { Args, Flags, ux } from "@oclif/core";
+
+import { GetSchemaResp, ListSchemaResp } from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import { ApiError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
+import { formatErrorRespMessage, withSpinner } from "@/lib/helpers/request";
+import { promptToConfirm } from "@/lib/helpers/ux";
+import * as Schema from "@/lib/marshal/schema";
+
+export default class SchemaPull extends BaseCommand<typeof SchemaPull> {
+  static summary =
+    "Pull one or more item schemas from an environment into a local file system.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    branch: CustomFlags.branch,
+    all: Flags.boolean({
+      summary:
+        "Whether to pull all item schemas from the specified environment.",
+    }),
+    collection: Flags.string({
+      summary: "The object collection key for object schemas.",
+    }),
+    "schemas-dir": CustomFlags.dirPath({
+      summary: "The target schemas directory path.",
+    }),
+    force: Flags.boolean({
+      summary: "Remove the confirmation prompt.",
+    }),
+  };
+
+  static args = {
+    itemType: Args.string({
+      required: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = this.props;
+
+    if (flags.all && args.itemType) {
+      return this.error(
+        `itemType arg \`${args.itemType}\` cannot also be provided when using --all`,
+      );
+    }
+
+    if (flags.all && flags.collection) {
+      return this.error(
+        "Flag --collection cannot be provided when using --all",
+      );
+    }
+
+    return flags.all ? this.pullAllSchemas() : this.pullOneSchema();
+  }
+
+  async pullOneSchema(): Promise<void> {
+    const { flags } = this.props;
+    const itemType = this.parseItemType();
+    this.validateCollectionUsage(itemType);
+
+    const schemasDirCtx = await this.getSchemasDirContext();
+    const schemaFileCtx = await Schema.schemaFileContext(
+      schemasDirCtx.abspath,
+      itemType,
+      flags.collection,
+    );
+
+    if (schemaFileCtx.exists) {
+      const prompt = `Overwrite schema file at ${schemaFileCtx.abspath}?`;
+      const input = flags.force || (await promptToConfirm(prompt));
+      if (!input) return;
+    } else {
+      const prompt = `Create a new schema file at ${schemaFileCtx.abspath}?`;
+      const input = flags.force || (await promptToConfirm(prompt));
+      if (!input) return;
+    }
+
+    const resp = await withSpinner<GetSchemaResp>(
+      () => this.apiV1.getSchema(this.props, itemType, flags.collection),
+      { action: "‣ Loading" },
+    );
+
+    if (!resp.data.schema) {
+      ux.error(new ApiError(formatErrorRespMessage(resp)));
+    }
+
+    await Schema.writeSchemaFileFromData(schemaFileCtx, resp.data.schema);
+
+    const action = schemaFileCtx.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
+    this.log(
+      `‣ Successfully ${action} schema file at ${schemaFileCtx.abspath} using ${scope}`,
+    );
+  }
+
+  async pullAllSchemas(): Promise<void> {
+    const { flags } = this.props;
+    const schemasDirCtx = await this.getSchemasDirContext();
+
+    const prompt = schemasDirCtx.exists
+      ? `Pull latest schemas into ${schemasDirCtx.abspath}?\n  This will overwrite matching schema files in this directory.`
+      : `Create a new schemas directory at ${schemasDirCtx.abspath}?`;
+    const input = flags.force || (await promptToConfirm(prompt));
+    if (!input) return;
+
+    const resp = await withSpinner<ListSchemaResp>(
+      () => this.apiV1.listSchemas(this.props),
+      {
+        action: "‣ Loading",
+      },
+    );
+
+    const schemas = resp.data.entries ?? [];
+    await Schema.writeSchemasIndexDir(schemasDirCtx.abspath, schemas);
+
+    const action = schemasDirCtx.exists ? "updated" : "created";
+    const scope = formatCommandScope(flags);
+    this.log(
+      `‣ Successfully ${action} ${schemas.length} schema file(s) at ${schemasDirCtx.abspath} using ${scope}`,
+    );
+  }
+
+  private parseItemType(): Schema.SchemaItemType {
+    const { itemType } = this.props.args;
+    if (!itemType) {
+      return this.error("Missing 1 required arg:\nitemType");
+    }
+
+    try {
+      return Schema.validateSchemaItemType(itemType);
+    } catch (error) {
+      return this.error((error as Error).message);
+    }
+  }
+
+  private validateCollectionUsage(itemType: Schema.SchemaItemType): void {
+    const { collection } = this.props.flags;
+
+    if (itemType === "object" && !collection) {
+      this.error("Flag --collection is required when itemType is `object`");
+    }
+
+    if (itemType !== "object" && collection) {
+      this.error("Flag --collection can only be provided for object schemas");
+    }
+  }
+
+  private async getSchemasDirContext() {
+    return this.props.flags["schemas-dir"]
+      ? this.props.flags["schemas-dir"]
+      : Schema.resolveSchemasDir(this.projectConfig, this.runContext.cwd);
+  }
+}

--- a/src/commands/schema/pull.ts
+++ b/src/commands/schema/pull.ts
@@ -156,6 +156,14 @@ export default class SchemaPull extends BaseCommand<typeof SchemaPull> {
     if (itemType !== "object" && collection) {
       this.error("Flag --collection can only be provided for object schemas");
     }
+
+    if (itemType === "object" && collection) {
+      try {
+        Schema.validateSchemaCollection(collection);
+      } catch (error) {
+        this.error((error as Error).message);
+      }
+    }
   }
 
   private async getSchemasDirContext() {

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -1,0 +1,187 @@
+import { Args, Flags } from "@oclif/core";
+
+import { UpsertSchemaResp } from "@/lib/api-v1";
+import BaseCommand from "@/lib/base-command";
+import { formatCommandScope } from "@/lib/helpers/command";
+import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
+import * as CustomFlags from "@/lib/helpers/flag";
+import { withSpinner } from "@/lib/helpers/request";
+import { indentString } from "@/lib/helpers/string";
+import * as Schema from "@/lib/marshal/schema";
+
+export default class SchemaPush extends BaseCommand<typeof SchemaPush> {
+  static summary =
+    "Push one or more local item schemas to a Knock environment.";
+
+  static flags = {
+    environment: Flags.string({
+      default: "development",
+      summary: "The environment to use.",
+    }),
+    branch: CustomFlags.branch,
+    all: Flags.boolean({
+      summary: "Whether to push all schemas from the target schemas directory.",
+    }),
+    collection: Flags.string({
+      summary: "The object collection key for object schemas.",
+    }),
+    "schemas-dir": CustomFlags.dirPath({
+      summary: "The target schemas directory path.",
+    }),
+  };
+
+  static args = {
+    itemType: Args.string({
+      required: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = this.props;
+
+    if (flags.all && args.itemType) {
+      return this.error(
+        `itemType arg \`${args.itemType}\` cannot also be provided when using --all`,
+      );
+    }
+
+    if (flags.all && flags.collection) {
+      return this.error(
+        "Flag --collection cannot be provided when using --all",
+      );
+    }
+
+    return flags.all ? this.pushAllSchemas() : this.pushOneSchema();
+  }
+
+  async pushOneSchema(): Promise<void> {
+    const { flags } = this.props;
+    const itemType = this.parseItemType();
+    this.validateCollectionUsage(itemType);
+
+    const schemasDirCtx = await this.getSchemasDirContext();
+    const schemaFileCtx = await Schema.schemaFileContext(
+      schemasDirCtx.abspath,
+      itemType,
+      flags.collection,
+    );
+
+    const [schema, readErrors] = await Schema.readSchemaFile(schemaFileCtx);
+    if (readErrors.length > 0) {
+      this.error(formatErrors(readErrors, { prependBy: "\n\n" }));
+    }
+
+    await this.pushSchema({
+      ...schemaFileCtx,
+      content: this.normalizeSchemaForPush(schema!, itemType, flags.collection),
+    });
+
+    const scope = formatCommandScope(flags);
+    this.log(`‣ Successfully pushed 1 schema to ${scope}`);
+  }
+
+  async pushAllSchemas(): Promise<void> {
+    const schemasDirCtx = await this.getSchemasDirContext();
+    const [schemas, readErrors] = await Schema.readAllSchemaFiles(
+      schemasDirCtx.abspath,
+    );
+
+    if (readErrors.length > 0) {
+      this.error(formatErrors(readErrors, { prependBy: "\n\n" }));
+    }
+
+    if (schemas.length === 0) {
+      this.error(`No schema files found in ${schemasDirCtx.abspath}`);
+    }
+
+    for (const schema of schemas) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.pushSchema({
+        ...schema,
+        content: this.normalizeSchemaForPush(
+          schema.content,
+          schema.itemType,
+          schema.collection,
+        ),
+      });
+    }
+
+    const schemaPaths = schemas.map((schema) => schema.abspath);
+    const scope = formatCommandScope(this.props.flags);
+    this.log(
+      `‣ Successfully pushed ${schemas.length} schema file(s) to ${scope}:\n` +
+        indentString(schemaPaths.join("\n"), 4),
+    );
+  }
+
+  private async pushSchema(
+    schema: Schema.SchemaFileDataContext,
+  ): Promise<void> {
+    try {
+      const resp = await withSpinner<UpsertSchemaResp>(
+        () =>
+          this.apiV1.upsertSchema(
+            this.props,
+            schema.itemType,
+            schema.content,
+            schema.collection,
+          ),
+        { action: "‣ Pushing" },
+      );
+
+      if (resp.data.schema) {
+        await Schema.writeSchemaFileFromData(schema, resp.data.schema);
+      }
+    } catch (error) {
+      const sourceError = new SourceError(
+        (error as Error).message,
+        schema.abspath,
+        "ApiError",
+      );
+      this.error(formatError(sourceError));
+    }
+  }
+
+  private normalizeSchemaForPush(
+    schema: Schema.SchemaData,
+    itemType: Schema.SchemaItemType,
+    collection?: string,
+  ): Schema.SchemaData {
+    return {
+      ...schema,
+      item_type: itemType,
+      item_id: itemType === "object" ? collection : null,
+    };
+  }
+
+  private parseItemType(): Schema.SchemaItemType {
+    const { itemType } = this.props.args;
+    if (!itemType) {
+      return this.error("Missing 1 required arg:\nitemType");
+    }
+
+    try {
+      return Schema.validateSchemaItemType(itemType);
+    } catch (error) {
+      return this.error((error as Error).message);
+    }
+  }
+
+  private validateCollectionUsage(itemType: Schema.SchemaItemType): void {
+    const { collection } = this.props.flags;
+
+    if (itemType === "object" && !collection) {
+      this.error("Flag --collection is required when itemType is `object`");
+    }
+
+    if (itemType !== "object" && collection) {
+      this.error("Flag --collection can only be provided for object schemas");
+    }
+  }
+
+  private async getSchemasDirContext() {
+    return this.props.flags["schemas-dir"]
+      ? this.props.flags["schemas-dir"]
+      : Schema.resolveSchemasDir(this.projectConfig, this.runContext.cwd);
+  }
+}

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -177,6 +177,14 @@ export default class SchemaPush extends BaseCommand<typeof SchemaPush> {
     if (itemType !== "object" && collection) {
       this.error("Flag --collection can only be provided for object schemas");
     }
+
+    if (itemType === "object" && collection) {
+      try {
+        Schema.validateSchemaCollection(collection);
+      } catch (error) {
+        this.error((error as Error).message);
+      }
+    }
   }
 
   private async getSchemasDirContext() {

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -5,7 +5,7 @@ import BaseCommand from "@/lib/base-command";
 import { formatCommandScope } from "@/lib/helpers/command";
 import { formatError, formatErrors, SourceError } from "@/lib/helpers/error";
 import * as CustomFlags from "@/lib/helpers/flag";
-import { withSpinner } from "@/lib/helpers/request";
+import { formatErrorRespMessage, withSpinner } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
 import * as Schema from "@/lib/marshal/schema";
 
@@ -129,9 +129,11 @@ export default class SchemaPush extends BaseCommand<typeof SchemaPush> {
         { action: "‣ Pushing" },
       );
 
-      if (resp.data.schema) {
-        await Schema.writeSchemaFileFromData(schema, resp.data.schema);
+      if (!resp.data.schema) {
+        throw new Error(formatErrorRespMessage(resp));
       }
+
+      await Schema.writeSchemaFileFromData(schema, resp.data.schema);
     } catch (error) {
       const sourceError = new SourceError(
         (error as Error).message,

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -593,12 +593,13 @@ export default class ApiV1 {
 
   async listSchemas(
     { flags }: Props,
-    filters: { itemType?: Schema.SchemaItemType } = {},
+    filters: { itemType?: Schema.SchemaItemType; after?: string } = {},
   ): Promise<AxiosResponse<ListSchemaResp>> {
     const params = prune({
       environment: flags.environment,
       branch: flags.branch,
       item_type: filters.itemType,
+      after: filters.after,
     });
 
     return this.get("/schemas", { params });

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -15,6 +15,7 @@ import * as EmailLayout from "@/lib/marshal/email-layout";
 import * as Guide from "@/lib/marshal/guide";
 import * as MessageType from "@/lib/marshal/message-type";
 import * as Partial from "@/lib/marshal/partial";
+import * as Schema from "@/lib/marshal/schema";
 import { MaybeWithAnnotation } from "@/lib/marshal/shared/types";
 import * as Source from "@/lib/marshal/source";
 import * as Translation from "@/lib/marshal/translation";
@@ -588,6 +589,51 @@ export default class ApiV1 {
     return this.put(`/guides/${args.guideKey}/activate`, {}, { params });
   }
 
+  // By resources: Schemas
+
+  async listSchemas(
+    { flags }: Props,
+    filters: { itemType?: Schema.SchemaItemType } = {},
+  ): Promise<AxiosResponse<ListSchemaResp>> {
+    const params = prune({
+      environment: flags.environment,
+      branch: flags.branch,
+      item_type: filters.itemType,
+    });
+
+    return this.get("/schemas", { params });
+  }
+
+  async getSchema(
+    { flags }: Props,
+    itemType: Schema.SchemaItemType,
+    collection?: string,
+  ): Promise<AxiosResponse<GetSchemaResp>> {
+    const params = prune({
+      environment: flags.environment,
+      branch: flags.branch,
+      item_id: collection,
+    });
+
+    return this.get(`/schemas/${itemType}`, { params });
+  }
+
+  async upsertSchema(
+    { flags }: Props,
+    itemType: Schema.SchemaItemType,
+    schema: Schema.SchemaData,
+    collection?: string,
+  ): Promise<AxiosResponse<UpsertSchemaResp>> {
+    const params = prune({
+      environment: flags.environment,
+      branch: flags.branch,
+      item_id: collection,
+    });
+    const data = { schema };
+
+    return this.put(`/schemas/${itemType}`, data, { params });
+  }
+
   async listAllChannels(): Promise<Channel[]> {
     const channels: Channel[] = [];
     for await (const channel of this.mgmtClient.channels.list()) {
@@ -774,5 +820,17 @@ export type ListSourceResp<A extends MaybeWithAnnotation = unknown> =
 
 export type GetSourceResp<A extends MaybeWithAnnotation = unknown> =
   Source.SourceData<A>;
+
+export type ListSchemaResp = PaginatedResp<Schema.SchemaData>;
+
+export type GetSchemaResp = {
+  schema?: Schema.SchemaData;
+  errors?: InputError[];
+};
+
+export type UpsertSchemaResp = {
+  schema?: Schema.SchemaData;
+  errors?: InputError[];
+};
 
 export type ListBranchResp = PaginatedResp<Branch>;

--- a/src/lib/marshal/schema/helpers.ts
+++ b/src/lib/marshal/schema/helpers.ts
@@ -1,0 +1,111 @@
+import path from "node:path";
+
+import * as fs from "fs-extra";
+
+import { DirContext } from "@/lib/helpers/fs";
+import { ProjectConfig } from "@/lib/helpers/project-config";
+
+import {
+  SCHEMA_ITEM_TYPES,
+  SchemaData,
+  SchemaFileContext,
+  SchemaItemType,
+} from "./types";
+
+export const SCHEMA_FILE_SCHEMA = "https://schemas.knock.app/cli/schema.json";
+
+export const isSchemaItemType = (value: string): value is SchemaItemType =>
+  SCHEMA_ITEM_TYPES.includes(value as SchemaItemType);
+
+export const validateSchemaItemType = (value: string): SchemaItemType => {
+  if (!isSchemaItemType(value)) {
+    throw new Error(
+      `Invalid item type \`${value}\`. Must be one of: ${SCHEMA_ITEM_TYPES.join(
+        ", ",
+      )}`,
+    );
+  }
+
+  return value;
+};
+
+export const validateSchemaCollection = (collection: string): string => {
+  if (
+    !collection ||
+    collection.includes("/") ||
+    collection.includes("\\") ||
+    collection === "." ||
+    collection === ".."
+  ) {
+    throw new Error(`Invalid object collection \`${collection}\``);
+  }
+
+  return collection;
+};
+
+export const resolveSchemasDir = async (
+  projectConfig: ProjectConfig | undefined,
+  basePath: string,
+): Promise<DirContext> => {
+  const schemasDirPath = projectConfig
+    ? path.resolve(
+        path.isAbsolute(projectConfig.knockDir)
+          ? projectConfig.knockDir
+          : path.resolve(basePath, projectConfig.knockDir),
+        "schemas",
+      )
+    : path.resolve(basePath, "schemas");
+
+  const exists = await fs.pathExists(schemasDirPath);
+  if (exists && !(await fs.lstat(schemasDirPath)).isDirectory()) {
+    throw new Error(`${schemasDirPath} is not a directory`);
+  }
+
+  return { abspath: schemasDirPath, exists };
+};
+
+export const schemaFilePath = (
+  schemasDirPath: string,
+  itemType: SchemaItemType,
+  collection?: string,
+): string => {
+  if (itemType === "object") {
+    return path.resolve(
+      schemasDirPath,
+      "objects",
+      `${validateSchemaCollection(collection ?? "")}.json`,
+    );
+  }
+
+  return path.resolve(schemasDirPath, `${itemType}.json`);
+};
+
+export const schemaFileContext = async (
+  schemasDirPath: string,
+  itemType: SchemaItemType,
+  collection?: string,
+): Promise<SchemaFileContext> => {
+  const abspath = schemaFilePath(schemasDirPath, itemType, collection);
+  const exists = await fs.pathExists(abspath);
+
+  if (exists && !(await fs.lstat(abspath)).isFile()) {
+    throw new Error(`${abspath} is not a file`);
+  }
+
+  return { itemType, collection, abspath, exists };
+};
+
+export const schemaTargetFromData = (
+  schema: SchemaData,
+): { itemType: SchemaItemType; collection?: string } => {
+  const itemType = validateSchemaItemType(schema.item_type);
+
+  if (itemType === "object") {
+    return {
+      itemType,
+      collection: validateSchemaCollection(schema.item_id ?? ""),
+    };
+  }
+
+  return { itemType };
+};

--- a/src/lib/marshal/schema/index.ts
+++ b/src/lib/marshal/schema/index.ts
@@ -1,0 +1,4 @@
+export * from "./helpers";
+export * from "./reader";
+export * from "./types";
+export * from "./writer";

--- a/src/lib/marshal/schema/reader.ts
+++ b/src/lib/marshal/schema/reader.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+import * as fs from "fs-extra";
+
+import { formatErrors, SourceError } from "@/lib/helpers/error";
+import { readJson } from "@/lib/helpers/json";
+import { omitDeep } from "@/lib/helpers/object.isomorphic";
+
+import { schemaFileContext, validateSchemaItemType } from "./helpers";
+import { SchemaData, SchemaFileContext, SchemaFileDataContext } from "./types";
+
+export const readSchemaFile = async (
+  schemaFileCtx: SchemaFileContext,
+): Promise<[SchemaData | undefined, SourceError[]]> => {
+  if (!schemaFileCtx.exists) {
+    throw new Error(
+      `Cannot locate schema file at \`${schemaFileCtx.abspath}\``,
+    );
+  }
+
+  const [schemaJson, readErrors] = await readJson(schemaFileCtx.abspath);
+  if (!schemaJson) {
+    return [
+      undefined,
+      [new SourceError(formatErrors(readErrors), schemaFileCtx.abspath)],
+    ];
+  }
+
+  const schema = omitDeep(schemaJson, ["$schema", "__readonly"]) as SchemaData;
+  return [schema, []];
+};
+
+export const readAllSchemaFiles = async (
+  schemasDirPath: string,
+): Promise<[SchemaFileDataContext[], SourceError[]]> => {
+  if (!(await fs.pathExists(schemasDirPath))) {
+    throw new Error(`Cannot locate schema files in \`${schemasDirPath}\``);
+  }
+
+  const schemas: SchemaFileDataContext[] = [];
+  const errors: SourceError[] = [];
+
+  for (const itemType of ["user", "tenant"] as const) {
+    // eslint-disable-next-line no-await-in-loop
+    const ctx = await schemaFileContext(schemasDirPath, itemType);
+    if (!ctx.exists) continue;
+
+    // eslint-disable-next-line no-await-in-loop
+    const [content, readErrors] = await readSchemaFile(ctx);
+    if (readErrors.length > 0) {
+      errors.push(...readErrors);
+      continue;
+    }
+
+    schemas.push({ ...ctx, content: content! });
+  }
+
+  const objectsDirPath = path.resolve(schemasDirPath, "objects");
+  if (await fs.pathExists(objectsDirPath)) {
+    const dirents = await fs.readdir(objectsDirPath, { withFileTypes: true });
+
+    for (const dirent of dirents) {
+      if (!dirent.isFile() || !dirent.name.endsWith(".json")) continue;
+
+      const collection = path.basename(dirent.name, ".json");
+      // eslint-disable-next-line no-await-in-loop
+      const ctx = await schemaFileContext(schemasDirPath, "object", collection);
+      // eslint-disable-next-line no-await-in-loop
+      const [content, readErrors] = await readSchemaFile(ctx);
+      if (readErrors.length > 0) {
+        errors.push(...readErrors);
+        continue;
+      }
+
+      schemas.push({ ...ctx, content: content! });
+    }
+  }
+
+  return [
+    schemas.map((schema) => ({
+      ...schema,
+      content: {
+        ...schema.content,
+        item_type: validateSchemaItemType(schema.content.item_type),
+      },
+    })),
+    errors,
+  ];
+};

--- a/src/lib/marshal/schema/reader.ts
+++ b/src/lib/marshal/schema/reader.ts
@@ -76,14 +76,22 @@ export const readAllSchemaFiles = async (
     }
   }
 
-  return [
-    schemas.map((schema) => ({
-      ...schema,
-      content: {
-        ...schema.content,
-        item_type: validateSchemaItemType(schema.content.item_type),
-      },
-    })),
-    errors,
-  ];
+  const validated: SchemaFileDataContext[] = [];
+  for (const schema of schemas) {
+    try {
+      validated.push({
+        ...schema,
+        content: {
+          ...schema.content,
+          item_type: validateSchemaItemType(schema.content.item_type),
+        },
+      });
+    } catch (error) {
+      errors.push(
+        new SourceError((error as Error).message, schema.abspath, "ReadError"),
+      );
+    }
+  }
+
+  return [validated, errors];
 };

--- a/src/lib/marshal/schema/reader.ts
+++ b/src/lib/marshal/schema/reader.ts
@@ -79,12 +79,20 @@ export const readAllSchemaFiles = async (
   const validated: SchemaFileDataContext[] = [];
   for (const schema of schemas) {
     try {
+      const itemType = validateSchemaItemType(schema.content.item_type);
+
+      // The file path determines where a schema is pushed, so a file that
+      // declares a different item_type is ambiguous. Error instead of silently
+      // reinterpreting it.
+      if (itemType !== schema.itemType) {
+        throw new Error(
+          `Schema file declares item_type \`${itemType}\` but its file path implies \`${schema.itemType}\``,
+        );
+      }
+
       validated.push({
         ...schema,
-        content: {
-          ...schema.content,
-          item_type: validateSchemaItemType(schema.content.item_type),
-        },
+        content: { ...schema.content, item_type: itemType },
       });
     } catch (error) {
       errors.push(

--- a/src/lib/marshal/schema/reader.ts
+++ b/src/lib/marshal/schema/reader.ts
@@ -63,8 +63,24 @@ export const readAllSchemaFiles = async (
       if (!dirent.isFile() || !dirent.name.endsWith(".json")) continue;
 
       const collection = path.basename(dirent.name, ".json");
-      // eslint-disable-next-line no-await-in-loop
-      const ctx = await schemaFileContext(schemasDirPath, "object", collection);
+
+      // An invalid filename (e.g. `..json`) fails collection validation;
+      // collect it like any other read error instead of aborting the run.
+      let ctx: SchemaFileContext;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        ctx = await schemaFileContext(schemasDirPath, "object", collection);
+      } catch (error) {
+        errors.push(
+          new SourceError(
+            (error as Error).message,
+            path.resolve(objectsDirPath, dirent.name),
+            "ReadError",
+          ),
+        );
+        continue;
+      }
+
       // eslint-disable-next-line no-await-in-loop
       const [content, readErrors] = await readSchemaFile(ctx);
       if (readErrors.length > 0) {
@@ -87,6 +103,18 @@ export const readAllSchemaFiles = async (
       if (itemType !== schema.itemType) {
         throw new Error(
           `Schema file declares item_type \`${itemType}\` but its file path implies \`${schema.itemType}\``,
+        );
+      }
+
+      // Same for an object schema whose declared item_id disagrees with its
+      // objects/<collection>.json path.
+      if (
+        itemType === "object" &&
+        schema.content.item_id &&
+        schema.content.item_id !== schema.collection
+      ) {
+        throw new Error(
+          `Schema file declares item_id \`${schema.content.item_id}\` but its file path implies \`${schema.collection}\``,
         );
       }
 

--- a/src/lib/marshal/schema/types.ts
+++ b/src/lib/marshal/schema/types.ts
@@ -18,14 +18,6 @@ export type SchemaData = {
   properties: SchemaProperty[];
 };
 
-export type SchemaFileData = SchemaData & {
-  $schema?: string;
-  __readonly?: {
-    item_type?: SchemaItemType;
-    item_id?: string | null;
-  };
-};
-
 export type SchemaFileContext = {
   itemType: SchemaItemType;
   collection?: string;

--- a/src/lib/marshal/schema/types.ts
+++ b/src/lib/marshal/schema/types.ts
@@ -1,0 +1,38 @@
+export const SCHEMA_ITEM_TYPES = ["user", "tenant", "object"] as const;
+
+export type SchemaItemType = (typeof SCHEMA_ITEM_TYPES)[number];
+
+export type SchemaProperty = {
+  key: string;
+  label?: string | null;
+  description?: string | null;
+  type?: string | null;
+  item_type?: string | null;
+  preview_text?: string | null;
+  visible?: boolean | null;
+};
+
+export type SchemaData = {
+  item_type: SchemaItemType;
+  item_id?: string | null;
+  properties: SchemaProperty[];
+};
+
+export type SchemaFileData = SchemaData & {
+  $schema?: string;
+  __readonly?: {
+    item_type?: SchemaItemType;
+    item_id?: string | null;
+  };
+};
+
+export type SchemaFileContext = {
+  itemType: SchemaItemType;
+  collection?: string;
+  abspath: string;
+  exists: boolean;
+};
+
+export type SchemaFileDataContext = SchemaFileContext & {
+  content: SchemaData;
+};

--- a/src/lib/marshal/schema/writer.ts
+++ b/src/lib/marshal/schema/writer.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs-extra";
+
+import { DOUBLE_SPACES } from "@/lib/helpers/json";
+
+import {
+  SCHEMA_FILE_SCHEMA,
+  schemaFileContext,
+  schemaTargetFromData,
+} from "./helpers";
+import { SchemaData, SchemaFileContext } from "./types";
+
+export const schemaJsonForWrite = (
+  schema: SchemaData,
+): Record<string, unknown> => ({
+  $schema: SCHEMA_FILE_SCHEMA,
+  item_type: schema.item_type,
+  item_id: schema.item_id ?? null,
+  properties: schema.properties,
+  __readonly: {
+    item_type: schema.item_type,
+    item_id: schema.item_id ?? null,
+  },
+});
+
+export const writeSchemaFileFromData = async (
+  schemaFileCtx: SchemaFileContext,
+  schema: SchemaData,
+): Promise<void> => {
+  await fs.outputJson(schemaFileCtx.abspath, schemaJsonForWrite(schema), {
+    spaces: DOUBLE_SPACES,
+  });
+};
+
+export const writeSchemasIndexDir = async (
+  schemasDirPath: string,
+  schemas: SchemaData[],
+): Promise<void> => {
+  for (const schema of schemas) {
+    const { itemType, collection } = schemaTargetFromData(schema);
+    // eslint-disable-next-line no-await-in-loop
+    const ctx = await schemaFileContext(schemasDirPath, itemType, collection);
+    // eslint-disable-next-line no-await-in-loop
+    await writeSchemaFileFromData(ctx, schema);
+  }
+};

--- a/src/lib/marshal/schema/writer.ts
+++ b/src/lib/marshal/schema/writer.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import * as fs from "fs-extra";
 
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
@@ -5,6 +7,7 @@ import { DOUBLE_SPACES } from "@/lib/helpers/json";
 import {
   SCHEMA_FILE_SCHEMA,
   schemaFileContext,
+  schemaFilePath,
   schemaTargetFromData,
 } from "./helpers";
 import { SchemaData, SchemaFileContext } from "./types";
@@ -31,10 +34,53 @@ export const writeSchemaFileFromData = async (
   });
 };
 
+/*
+ * Prunes schema files that are no longer present in the remote set, so a later
+ * `schema push --all` cannot push stale schemas back into the environment.
+ * Only removes the file shapes push reads (user.json, tenant.json, and
+ * objects/<collection>.json); anything else in the directory is left alone.
+ */
+const pruneSchemasIndexDir = async (
+  schemasDirPath: string,
+  remoteSchemas: SchemaData[],
+): Promise<void> => {
+  const expectedPaths = new Set(
+    remoteSchemas.map((schema) => {
+      const { itemType, collection } = schemaTargetFromData(schema);
+      return schemaFilePath(schemasDirPath, itemType, collection);
+    }),
+  );
+
+  const candidatePaths = [
+    path.resolve(schemasDirPath, "user.json"),
+    path.resolve(schemasDirPath, "tenant.json"),
+  ];
+
+  const objectsDirPath = path.resolve(schemasDirPath, "objects");
+  if (await fs.pathExists(objectsDirPath)) {
+    const dirents = await fs.readdir(objectsDirPath, { withFileTypes: true });
+    for (const dirent of dirents) {
+      if (dirent.isFile() && dirent.name.endsWith(".json")) {
+        candidatePaths.push(path.resolve(objectsDirPath, dirent.name));
+      }
+    }
+  }
+
+  await Promise.all(
+    candidatePaths
+      .filter((abspath) => !expectedPaths.has(abspath))
+      .map((abspath) => fs.remove(abspath)),
+  );
+};
+
 export const writeSchemasIndexDir = async (
   schemasDirPath: string,
   schemas: SchemaData[],
 ): Promise<void> => {
+  if (await fs.pathExists(schemasDirPath)) {
+    await pruneSchemasIndexDir(schemasDirPath, schemas);
+  }
+
   for (const schema of schemas) {
     const { itemType, collection } = schemaTargetFromData(schema);
     // eslint-disable-next-line no-await-in-loop

--- a/src/lib/marshal/schema/writer.ts
+++ b/src/lib/marshal/schema/writer.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 
 import * as fs from "fs-extra";
+import { uniqueId } from "lodash";
 
+import { sandboxDir } from "@/lib/helpers/const";
 import { DOUBLE_SPACES } from "@/lib/helpers/json";
 
 import {
@@ -77,15 +79,37 @@ export const writeSchemasIndexDir = async (
   schemasDirPath: string,
   schemas: SchemaData[],
 ): Promise<void> => {
-  if (await fs.pathExists(schemasDirPath)) {
-    await pruneSchemasIndexDir(schemasDirPath, schemas);
-  }
+  const dirExists = await fs.pathExists(schemasDirPath);
+  const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
 
-  for (const schema of schemas) {
-    const { itemType, collection } = schemaTargetFromData(schema);
-    // eslint-disable-next-line no-await-in-loop
-    const ctx = await schemaFileContext(schemasDirPath, itemType, collection);
-    // eslint-disable-next-line no-await-in-loop
-    await writeSchemaFileFromData(ctx, schema);
+  try {
+    // If the schemas directory already exists, back it up in the temp sandbox
+    // before pruning stale files, so a failed write can restore it.
+    if (dirExists) {
+      await fs.copy(schemasDirPath, backupDirPath);
+      await pruneSchemasIndexDir(schemasDirPath, schemas);
+    }
+
+    for (const schema of schemas) {
+      const { itemType, collection } = schemaTargetFromData(schema);
+      // eslint-disable-next-line no-await-in-loop
+      const ctx = await schemaFileContext(schemasDirPath, itemType, collection);
+      // eslint-disable-next-line no-await-in-loop
+      await writeSchemaFileFromData(ctx, schema);
+    }
+  } catch (error) {
+    // In case of any error, wipe the schemas directory that is likely in a bad
+    // state then restore the backup if one existed before.
+    if (dirExists) {
+      await fs.emptyDir(schemasDirPath);
+      await fs.copy(backupDirPath, schemasDirPath);
+    } else {
+      await fs.remove(schemasDirPath);
+    }
+
+    throw error;
+  } finally {
+    // Always clean up the backup directory in the temp sandbox.
+    await fs.remove(backupDirPath);
   }
 };

--- a/src/lib/marshal/schema/writer.ts
+++ b/src/lib/marshal/schema/writer.ts
@@ -81,12 +81,14 @@ export const writeSchemasIndexDir = async (
 ): Promise<void> => {
   const dirExists = await fs.pathExists(schemasDirPath);
   const backupDirPath = path.resolve(sandboxDir, uniqueId("backup"));
+  let backedUp = false;
 
   try {
     // If the schemas directory already exists, back it up in the temp sandbox
     // before pruning stale files, so a failed write can restore it.
     if (dirExists) {
       await fs.copy(schemasDirPath, backupDirPath);
+      backedUp = true;
       await pruneSchemasIndexDir(schemasDirPath, schemas);
     }
 
@@ -99,11 +101,13 @@ export const writeSchemasIndexDir = async (
     }
   } catch (error) {
     // In case of any error, wipe the schemas directory that is likely in a bad
-    // state then restore the backup if one existed before.
-    if (dirExists) {
+    // state then restore the backup, but only when the backup completed. If
+    // the backup copy itself failed, nothing has touched the original tree, so
+    // leave it alone.
+    if (dirExists && backedUp) {
       await fs.emptyDir(schemasDirPath);
       await fs.copy(backupDirPath, schemasDirPath);
-    } else {
+    } else if (!dirExists) {
       await fs.remove(schemasDirPath);
     }
 

--- a/test/commands/schema/pull.test.ts
+++ b/test/commands/schema/pull.test.ts
@@ -116,6 +116,42 @@ describe("commands/schema/pull", () => {
       ).to.be.true;
     });
 
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(enquirer.prototype, "prompt", (stub) =>
+      stub.resolves({ input: true }),
+    )
+    .stub(KnockApiV1.prototype, "listSchemas", (stub) =>
+      stub
+        .onFirstCall()
+        .resolves(
+          factory.resp({
+            data: factory.paginatedResp([userSchema], { after: "cursor" }),
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          factory.resp({
+            data: factory.paginatedResp([objectSchema], { after: null }),
+          }),
+        ),
+    )
+    .stdout()
+    .command(["schema pull", "--all", "--force"])
+    .it("pulls all schemas across paginated pages", () => {
+      sinon.assert.calledTwice(
+        KnockApiV1.prototype.listSchemas as sinon.SinonStub,
+      );
+
+      expect(fs.existsSync(path.resolve(sandboxDir, "schemas", "user.json"))).to
+        .be.true;
+      expect(
+        fs.existsSync(
+          path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        ),
+      ).to.be.true;
+    });
+
   setupGetSchema()
     .stdout()
     .command(["schema pull", "object"])

--- a/test/commands/schema/pull.test.ts
+++ b/test/commands/schema/pull.test.ts
@@ -1,0 +1,130 @@
+import * as path from "node:path";
+
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import * as fs from "fs-extra";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+import { sandboxDir } from "@/lib/helpers/const";
+import { SchemaData } from "@/lib/marshal/schema";
+
+const userSchema: SchemaData = {
+  item_type: "user",
+  item_id: null,
+  properties: [{ key: "email", type: "string", visible: true }],
+};
+
+const objectSchema: SchemaData = {
+  item_type: "object",
+  item_id: "accounts",
+  properties: [{ key: "plan", type: "string", visible: true }],
+};
+
+const currCwd = process.cwd();
+
+const setupGetSchema = (schema = userSchema) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(enquirer.prototype, "prompt", (stub) =>
+      stub.resolves({ input: true }),
+    )
+    .stub(KnockApiV1.prototype, "getSchema", (stub) =>
+      stub.resolves(factory.resp({ data: { schema } })),
+    );
+
+describe("commands/schema/pull", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+    process.chdir(sandboxDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  setupGetSchema()
+    .stdout()
+    .command(["schema pull", "user", "--force"])
+    .it("pulls one user schema into schemas/user.json", () => {
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.getSchema as sinon.SinonStub,
+        sinon.match.any,
+        "user",
+        sinon.match((value) => value === undefined, "undefined"),
+      );
+
+      const schemaPath = path.resolve(sandboxDir, "schemas", "user.json");
+      expect(fs.existsSync(schemaPath)).to.be.true;
+      expect(fs.readJsonSync(schemaPath)).to.eql({
+        $schema: "https://schemas.knock.app/cli/schema.json",
+        item_type: "user",
+        item_id: null,
+        properties: [{ key: "email", type: "string", visible: true }],
+        __readonly: { item_type: "user", item_id: null },
+      });
+    });
+
+  setupGetSchema(objectSchema)
+    .stdout()
+    .command(["schema pull", "object", "--collection", "accounts", "--force"])
+    .it("pulls one object schema into schemas/objects/:collection.json", () => {
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.getSchema as sinon.SinonStub,
+        sinon.match.any,
+        "object",
+        "accounts",
+      );
+
+      const schemaPath = path.resolve(
+        sandboxDir,
+        "schemas",
+        "objects",
+        "accounts.json",
+      );
+      expect(fs.existsSync(schemaPath)).to.be.true;
+    });
+
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(enquirer.prototype, "prompt", (stub) =>
+      stub.resolves({ input: true }),
+    )
+    .stub(KnockApiV1.prototype, "listSchemas", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: factory.paginatedResp([userSchema, objectSchema]),
+        }),
+      ),
+    )
+    .stdout()
+    .command(["schema pull", "--all", "--force"])
+    .it("pulls all schemas returned by the list endpoint", () => {
+      sinon.assert.calledOnce(
+        KnockApiV1.prototype.listSchemas as sinon.SinonStub,
+      );
+
+      expect(fs.existsSync(path.resolve(sandboxDir, "schemas", "user.json"))).to
+        .be.true;
+      expect(
+        fs.existsSync(
+          path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        ),
+      ).to.be.true;
+    });
+
+  setupGetSchema()
+    .stdout()
+    .command(["schema pull", "object"])
+    .exit(2)
+    .it("requires --collection for one object schema pull");
+
+  setupGetSchema()
+    .stdout()
+    .command(["schema pull", "user", "--collection", "accounts"])
+    .exit(2)
+    .it("rejects --collection for user schema pull");
+});

--- a/test/commands/schema/pull.test.ts
+++ b/test/commands/schema/pull.test.ts
@@ -152,6 +152,57 @@ describe("commands/schema/pull", () => {
       ).to.be.true;
     });
 
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(enquirer.prototype, "prompt", (stub) =>
+      stub.resolves({ input: true }),
+    )
+    .stub(KnockApiV1.prototype, "listSchemas", (stub) =>
+      stub.resolves(
+        factory.resp({
+          data: factory.paginatedResp([userSchema, objectSchema]),
+        }),
+      ),
+    )
+    .do(() => {
+      // Stale schema files no longer present remotely, plus an unrelated file
+      // the prune must leave alone.
+      fs.outputJsonSync(path.resolve(sandboxDir, "schemas", "tenant.json"), {
+        item_type: "tenant",
+        properties: [],
+      });
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "objects", "legacy.json"),
+        { item_type: "object", item_id: "legacy", properties: [] },
+      );
+      fs.outputFileSync(
+        path.resolve(sandboxDir, "schemas", "README.md"),
+        "notes",
+      );
+    })
+    .stdout()
+    .command(["schema pull", "--all", "--force"])
+    .it("removes local schema files no longer present remotely", () => {
+      expect(fs.existsSync(path.resolve(sandboxDir, "schemas", "user.json"))).to
+        .be.true;
+      expect(
+        fs.existsSync(
+          path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        ),
+      ).to.be.true;
+
+      expect(fs.existsSync(path.resolve(sandboxDir, "schemas", "tenant.json")))
+        .to.be.false;
+      expect(
+        fs.existsSync(
+          path.resolve(sandboxDir, "schemas", "objects", "legacy.json"),
+        ),
+      ).to.be.false;
+
+      expect(fs.existsSync(path.resolve(sandboxDir, "schemas", "README.md"))).to
+        .be.true;
+    });
+
   setupGetSchema()
     .stdout()
     .command(["schema pull", "object"])

--- a/test/commands/schema/push.test.ts
+++ b/test/commands/schema/push.test.ts
@@ -1,0 +1,128 @@
+import * as path from "node:path";
+
+import { test } from "@oclif/test";
+import * as fs from "fs-extra";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+import { sandboxDir } from "@/lib/helpers/const";
+import { SchemaData } from "@/lib/marshal/schema";
+
+const userSchema: SchemaData = {
+  item_type: "user",
+  item_id: null,
+  properties: [{ key: "email", type: "string", visible: true }],
+};
+
+const objectSchema: SchemaData = {
+  item_type: "object",
+  item_id: "accounts",
+  properties: [{ key: "plan", type: "string", visible: true }],
+};
+
+const currCwd = process.cwd();
+
+const setupUpsertSchema = (schema = userSchema) =>
+  test
+    .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+    .stub(KnockApiV1.prototype, "upsertSchema", (stub) =>
+      stub.resolves(factory.resp({ data: { schema } })),
+    );
+
+describe("commands/schema/push", () => {
+  beforeEach(() => {
+    fs.removeSync(sandboxDir);
+    fs.ensureDirSync(sandboxDir);
+    process.chdir(sandboxDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currCwd);
+    fs.removeSync(sandboxDir);
+  });
+
+  setupUpsertSchema()
+    .do(() => {
+      fs.outputJsonSync(path.resolve(sandboxDir, "schemas", "user.json"), {
+        $schema: "https://schemas.knock.app/cli/schema.json",
+        item_type: "user",
+        item_id: null,
+        properties: [{ key: "email", type: "string", visible: true }],
+        __readonly: { item_type: "user", item_id: null },
+      });
+    })
+    .stdout()
+    .command(["schema push", "user"])
+    .it("pushes one schema file", () => {
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+        sinon.match.any,
+        "user",
+        sinon.match({
+          item_type: "user",
+          item_id: null,
+          properties: [{ key: "email", type: "string", visible: true }],
+        }),
+        sinon.match((value) => value === undefined, "undefined"),
+      );
+    });
+
+  setupUpsertSchema(objectSchema)
+    .do(() => {
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        {
+          item_type: "object",
+          item_id: "accounts",
+          properties: [{ key: "plan", type: "string", visible: true }],
+        },
+      );
+    })
+    .stdout()
+    .command(["schema push", "object", "--collection", "accounts"])
+    .it("pushes one object schema file", () => {
+      sinon.assert.calledWith(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+        sinon.match.any,
+        "object",
+        sinon.match({
+          item_type: "object",
+          item_id: "accounts",
+          properties: [{ key: "plan", type: "string", visible: true }],
+        }),
+        "accounts",
+      );
+    });
+
+  setupUpsertSchema()
+    .do(() => {
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "user.json"),
+        userSchema,
+      );
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        objectSchema,
+      );
+    })
+    .stdout()
+    .command(["schema push", "--all"])
+    .it("pushes every local schema file", () => {
+      sinon.assert.calledTwice(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+      );
+    });
+
+  setupUpsertSchema()
+    .stdout()
+    .command(["schema push", "object"])
+    .exit(2)
+    .it("requires --collection for one object schema push");
+
+  setupUpsertSchema()
+    .stdout()
+    .command(["schema push", "tenant", "--collection", "accounts"])
+    .exit(2)
+    .it("rejects --collection for tenant schema push");
+});

--- a/test/commands/schema/push.test.ts
+++ b/test/commands/schema/push.test.ts
@@ -115,6 +115,23 @@ describe("commands/schema/push", () => {
     });
 
   setupUpsertSchema()
+    .do(() => {
+      // A tenant.json file that declares item_type user contradicts its path.
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "tenant.json"),
+        userSchema,
+      );
+    })
+    .stdout()
+    .command(["schema push", "--all"])
+    .exit(2)
+    .it("errors when a schema file's item_type contradicts its path", () => {
+      sinon.assert.notCalled(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+      );
+    });
+
+  setupUpsertSchema()
     .stdout()
     .command(["schema push", "object"])
     .exit(2)

--- a/test/commands/schema/push.test.ts
+++ b/test/commands/schema/push.test.ts
@@ -132,6 +132,42 @@ describe("commands/schema/push", () => {
     });
 
   setupUpsertSchema()
+    .do(() => {
+      // An accounts.json file that declares a different collection contradicts
+      // its path.
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "objects", "accounts.json"),
+        { ...objectSchema, item_id: "projects" },
+      );
+    })
+    .stdout()
+    .command(["schema push", "--all"])
+    .exit(2)
+    .it("errors when an object schema's item_id contradicts its path", () => {
+      sinon.assert.notCalled(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+      );
+    });
+
+  setupUpsertSchema()
+    .do(() => {
+      // A filename that yields an invalid collection (`.`) must be reported as
+      // a read error, not crash the run.
+      fs.outputJsonSync(
+        path.resolve(sandboxDir, "schemas", "objects", "..json"),
+        objectSchema,
+      );
+    })
+    .stdout()
+    .command(["schema push", "--all"])
+    .exit(2)
+    .it("errors on an invalid object schema filename", () => {
+      sinon.assert.notCalled(
+        KnockApiV1.prototype.upsertSchema as sinon.SinonStub,
+      );
+    });
+
+  setupUpsertSchema()
     .stdout()
     .command(["schema push", "object"])
     .exit(2)

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -191,6 +191,108 @@ describe("lib/api-v1", () => {
     });
   });
 
+  describe("schemas", () => {
+    it("lists schemas with supported params", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "get").returns(
+        Promise.resolve({
+          status: 200,
+          data: factory.paginatedResp([]),
+        }),
+      );
+
+      const flags = {
+        environment: "development",
+        branch: "my-branch",
+        "rogue-flag": "hey",
+        ...factory.gFlags(),
+      };
+      await apiV1.listSchemas(factory.props({ flags }), { itemType: "object" });
+
+      sinon.assert.calledWith(stub, "/v1/schemas", {
+        params: {
+          environment: "development",
+          branch: "my-branch",
+          item_type: "object",
+        },
+      });
+
+      stub.restore();
+    });
+
+    it("gets one schema with supported params", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "get").returns(
+        Promise.resolve({
+          status: 200,
+          data: { schema: {} },
+        }),
+      );
+
+      const flags = {
+        environment: "development",
+        branch: "my-branch",
+        ...factory.gFlags(),
+      };
+      await apiV1.getSchema(factory.props({ flags }), "object", "accounts");
+
+      sinon.assert.calledWith(stub, "/v1/schemas/object", {
+        params: {
+          environment: "development",
+          branch: "my-branch",
+          item_id: "accounts",
+        },
+      });
+
+      stub.restore();
+    });
+
+    it("upserts one schema with a schema envelope", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "put").returns(
+        Promise.resolve({
+          status: 200,
+          data: { schema: {} },
+        }),
+      );
+
+      const flags = {
+        environment: "development",
+        branch: "my-branch",
+        ...factory.gFlags(),
+      };
+      const schema = {
+        item_type: "object" as const,
+        item_id: "accounts",
+        properties: [{ key: "plan", type: "string" }],
+      };
+      await apiV1.upsertSchema(
+        factory.props({ flags }),
+        "object",
+        schema,
+        "accounts",
+      );
+
+      sinon.assert.calledWith(
+        stub,
+        "/v1/schemas/object",
+        { schema },
+        {
+          params: {
+            environment: "development",
+            branch: "my-branch",
+            item_id: "accounts",
+          },
+        },
+      );
+
+      stub.restore();
+    });
+  });
+
   describe("listCommits", () => {
     it("makes a GET request to /v1/commits with supported params", async () => {
       const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);


### PR DESCRIPTION
### Description
Adds the `schema` command topic:

- `knock schema pull [ITEMTYPE]`
- `knock schema push [ITEMTYPE]`

Supported local layout:

- `schemas/user.json`
- `schemas/tenant.json`
- `schemas/objects/<collection>.json`

Pull supports single schema pulls and `--all` via `GET /v1/schemas`. Push supports single schema pushes and `--all` by discovering local schema files. Schema files include `$schema` plus `__readonly` metadata for `item_type` and `item_id`, and push strips local-only metadata before calling the API.

