### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g @knocklabs/cli
 $ knock COMMAND
 running command...
 $ knock (--version)
-@knocklabs/cli/1.1.5 darwin-arm64 node-v24.13.0
+@knocklabs/cli/1.2.0 darwin-arm64 node-v24.13.0
 $ knock --help [COMMAND]
 USAGE
   $ knock COMMAND
@@ -83,6 +83,10 @@ USAGE
 * [`knock partial validate [PARTIALKEY]`](#knock-partial-validate-partialkey)
 * [`knock pull`](#knock-pull)
 * [`knock push`](#knock-push)
+* [`knock schema pull [ITEMTYPE]`](#knock-schema-pull-itemtype)
+* [`knock schema push [ITEMTYPE]`](#knock-schema-push-itemtype)
+* [`knock source get SOURCEKEY`](#knock-source-get-sourcekey)
+* [`knock source list`](#knock-source-list)
 * [`knock translation get TRANSLATIONREF`](#knock-translation-get-translationref)
 * [`knock translation list`](#knock-translation-list)
 * [`knock translation pull [TRANSLATIONREF]`](#knock-translation-pull-translationref)
@@ -125,7 +129,7 @@ DESCRIPTION
   Use this command with caution.
 ```
 
-_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/archive.ts)_
+_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/archive.ts)_
 
 ## `knock audience get AUDIENCEKEY`
 
@@ -146,7 +150,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/get.ts)_
+_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/get.ts)_
 
 ## `knock audience list`
 
@@ -170,7 +174,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/list.ts)_
+_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/list.ts)_
 
 ## `knock audience new`
 
@@ -195,7 +199,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/new.ts)_
+_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/new.ts)_
 
 ## `knock audience open AUDIENCEKEY`
 
@@ -211,7 +215,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/open.ts)_
+_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/open.ts)_
 
 ## `knock audience pull [AUDIENCEKEY]`
 
@@ -232,7 +236,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/pull.ts)_
+_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/pull.ts)_
 
 ## `knock audience push [AUDIENCEKEY]`
 
@@ -256,7 +260,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/push.ts)_
+_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/push.ts)_
 
 ## `knock audience validate [AUDIENCEKEY]`
 
@@ -276,7 +280,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/audience/validate.ts)_
+_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/validate.ts)_
 
 ## `knock branch create [SLUG]`
 
@@ -296,7 +300,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/create.ts)_
+_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/create.ts)_
 
 ## `knock branch delete SLUG`
 
@@ -314,7 +318,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/delete.ts)_
+_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/delete.ts)_
 
 ## `knock branch exit`
 
@@ -328,7 +332,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/exit.ts)_
+_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/exit.ts)_
 
 ## `knock branch list`
 
@@ -348,7 +352,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/list.ts)_
+_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/list.ts)_
 
 ## `knock branch merge SLUG`
 
@@ -367,7 +371,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/merge.ts)_
+_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/merge.ts)_
 
 ## `knock branch switch SLUG`
 
@@ -386,7 +390,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/branch/switch.ts)_
+_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/switch.ts)_
 
 ## `knock channel list`
 
@@ -403,7 +407,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/channel/list.ts)_
+_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/channel/list.ts)_
 
 ## `knock commit`
 
@@ -430,7 +434,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/commit/index.ts)_
+_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/index.ts)_
 
 ## `knock commit get ID`
 
@@ -447,7 +451,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/commit/get.ts)_
+_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/get.ts)_
 
 ## `knock commit list`
 
@@ -479,7 +483,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/commit/list.ts)_
+_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/list.ts)_
 
 ## `knock commit promote`
 
@@ -496,7 +500,7 @@ FLAGS
   --to=<value>             The destination environment to promote all changes from the preceding environment.
 ```
 
-_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/commit/promote.ts)_
+_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/promote.ts)_
 
 ## `knock environment list`
 
@@ -513,7 +517,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/environment/list.ts)_
+_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/environment/list.ts)_
 
 ## `knock guide activate GUIDEKEY`
 
@@ -544,7 +548,7 @@ DESCRIPTION
   or deactivated at a later time using the --from and --until flags.
 ```
 
-_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/activate.ts)_
+_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/activate.ts)_
 
 ## `knock guide generate-types`
 
@@ -567,7 +571,7 @@ DESCRIPTION
   Generate types for all guides in an environment and write them to a file.
 ```
 
-_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/generate-types.ts)_
+_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/generate-types.ts)_
 
 ## `knock guide get GUIDEKEY`
 
@@ -588,7 +592,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/get.ts)_
+_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/get.ts)_
 
 ## `knock guide list`
 
@@ -612,7 +616,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/list.ts)_
+_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/list.ts)_
 
 ## `knock guide new`
 
@@ -636,7 +640,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/new.ts)_
+_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/new.ts)_
 
 ## `knock guide open GUIDEKEY`
 
@@ -652,7 +656,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/open.ts)_
+_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/open.ts)_
 
 ## `knock guide pull [GUIDEKEY]`
 
@@ -673,7 +677,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/pull.ts)_
+_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/pull.ts)_
 
 ## `knock guide push [GUIDEKEY]`
 
@@ -697,7 +701,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/push.ts)_
+_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/push.ts)_
 
 ## `knock guide validate [GUIDEKEY]`
 
@@ -716,7 +720,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/guide/validate.ts)_
+_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/validate.ts)_
 
 ## `knock help [COMMAND]`
 
@@ -756,7 +760,7 @@ DESCRIPTION
   resources directory.
 ```
 
-_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/init.ts)_
 
 ## `knock layout get EMAILLAYOUTKEY`
 
@@ -777,7 +781,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/get.ts)_
+_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/get.ts)_
 
 ## `knock layout list`
 
@@ -801,7 +805,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/list.ts)_
+_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/list.ts)_
 
 ## `knock layout new`
 
@@ -824,7 +828,7 @@ FLAGS
       --template=<value>       The template to use for the email layout. Should be `email-layouts/{key}`.
 ```
 
-_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/new.ts)_
+_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/new.ts)_
 
 ## `knock layout open LAYOUTKEY`
 
@@ -840,7 +844,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/open.ts)_
+_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/open.ts)_
 
 ## `knock layout pull [EMAILLAYOUTKEY]`
 
@@ -861,7 +865,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/pull.ts)_
+_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/pull.ts)_
 
 ## `knock layout push [EMAILLAYOUTKEY]`
 
@@ -887,7 +891,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/push.ts)_
+_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/push.ts)_
 
 ## `knock layout validate [EMAILLAYOUTKEY]`
 
@@ -907,7 +911,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/layout/validate.ts)_
+_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/validate.ts)_
 
 ## `knock login`
 
@@ -921,7 +925,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/login.ts)_
 
 ## `knock logout`
 
@@ -935,7 +939,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/logout.ts)_
 
 ## `knock message-type get MESSAGETYPEKEY`
 
@@ -956,7 +960,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/get.ts)_
+_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/get.ts)_
 
 ## `knock message-type list`
 
@@ -980,7 +984,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/list.ts)_
+_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/list.ts)_
 
 ## `knock message-type new`
 
@@ -1003,7 +1007,7 @@ FLAGS
       --template=<value>       The template to use for the message type. Should be `message-types/{key}`.
 ```
 
-_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/new.ts)_
+_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/new.ts)_
 
 ## `knock message-type open MESSAGETYPEKEY`
 
@@ -1019,7 +1023,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/open.ts)_
+_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/open.ts)_
 
 ## `knock message-type pull [MESSAGETYPEKEY]`
 
@@ -1040,7 +1044,7 @@ FLAGS
   --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/pull.ts)_
+_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/pull.ts)_
 
 ## `knock message-type push [MESSAGETYPEKEY]`
 
@@ -1066,7 +1070,7 @@ FLAGS
       --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/push.ts)_
+_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/push.ts)_
 
 ## `knock message-type validate [MESSAGETYPEKEY]`
 
@@ -1087,7 +1091,7 @@ FLAGS
   --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/message-type/validate.ts)_
+_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/validate.ts)_
 
 ## `knock partial get PARTIALKEY`
 
@@ -1108,7 +1112,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/get.ts)_
+_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/get.ts)_
 
 ## `knock partial list`
 
@@ -1132,7 +1136,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/list.ts)_
+_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/list.ts)_
 
 ## `knock partial new`
 
@@ -1158,7 +1162,7 @@ FLAGS
                                with --type.
 ```
 
-_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/new.ts)_
+_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/new.ts)_
 
 ## `knock partial open PARTIALKEY`
 
@@ -1174,7 +1178,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/open.ts)_
+_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/open.ts)_
 
 ## `knock partial pull [PARTIALKEY]`
 
@@ -1195,7 +1199,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/pull.ts)_
+_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/pull.ts)_
 
 ## `knock partial push [PARTIALKEY]`
 
@@ -1220,7 +1224,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/push.ts)_
+_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/push.ts)_
 
 ## `knock partial validate [PARTIALKEY]`
 
@@ -1240,7 +1244,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/partial/validate.ts)_
+_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/validate.ts)_
 
 ## `knock pull`
 
@@ -1260,7 +1264,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/pull.ts)_
+_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/pull.ts)_
 
 ## `knock push`
 
@@ -1284,7 +1288,88 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/push.ts)_
+
+## `knock schema pull [ITEMTYPE]`
+
+Pull one or more item schemas from an environment into a local file system.
+
+```
+USAGE
+  $ knock schema pull [ITEMTYPE] [--service-token <value>] [--environment <value>] [--branch <value>] [--all]
+    [--collection <value>] [--schemas-dir <value>] [--force]
+
+FLAGS
+  --all                    Whether to pull all item schemas from the specified environment.
+  --branch=<value>         The slug of the branch to use.
+  --collection=<value>     The object collection key for object schemas.
+  --environment=<value>    [default: development] The environment to use.
+  --force                  Remove the confirmation prompt.
+  --schemas-dir=<value>    The target schemas directory path.
+  --service-token=<value>  The service token to authenticate with.
+```
+
+_See code: [src/commands/schema/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/schema/pull.ts)_
+
+## `knock schema push [ITEMTYPE]`
+
+Push one or more local item schemas to a Knock environment.
+
+```
+USAGE
+  $ knock schema push [ITEMTYPE] [--service-token <value>] [--environment <value>] [--branch <value>] [--all]
+    [--collection <value>] [--schemas-dir <value>]
+
+FLAGS
+  --all                    Whether to push all schemas from the target schemas directory.
+  --branch=<value>         The slug of the branch to use.
+  --collection=<value>     The object collection key for object schemas.
+  --environment=<value>    [default: development] The environment to use.
+  --schemas-dir=<value>    The target schemas directory path.
+  --service-token=<value>  The service token to authenticate with.
+```
+
+_See code: [src/commands/schema/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/schema/push.ts)_
+
+## `knock source get SOURCEKEY`
+
+Display a single source from an environment.
+
+```
+USAGE
+  $ knock source get SOURCEKEY [--json] [--service-token <value>] [--environment <value>]
+
+FLAGS
+  --environment=<value>    The environment to use.
+  --service-token=<value>  The service token to authenticate with.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+```
+
+_See code: [src/commands/source/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/source/get.ts)_
+
+## `knock source list`
+
+Display all sources for an environment.
+
+```
+USAGE
+  $ knock source list [--json] [--service-token <value>] [--environment <value>] [--after <value>] [--before
+    <value>] [--limit <value>]
+
+FLAGS
+  --after=<value>          The cursor after which to fetch the next page.
+  --before=<value>         The cursor before which to fetch the previous page.
+  --environment=<value>    The environment to use.
+  --limit=<value>          The total number of entries to fetch per page.
+  --service-token=<value>  The service token to authenticate with.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+```
+
+_See code: [src/commands/source/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/source/list.ts)_
 
 ## `knock translation get TRANSLATIONREF`
 
@@ -1312,7 +1397,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/translation/get.ts)_
+_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/get.ts)_
 
 ## `knock translation list`
 
@@ -1336,7 +1421,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/translation/list.ts)_
+_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/list.ts)_
 
 ## `knock translation pull [TRANSLATIONREF]`
 
@@ -1364,7 +1449,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to pull all translations into.
 ```
 
-_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/translation/pull.ts)_
+_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/pull.ts)_
 
 ## `knock translation push [TRANSLATIONREF]`
 
@@ -1395,7 +1480,7 @@ FLAGS
       --translations-dir=<value>  The target directory path to find all translations to push.
 ```
 
-_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/translation/push.ts)_
+_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/push.ts)_
 
 ## `knock translation validate [TRANSLATIONREF]`
 
@@ -1421,7 +1506,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to find all translations to validate.
 ```
 
-_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/translation/validate.ts)_
+_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/validate.ts)_
 
 ## `knock whoami`
 
@@ -1438,7 +1523,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/whoami.ts)_
 
 ## `knock workflow activate WORKFLOWKEY`
 
@@ -1467,7 +1552,7 @@ DESCRIPTION
   with `false` in order to deactivate it.
 ```
 
-_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/activate.ts)_
+_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/activate.ts)_
 
 ## `knock workflow generate-types`
 
@@ -1490,7 +1575,7 @@ DESCRIPTION
   Generate types for all workflows in an environment and write them to a file.
 ```
 
-_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/generate-types.ts)_
+_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/generate-types.ts)_
 
 ## `knock workflow get WORKFLOWKEY`
 
@@ -1511,7 +1596,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/get.ts)_
+_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/get.ts)_
 
 ## `knock workflow list`
 
@@ -1535,7 +1620,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/list.ts)_
+_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/list.ts)_
 
 ## `knock workflow new`
 
@@ -1560,7 +1645,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/new.ts)_
+_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/new.ts)_
 
 ## `knock workflow open WORKFLOWKEY`
 
@@ -1576,7 +1661,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/open.ts)_
+_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/open.ts)_
 
 ## `knock workflow pull [WORKFLOWKEY]`
 
@@ -1597,7 +1682,7 @@ FLAGS
   --workflows-dir=<value>     The target directory path to pull all workflows into.
 ```
 
-_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/pull.ts)_
+_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/pull.ts)_
 
 ## `knock workflow push [WORKFLOWKEY]`
 
@@ -1621,7 +1706,7 @@ FLAGS
       --workflows-dir=<value>   The target directory path to find all workflows to push.
 ```
 
-_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/push.ts)_
+_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/push.ts)_
 
 ## `knock workflow run WORKFLOWKEY`
 
@@ -1646,7 +1731,7 @@ FLAGS
   --tenant=<value>         A tenant id for the workflow run.
 ```
 
-_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/run.ts)_
+_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/run.ts)_
 
 ## `knock workflow validate [WORKFLOWKEY]`
 
@@ -1665,5 +1750,5 @@ FLAGS
   --workflows-dir=<value>  The target directory path to find all workflows to validate.
 ```
 
-_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.1.5/src/commands/workflow/validate.ts)_
+_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/validate.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/cli",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Knock CLI",
   "author": "@knocklabs",
   "bin": {


### PR DESCRIPTION
Release version bump to v1.2.0.

## Summary
- Bumps package.json from 1.1.5 to 1.2.0
- Regenerates README with updated command list

## Notable changes since v1.1.5
- feat(KNO-13755): add schema pull and push commands (#824)
- feat(source): add `source get` command (#822)
- feat(source): add `source list` command (#821)

## Test plan
- [ ] CI passes
- [ ] After merge, run `/release cut knock-cli -v 1.2.0` in Slack