### PR TITLE
feat: add --allow-empty support for empty commits

### DIFF
--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -7,7 +7,14 @@ import { KnockEnv } from "@/lib/helpers/const";
 import * as CustomFlags from "@/lib/helpers/flag";
 import { withSpinner } from "@/lib/helpers/request";
 import { promptToConfirm } from "@/lib/helpers/ux";
-import { ALL_RESOURCE_TYPES } from "@/lib/resources";
+import {
+  ALL_RESOURCE_TYPES,
+  ALLOW_EMPTY_RESOURCE_TYPES,
+} from "@/lib/resources";
+
+const ALLOW_EMPTY_RESOURCE_TYPE_SET = new Set<string>(
+  ALLOW_EMPTY_RESOURCE_TYPES,
+);
 
 export default class Commit extends BaseCommand<typeof Commit> {
   static summary =
@@ -28,6 +35,7 @@ export default class Commit extends BaseCommand<typeof Commit> {
     force: Flags.boolean({
       summary: "Remove the confirmation prompt.",
     }),
+    "allow-empty": CustomFlags.allowEmpty,
     "resource-type": Flags.string({
       summary:
         "Commit only changes for the given resource type. Can be used alone or together with --resource-id.",
@@ -48,10 +56,27 @@ export default class Commit extends BaseCommand<typeof Commit> {
       );
     }
 
+    if (flags["allow-empty"]) {
+      if (!flags["resource-type"] || !flags["resource-id"]) {
+        this.error(
+          "The --allow-empty flag must be used with a single --resource-type and --resource-id.",
+        );
+      }
+
+      if (!ALLOW_EMPTY_RESOURCE_TYPE_SET.has(flags["resource-type"])) {
+        this.error(
+          "Empty commits for `audience` are not yet supported. Other supported resource types: " +
+            ALLOW_EMPTY_RESOURCE_TYPES.join(", "),
+        );
+      }
+    }
+
     const scope = formatCommandScope(flags);
     const qualifier = this.formatResourceQualifier(flags);
 
-    const prompt = qualifier
+    const prompt = flags["allow-empty"]
+      ? `Create empty commit for ${qualifier} in the ${scope}?`
+      : qualifier
       ? `Commit ${qualifier} in the ${scope}?`
       : `Commit all changes in the ${scope}?`;
     const input = flags.force || (await promptToConfirm(prompt));
@@ -61,7 +86,9 @@ export default class Commit extends BaseCommand<typeof Commit> {
       this.apiV1.commitAllChanges(this.props),
     );
 
-    const successMsg = qualifier
+    const successMsg = flags["allow-empty"]
+      ? `‣ Successfully created empty commit for ${qualifier} in ${scope}`
+      : qualifier
       ? `‣ Successfully committed ${qualifier} in ${scope}`
       : `‣ Successfully committed all changes in ${scope}`;
     this.log(successMsg);
@@ -72,7 +99,7 @@ export default class Commit extends BaseCommand<typeof Commit> {
     "resource-id"?: string;
   }): string | null {
     if (flags["resource-type"] && flags["resource-id"]) {
-      return `\`${flags["resource-type"]}\` changes for \`${flags["resource-id"]}\``;
+      return `\`${flags["resource-type"]}\` \`${flags["resource-id"]}\``;
     }
 
     if (flags["resource-type"]) {

--- a/src/commands/guide/push.ts
+++ b/src/commands/guide/push.ts
@@ -38,6 +38,7 @@ export default class GuidePush extends BaseCommand<typeof GuidePush> {
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/commands/layout/push.ts
+++ b/src/commands/layout/push.ts
@@ -44,6 +44,7 @@ export default class EmailLayoutPush extends BaseCommand<
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/commands/message-type/push.ts
+++ b/src/commands/message-type/push.ts
@@ -43,6 +43,7 @@ export default class MessageTypePush extends BaseCommand<
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/commands/partial/push.ts
+++ b/src/commands/partial/push.ts
@@ -41,6 +41,7 @@ export default class PartialPush extends BaseCommand<typeof PartialPush> {
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -45,6 +45,7 @@ export default class Push extends BaseCommand<typeof Push> {
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 
@@ -76,6 +77,7 @@ export default class Push extends BaseCommand<typeof Push> {
       ...(flags["commit-message"]
         ? ["--commit-message", flags["commit-message"]]
         : []),
+      ...(flags["allow-empty"] ? ["--allow-empty"] : []),
       ...(flags.force ? ["--force"] : []),
     ];
 

--- a/src/commands/translation/push.ts
+++ b/src/commands/translation/push.ts
@@ -43,6 +43,7 @@ export default class TranslationPush extends BaseCommand<
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/commands/workflow/push.ts
+++ b/src/commands/workflow/push.ts
@@ -40,6 +40,7 @@ export default class WorkflowPush extends BaseCommand<typeof WorkflowPush> {
       char: "m",
       dependsOn: ["commit"],
     }),
+    "allow-empty": CustomFlags.allowEmptyOnPush,
     force: CustomFlags.force,
   };
 

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -115,6 +115,7 @@ export default class ApiV1 {
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       force: flags.force,
     });
     const data = { workflow };
@@ -194,6 +195,7 @@ export default class ApiV1 {
       environment: flags.environment,
       branch: flags.branch,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       resource_type: flags["resource-type"],
       resource_id: flags["resource-id"],
     });
@@ -260,6 +262,7 @@ export default class ApiV1 {
       branch: flags.branch,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       namespace: translation.namespace,
       force: flags.force,
     });
@@ -327,6 +330,7 @@ export default class ApiV1 {
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       force: flags.force,
     });
     const data = { email_layout: layout };
@@ -389,6 +393,7 @@ export default class ApiV1 {
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       force: flags.force,
     });
     const data = { partial };
@@ -463,6 +468,7 @@ export default class ApiV1 {
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       force: flags.force,
     });
     const data = { message_type: messageType };
@@ -541,6 +547,7 @@ export default class ApiV1 {
       annotate: flags.annotate,
       commit: flags.commit,
       commit_message: flags["commit-message"],
+      allow_empty: flags["allow-empty"],
       force: flags.force,
     });
     const data = { guide };

--- a/src/lib/helpers/flag.ts
+++ b/src/lib/helpers/flag.ts
@@ -124,3 +124,15 @@ export const force = Flags.boolean({
     "Force pushes the resource or resources to Knock, overwriting whatever is currently stored. " +
     "If you're using this on a non-development environment, you should also ensure you `commit` the changes.",
 });
+
+export const allowEmpty = Flags.boolean({
+  summary:
+    "Create an empty commit for an already-published resource (analogous to git commit --allow-empty). " +
+    "Requires --resource-type and --resource-id.",
+});
+
+export const allowEmptyOnPush = Flags.boolean({
+  summary:
+    "Create an empty commit for an already-published resource (analogous to git commit --allow-empty).",
+  dependsOn: ["commit"],
+});

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -10,6 +10,22 @@ export type NonHiddenResourceType = Exclude<ResourceType, "reusable_step">;
  * example, if an email layout references a partial, that partial must be pushed
  * first or else the validation and upsert of the layout will fail.
  */
+/**
+ * Resource types that support empty commits via --allow-empty.
+ * Excludes audience until @knocklabs/mgmt ships allow_empty on upsert params.
+ */
+export const ALLOW_EMPTY_RESOURCE_TYPES = [
+  "partial",
+  "email_layout",
+  "workflow",
+  "message_type",
+  "guide",
+  "translation",
+] as const satisfies readonly NonHiddenResourceType[];
+
+export type AllowEmptyResourceType =
+  (typeof ALLOW_EMPTY_RESOURCE_TYPES)[number];
+
 export const ALL_RESOURCE_TYPES: NonHiddenResourceType[] = [
   // Audiences can be referenced by workflows, so push them early
   "audience",

--- a/test/commands/commit/index.test.ts
+++ b/test/commands/commit/index.test.ts
@@ -175,4 +175,104 @@ describe("commands/commit/index", () => {
         expect(ctx.stdout).to.contain("default");
       });
   });
+
+  describe("given allow-empty flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "commitAllChanges", (stub) =>
+        stub.resolves(factory.resp({ data: "success" })),
+      )
+      .stdout()
+      .command([
+        "commit",
+        "--resource-type",
+        "workflow",
+        "--resource-id",
+        "my-workflow-key",
+        "--allow-empty",
+        "-m",
+        "Empty touch",
+        "--force",
+      ])
+      .it("calls apiV1 commitAllChanges with allow-empty in props", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.commitAllChanges as any,
+          sinon.match(({ flags }) =>
+            isEqual(flags, {
+              "service-token": "valid-token",
+              environment: "development",
+              "commit-message": "Empty touch",
+              "resource-type": "workflow",
+              "resource-id": "my-workflow-key",
+              "allow-empty": true,
+              force: true,
+            }),
+          ),
+        );
+      });
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .stderr()
+      .command(["commit", "--allow-empty", "--force"])
+      .exit(2)
+      .it(
+        "exits when allow-empty is used without resource-type and resource-id",
+      );
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .stderr()
+      .command([
+        "commit",
+        "--allow-empty",
+        "--resource-type",
+        "workflow",
+        "--force",
+      ])
+      .exit(2)
+      .it("exits when allow-empty is used without resource-id");
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stdout()
+      .stderr()
+      .command([
+        "commit",
+        "--allow-empty",
+        "--resource-type",
+        "audience",
+        "--resource-id",
+        "my-audience",
+        "--force",
+      ])
+      .exit(2)
+      .it("exits when allow-empty is used with audience resource type");
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "commitAllChanges", (stub) =>
+        stub.resolves(factory.resp({ data: "success" })),
+      )
+      .stdout()
+      .command([
+        "commit",
+        "--resource-type",
+        "translation",
+        "--resource-id",
+        "es/courses~tenant",
+        "--allow-empty",
+        "--force",
+      ])
+      .it("passes translation resource-id through to commitAllChanges", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.commitAllChanges as any,
+          sinon.match(({ flags }) =>
+            isEqual(flags["resource-id"], "es/courses~tenant"),
+          ),
+        );
+      });
+  });
 });

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -584,6 +584,42 @@ describe("commands/push", () => {
               );
             },
           );
+
+        test
+          .command([
+            "push",
+            "--knock-dir",
+            ".",
+            "--commit",
+            "--allow-empty",
+            "-m",
+            "Empty touch",
+          ])
+          .it("forwards allow-empty to resource push commands", () => {
+            sinon.assert.calledOnceWithExactly(
+              upsertWorkflowStub,
+              sinon.match(
+                ({ args, flags }) =>
+                  isEqual(args, {}) &&
+                  isEqual(flags, {
+                    annotate: true,
+                    "service-token": "valid-token",
+                    environment: "development",
+                    all: true,
+                    "workflows-dir": {
+                      abspath: workflowsSubdirPath,
+                      exists: true,
+                    },
+                    commit: true,
+                    "commit-message": "Empty touch",
+                    "allow-empty": true,
+                  }),
+              ),
+              sinon.match((workflow) =>
+                isEqual(workflow, { key: "foo", name: "Foo" }),
+              ),
+            );
+          });
       });
 
       describe("and a non-empty message-types directory", () => {

--- a/test/commands/workflow/push.test.ts
+++ b/test/commands/workflow/push.test.ts
@@ -128,6 +128,44 @@ describe("commands/workflow/push", () => {
 
     setupWithStub({ data: { workflow: mockWorkflowData } })
       .stdout()
+      .command([
+        "workflow push",
+        "new-comment",
+        "--commit",
+        "--allow-empty",
+        "-m",
+        "Empty touch",
+      ])
+      .it(
+        "calls apiV1 upsertWorkflow with allow-empty flag, if provided",
+        () => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.upsertWorkflow as any,
+            sinon.match(
+              ({ args, flags }) =>
+                isEqual(args, { workflowKey: "new-comment" }) &&
+                isEqual(flags, {
+                  "service-token": "valid-token",
+
+                  environment: "development",
+                  commit: true,
+                  "commit-message": "Empty touch",
+                  "allow-empty": true,
+                  annotate: true,
+                }),
+            ),
+            sinon.match((workflow) =>
+              isEqual(workflow, {
+                key: "new-comment",
+                name: "New comment",
+              }),
+            ),
+          );
+        },
+      );
+
+    setupWithStub({ data: { workflow: mockWorkflowData } })
+      .stdout()
       .command(["workflow push", "new-comment", "--force"])
       .it("calls apiV1 upsertWorkflow with force flag, if provided", () => {
         sinon.assert.calledWith(

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -119,6 +119,47 @@ describe("lib/api-v1", () => {
 
       stub.restore();
     });
+
+    it("makes a PUT request to /v1/workflows/:workflowKey with allow_empty param", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "put").returns(
+        Promise.resolve({
+          data: factory.workflow(),
+        }),
+      );
+
+      const args = { workflowKey: "foo" };
+      const flags = {
+        environment: "development",
+        annotate: true,
+        commit: true,
+        "commit-message": "Empty touch",
+        "allow-empty": true,
+        ...factory.gFlags(),
+      };
+      const workflow = {
+        key: "foo",
+        name: "New campaign",
+      };
+      await apiV1.upsertWorkflow(factory.props({ args, flags }), workflow);
+
+      const params = {
+        environment: "development",
+        annotate: true,
+        commit: true,
+        commit_message: "Empty touch",
+        allow_empty: true,
+      };
+      sinon.assert.calledWith(
+        stub,
+        "/v1/workflows/foo",
+        { workflow },
+        { params },
+      );
+
+      stub.restore();
+    });
   });
 
   describe("validateWorkflow", () => {
@@ -249,6 +290,38 @@ describe("lib/api-v1", () => {
       const params = {
         environment: "development",
         commit_message: "latest changes",
+      };
+      sinon.assert.calledWith(stub, "/v1/commits", {}, { params });
+
+      stub.restore();
+    });
+
+    it("makes a PUT request to /v1/commits with allow_empty param", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "put").returns(
+        Promise.resolve({
+          data: { result: "success" },
+        }),
+      );
+
+      const args = {};
+      const flags = {
+        environment: "development",
+        "commit-message": "Empty touch",
+        "resource-type": "workflow",
+        "resource-id": "my-workflow",
+        "allow-empty": true,
+        ...factory.gFlags(),
+      };
+      await apiV1.commitAllChanges(factory.props({ args, flags }));
+
+      const params = {
+        environment: "development",
+        commit_message: "Empty touch",
+        allow_empty: true,
+        resource_type: "workflow",
+        resource_id: "my-workflow",
       };
       sinon.assert.calledWith(stub, "/v1/commits", {}, { params });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CLI support for empty commits (`allow_empty`), matching the Management API behavior from backend PR #10054. An empty commit publishes a new version row with identical content, enabling downstream promotion when a resource is already committed.

KNO-9038
