### PR TITLE
fix(KNO-14064): pin quicktype-core and ship npm-shrinkwrap.json on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.nyc_output
 /dist
 /lib
+/npm-shrinkwrap.json
 /package-lock.json
 /tmp
 node_modules

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "locale-codes": "^1.3.1",
     "lodash": "^4.18.1",
     "open": "8.4.2",
-    "quicktype-core": "^23.2.6",
+    "quicktype-core": "23.2.6",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -118,8 +118,8 @@
     "format.write": "yarn run format --write",
     "format.check": "yarn run format --check",
     "type.check": "tsc",
-    "postpack": "shx rm -f oclif.manifest.json",
-    "prepack": "yarn build && oclif manifest && oclif readme",
+    "postpack": "shx rm -f oclif.manifest.json npm-shrinkwrap.json",
+    "prepack": "yarn build && oclif manifest && oclif readme && npm shrinkwrap",
     "test": "mocha \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
     "check": "yarn run lint && yarn run format.check && yarn run type.check"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4782,9 +4782,9 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-quicktype-core@^23.2.6:
+quicktype-core@23.2.6:
   version "23.2.6"
-  resolved "https://registry.yarnpkg.com/quicktype-core/-/quicktype-core-23.2.6.tgz#24571b4c162789f847dbc6fab5547383b6e937bd"
+  resolved "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.2.6.tgz#24571b4c162789f847dbc6fab5547383b6e937bd"
   integrity sha512-asfeSv7BKBNVb9WiYhFRBvBZHcRutPRBwJMxW0pefluK4kkKu4lv0IvZBwFKvw2XygLcL1Rl90zxWDHYgkwCmA==
   dependencies:
     "@glideapps/ts-necessities" "2.2.3"


### PR DESCRIPTION
### Description

The published CLI declares `quicktype-core` with a caret range (`^23.2.6`) and ships no lockfile, so npm resolves the dependency fresh at install time. quicktype-core `23.3.1`–`23.3.17` contain a build error that loads `$fetch.ci.js`, which prints `=== RUNNING IN CI, USE FETCH.CI ===` to stdout at module load. Because quicktype-core is imported at the top level of the workflow and guide marshal helpers, that line fired on every workflow/guide command and corrupted `--json` output that CI scripts parse (see customer report in the linked issue).

Two layers of fix, per the issue:

1. **Pin `quicktype-core` to exact `23.2.6`** — the version `yarn.lock` already resolves to, so our own builds are unchanged; consumer installs can no longer drift into the buggy range.
2. **Generate `npm-shrinkwrap.json` in `prepack`** — the `files` array has always listed `/npm-shrinkwrap.json` (oclif boilerplate), but nothing generated it, so it never shipped. Now `npm shrinkwrap` runs at pack/publish time against the yarn-installed `node_modules` (i.e. the exact tree `yarn.lock` pins and CI tested), locking the **entire** dependency tree for consumers and preventing this class of bug for any dependency. `postpack` cleans the generated file up, and it's gitignored.

Verified end to end with a local `yarn pack`:
- tarball contains `npm-shrinkwrap.json` (lockfileVersion 3, 929 entries, all versioned; dev deps marked and excluded on consumer install)
- `npm install <tarball>` in a clean project resolves `quicktype-core@23.2.6` exactly
- `knock workflow list --json` from that install emits valid JSON only on stdout
- `yarn run check` and all 819 tests pass

One side effect to be aware of: npm 7+ keeps `yarn.lock` in sync when it writes a lockfile, so the `npm shrinkwrap` step rewrites `yarn.lock` in the working tree during pack/publish. In the release workflow the checkout is ephemeral, so it's harmless; if you run `yarn pack` locally, restore it with `git checkout yarn.lock`.

### Tasks

[KNO-14064](https://linear.app/knock/issue/KNO-14064/cli-loose-quicktype-core-dependency-causes-debug-text-to-corrupt-json)