### PR TITLE
v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g @knocklabs/cli
 $ knock COMMAND
 running command...
 $ knock (--version)
-@knocklabs/cli/1.2.0 darwin-arm64 node-v24.13.0
+@knocklabs/cli/1.2.1 darwin-arm64 node-v24.13.0
 $ knock --help [COMMAND]
 USAGE
   $ knock COMMAND
@@ -129,7 +129,7 @@ DESCRIPTION
   Use this command with caution.
 ```
 
-_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/archive.ts)_
+_See code: [src/commands/audience/archive.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/archive.ts)_
 
 ## `knock audience get AUDIENCEKEY`
 
@@ -150,7 +150,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/get.ts)_
+_See code: [src/commands/audience/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/get.ts)_
 
 ## `knock audience list`
 
@@ -174,7 +174,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/list.ts)_
+_See code: [src/commands/audience/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/list.ts)_
 
 ## `knock audience new`
 
@@ -199,7 +199,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/new.ts)_
+_See code: [src/commands/audience/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/new.ts)_
 
 ## `knock audience open AUDIENCEKEY`
 
@@ -215,7 +215,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/open.ts)_
+_See code: [src/commands/audience/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/open.ts)_
 
 ## `knock audience pull [AUDIENCEKEY]`
 
@@ -236,7 +236,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/pull.ts)_
+_See code: [src/commands/audience/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/pull.ts)_
 
 ## `knock audience push [AUDIENCEKEY]`
 
@@ -260,7 +260,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/push.ts)_
+_See code: [src/commands/audience/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/push.ts)_
 
 ## `knock audience validate [AUDIENCEKEY]`
 
@@ -280,7 +280,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/audience/validate.ts)_
+_See code: [src/commands/audience/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/audience/validate.ts)_
 
 ## `knock branch create [SLUG]`
 
@@ -300,7 +300,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/create.ts)_
+_See code: [src/commands/branch/create.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/create.ts)_
 
 ## `knock branch delete SLUG`
 
@@ -318,7 +318,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/delete.ts)_
+_See code: [src/commands/branch/delete.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/delete.ts)_
 
 ## `knock branch exit`
 
@@ -332,7 +332,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/exit.ts)_
+_See code: [src/commands/branch/exit.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/exit.ts)_
 
 ## `knock branch list`
 
@@ -352,7 +352,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/list.ts)_
+_See code: [src/commands/branch/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/list.ts)_
 
 ## `knock branch merge SLUG`
 
@@ -371,7 +371,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/merge.ts)_
+_See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/merge.ts)_
 
 ## `knock branch switch SLUG`
 
@@ -390,7 +390,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/branch/switch.ts)_
+_See code: [src/commands/branch/switch.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/switch.ts)_
 
 ## `knock channel list`
 
@@ -407,7 +407,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/channel/list.ts)_
+_See code: [src/commands/channel/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/channel/list.ts)_
 
 ## `knock commit`
 
@@ -416,11 +416,13 @@ Commit all changes in development environment, or only changes for a specific re
 ```
 USAGE
   $ knock commit [--service-token <value>] [--environment development] [--branch <value>] [-m <value>]
-    [--force] [--resource-type audience|partial|email_layout|workflow|message_type|guide|translation] [--resource-id
-    <value>]
+    [--force] [--allow-empty] [--resource-type audience|partial|email_layout|workflow|message_type|guide|translation]
+    [--resource-id <value>]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message.
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty). Requires --resource-type and --resource-id.
       --branch=<value>          The slug of the branch to use.
       --environment=<option>    [default: development] Committing changes applies to the development environment only,
                                 use `commit promote` to promote changes to a subsequent environment.
@@ -434,7 +436,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/index.ts)_
+_See code: [src/commands/commit/index.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/commit/index.ts)_
 
 ## `knock commit get ID`
 
@@ -451,7 +453,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/get.ts)_
+_See code: [src/commands/commit/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/commit/get.ts)_
 
 ## `knock commit list`
 
@@ -483,7 +485,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/list.ts)_
+_See code: [src/commands/commit/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/commit/list.ts)_
 
 ## `knock commit promote`
 
@@ -500,7 +502,7 @@ FLAGS
   --to=<value>             The destination environment to promote all changes from the preceding environment.
 ```
 
-_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/commit/promote.ts)_
+_See code: [src/commands/commit/promote.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/commit/promote.ts)_
 
 ## `knock environment list`
 
@@ -517,7 +519,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/environment/list.ts)_
+_See code: [src/commands/environment/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/environment/list.ts)_
 
 ## `knock guide activate GUIDEKEY`
 
@@ -548,7 +550,7 @@ DESCRIPTION
   or deactivated at a later time using the --from and --until flags.
 ```
 
-_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/activate.ts)_
+_See code: [src/commands/guide/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/activate.ts)_
 
 ## `knock guide generate-types`
 
@@ -571,7 +573,7 @@ DESCRIPTION
   Generate types for all guides in an environment and write them to a file.
 ```
 
-_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/generate-types.ts)_
+_See code: [src/commands/guide/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/generate-types.ts)_
 
 ## `knock guide get GUIDEKEY`
 
@@ -592,7 +594,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/get.ts)_
+_See code: [src/commands/guide/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/get.ts)_
 
 ## `knock guide list`
 
@@ -616,7 +618,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/list.ts)_
+_See code: [src/commands/guide/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/list.ts)_
 
 ## `knock guide new`
 
@@ -640,7 +642,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/new.ts)_
+_See code: [src/commands/guide/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/new.ts)_
 
 ## `knock guide open GUIDEKEY`
 
@@ -656,7 +658,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/open.ts)_
+_See code: [src/commands/guide/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/open.ts)_
 
 ## `knock guide pull [GUIDEKEY]`
 
@@ -677,7 +679,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/pull.ts)_
+_See code: [src/commands/guide/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/pull.ts)_
 
 ## `knock guide push [GUIDEKEY]`
 
@@ -686,11 +688,13 @@ Push one or more guides from a local file system to Knock.
 ```
 USAGE
   $ knock guide push [GUIDEKEY] [--service-token <value>] [--environment <value>] [--branch <value>]
-    [--guides-dir <value> --all] [-m <value> --commit] [--force]
+    [--guides-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message
       --all                     Whether to push all guides from the target directory.
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty).
       --branch=<value>          The slug of the branch to use.
       --commit                  Push and commit the guide(s) at the same time
       --environment=<value>     [default: development] The environment to push the guide to. Defaults to development.
@@ -701,7 +705,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/push.ts)_
+_See code: [src/commands/guide/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/push.ts)_
 
 ## `knock guide validate [GUIDEKEY]`
 
@@ -720,7 +724,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/guide/validate.ts)_
+_See code: [src/commands/guide/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/guide/validate.ts)_
 
 ## `knock help [COMMAND]`
 
@@ -740,7 +744,7 @@ DESCRIPTION
   Display help for knock.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.44/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.49/src/commands/help.ts)_
 
 ## `knock init`
 
@@ -760,7 +764,7 @@ DESCRIPTION
   resources directory.
 ```
 
-_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/init.ts)_
 
 ## `knock layout get EMAILLAYOUTKEY`
 
@@ -781,7 +785,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/get.ts)_
+_See code: [src/commands/layout/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/get.ts)_
 
 ## `knock layout list`
 
@@ -805,7 +809,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/list.ts)_
+_See code: [src/commands/layout/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/list.ts)_
 
 ## `knock layout new`
 
@@ -828,7 +832,7 @@ FLAGS
       --template=<value>       The template to use for the email layout. Should be `email-layouts/{key}`.
 ```
 
-_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/new.ts)_
+_See code: [src/commands/layout/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/new.ts)_
 
 ## `knock layout open LAYOUTKEY`
 
@@ -844,7 +848,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/open.ts)_
+_See code: [src/commands/layout/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/open.ts)_
 
 ## `knock layout pull [EMAILLAYOUTKEY]`
 
@@ -865,7 +869,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/pull.ts)_
+_See code: [src/commands/layout/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/pull.ts)_
 
 ## `knock layout push [EMAILLAYOUTKEY]`
 
@@ -874,11 +878,13 @@ Push one or more email layouts from a local file system to Knock.
 ```
 USAGE
   $ knock layout push [EMAILLAYOUTKEY] [--service-token <value>] [--environment development] [--branch <value>]
-    [--layouts-dir <value> --all] [-m <value> --commit] [--force]
+    [--layouts-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message
       --all                     Whether to push all layouts from the target directory.
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty).
       --branch=<value>          The slug of the branch to use.
       --commit                  Push and commit the layout(s) at the same time
       --environment=<option>    [default: development] Pushing an email layout is only allowed in the development
@@ -891,7 +897,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/push.ts)_
+_See code: [src/commands/layout/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/push.ts)_
 
 ## `knock layout validate [EMAILLAYOUTKEY]`
 
@@ -911,7 +917,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/layout/validate.ts)_
+_See code: [src/commands/layout/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/layout/validate.ts)_
 
 ## `knock login`
 
@@ -925,7 +931,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/login.ts)_
 
 ## `knock logout`
 
@@ -939,7 +945,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/logout.ts)_
 
 ## `knock message-type get MESSAGETYPEKEY`
 
@@ -960,7 +966,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/get.ts)_
+_See code: [src/commands/message-type/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/get.ts)_
 
 ## `knock message-type list`
 
@@ -984,7 +990,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/list.ts)_
+_See code: [src/commands/message-type/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/list.ts)_
 
 ## `knock message-type new`
 
@@ -1007,7 +1013,7 @@ FLAGS
       --template=<value>       The template to use for the message type. Should be `message-types/{key}`.
 ```
 
-_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/new.ts)_
+_See code: [src/commands/message-type/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/new.ts)_
 
 ## `knock message-type open MESSAGETYPEKEY`
 
@@ -1023,7 +1029,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/open.ts)_
+_See code: [src/commands/message-type/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/open.ts)_
 
 ## `knock message-type pull [MESSAGETYPEKEY]`
 
@@ -1044,7 +1050,7 @@ FLAGS
   --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/pull.ts)_
+_See code: [src/commands/message-type/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/pull.ts)_
 
 ## `knock message-type push [MESSAGETYPEKEY]`
 
@@ -1053,11 +1059,13 @@ Push one or more message types from a local file system to Knock.
 ```
 USAGE
   $ knock message-type push [MESSAGETYPEKEY] [--service-token <value>] [--environment development] [--branch <value>]
-    [--message-types-dir <value> --all] [-m <value> --commit] [--force]
+    [--message-types-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>     Use the given value as the commit message
       --all                        Whether to push all message types from the target directory.
+      --allow-empty                Create an empty commit for an already-published resource (analogous to git commit
+                                   --allow-empty).
       --branch=<value>             The slug of the branch to use.
       --commit                     Push and commit the message type(s) at the same time
       --environment=<option>       [default: development] Pushing a message type is only allowed in the development
@@ -1070,7 +1078,7 @@ FLAGS
       --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/push.ts)_
+_See code: [src/commands/message-type/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/push.ts)_
 
 ## `knock message-type validate [MESSAGETYPEKEY]`
 
@@ -1091,7 +1099,7 @@ FLAGS
   --service-token=<value>      The service token to authenticate with.
 ```
 
-_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/message-type/validate.ts)_
+_See code: [src/commands/message-type/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/message-type/validate.ts)_
 
 ## `knock partial get PARTIALKEY`
 
@@ -1112,7 +1120,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/get.ts)_
+_See code: [src/commands/partial/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/get.ts)_
 
 ## `knock partial list`
 
@@ -1136,7 +1144,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/list.ts)_
+_See code: [src/commands/partial/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/list.ts)_
 
 ## `knock partial new`
 
@@ -1162,7 +1170,7 @@ FLAGS
                                with --type.
 ```
 
-_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/new.ts)_
+_See code: [src/commands/partial/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/new.ts)_
 
 ## `knock partial open PARTIALKEY`
 
@@ -1178,7 +1186,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/open.ts)_
+_See code: [src/commands/partial/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/open.ts)_
 
 ## `knock partial pull [PARTIALKEY]`
 
@@ -1199,7 +1207,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/pull.ts)_
+_See code: [src/commands/partial/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/pull.ts)_
 
 ## `knock partial push [PARTIALKEY]`
 
@@ -1208,11 +1216,13 @@ Push one or more partials from a local file system to Knock.
 ```
 USAGE
   $ knock partial push [PARTIALKEY] [--service-token <value>] [--environment development] [--branch <value>]
-    [--partials-dir <value> --all] [-m <value> --commit] [--force]
+    [--partials-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message
       --all                     Whether to push all partials from the target directory.
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty).
       --branch=<value>          The slug of the branch to use.
       --commit                  Push and commit the partial(s) at the same time
       --environment=<option>    [default: development] Pushing a partial is only allowed in the development environment
@@ -1224,7 +1234,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/push.ts)_
+_See code: [src/commands/partial/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/push.ts)_
 
 ## `knock partial validate [PARTIALKEY]`
 
@@ -1244,7 +1254,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/partial/validate.ts)_
+_See code: [src/commands/partial/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/partial/validate.ts)_
 
 ## `knock pull`
 
@@ -1264,7 +1274,7 @@ FLAGS
   --service-token=<value>     The service token to authenticate with.
 ```
 
-_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/pull.ts)_
+_See code: [src/commands/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/pull.ts)_
 
 ## `knock push`
 
@@ -1273,10 +1283,12 @@ Push all resources from a local file system to Knock.
 ```
 USAGE
   $ knock push [--service-token <value>] [--environment development] [--branch <value>] [--knock-dir
-    <value>] [-m <value> --commit] [--force]
+    <value>] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty).
       --branch=<value>          The slug of the branch to use.
       --commit                  Push and commit the resource(s) at the same time
       --environment=<option>    [default: development] Pushing resources is only allowed in the development environment
@@ -1288,7 +1300,7 @@ FLAGS
       --service-token=<value>   The service token to authenticate with.
 ```
 
-_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/push.ts)_
 
 ## `knock schema pull [ITEMTYPE]`
 
@@ -1309,7 +1321,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/schema/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/schema/pull.ts)_
+_See code: [src/commands/schema/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/schema/pull.ts)_
 
 ## `knock schema push [ITEMTYPE]`
 
@@ -1329,7 +1341,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/schema/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/schema/push.ts)_
+_See code: [src/commands/schema/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/schema/push.ts)_
 
 ## `knock source get SOURCEKEY`
 
@@ -1347,7 +1359,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/source/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/source/get.ts)_
+_See code: [src/commands/source/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/source/get.ts)_
 
 ## `knock source list`
 
@@ -1369,7 +1381,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/source/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/source/list.ts)_
+_See code: [src/commands/source/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/source/list.ts)_
 
 ## `knock translation get TRANSLATIONREF`
 
@@ -1397,7 +1409,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/get.ts)_
+_See code: [src/commands/translation/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/translation/get.ts)_
 
 ## `knock translation list`
 
@@ -1421,7 +1433,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/list.ts)_
+_See code: [src/commands/translation/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/translation/list.ts)_
 
 ## `knock translation pull [TRANSLATIONREF]`
 
@@ -1449,7 +1461,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to pull all translations into.
 ```
 
-_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/pull.ts)_
+_See code: [src/commands/translation/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/translation/pull.ts)_
 
 ## `knock translation push [TRANSLATIONREF]`
 
@@ -1458,7 +1470,7 @@ Push one or more translations from a local file system to Knock.
 ```
 USAGE
   $ knock translation push [TRANSLATIONREF] [--service-token <value>] [--environment development] [--branch <value>]
-    [--translations-dir <value> --all] [-m <value> --commit] [--force]
+    [--translations-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 ARGUMENTS
   TRANSLATIONREF  Translation ref is a identifier string that refers to a unique translation.
@@ -1468,6 +1480,8 @@ ARGUMENTS
 FLAGS
   -m, --commit-message=<value>    Use the given value as the commit message
       --all                       Whether to push all translations from the target directory.
+      --allow-empty               Create an empty commit for an already-published resource (analogous to git commit
+                                  --allow-empty).
       --branch=<value>            The slug of the branch to use.
       --commit                    Push and commit the translation(s) at the same time
       --environment=<option>      [default: development] Pushing a translation is only allowed in the development
@@ -1480,7 +1494,7 @@ FLAGS
       --translations-dir=<value>  The target directory path to find all translations to push.
 ```
 
-_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/push.ts)_
+_See code: [src/commands/translation/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/translation/push.ts)_
 
 ## `knock translation validate [TRANSLATIONREF]`
 
@@ -1506,7 +1520,7 @@ FLAGS
   --translations-dir=<value>  The target directory path to find all translations to validate.
 ```
 
-_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/translation/validate.ts)_
+_See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/translation/validate.ts)_
 
 ## `knock whoami`
 
@@ -1523,7 +1537,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/whoami.ts)_
 
 ## `knock workflow activate WORKFLOWKEY`
 
@@ -1552,7 +1566,7 @@ DESCRIPTION
   with `false` in order to deactivate it.
 ```
 
-_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/activate.ts)_
+_See code: [src/commands/workflow/activate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/activate.ts)_
 
 ## `knock workflow generate-types`
 
@@ -1575,7 +1589,7 @@ DESCRIPTION
   Generate types for all workflows in an environment and write them to a file.
 ```
 
-_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/generate-types.ts)_
+_See code: [src/commands/workflow/generate-types.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/generate-types.ts)_
 
 ## `knock workflow get WORKFLOWKEY`
 
@@ -1596,7 +1610,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/get.ts)_
+_See code: [src/commands/workflow/get.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/get.ts)_
 
 ## `knock workflow list`
 
@@ -1620,7 +1634,7 @@ GLOBAL FLAGS
   --json  Format output as json.
 ```
 
-_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/list.ts)_
+_See code: [src/commands/workflow/list.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/list.ts)_
 
 ## `knock workflow new`
 
@@ -1645,7 +1659,7 @@ FLAGS
       --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/new.ts)_
+_See code: [src/commands/workflow/new.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/new.ts)_
 
 ## `knock workflow open WORKFLOWKEY`
 
@@ -1661,7 +1675,7 @@ FLAGS
   --service-token=<value>  The service token to authenticate with.
 ```
 
-_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/open.ts)_
+_See code: [src/commands/workflow/open.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/open.ts)_
 
 ## `knock workflow pull [WORKFLOWKEY]`
 
@@ -1682,7 +1696,7 @@ FLAGS
   --workflows-dir=<value>     The target directory path to pull all workflows into.
 ```
 
-_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/pull.ts)_
+_See code: [src/commands/workflow/pull.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/pull.ts)_
 
 ## `knock workflow push [WORKFLOWKEY]`
 
@@ -1691,11 +1705,13 @@ Push one or more workflows from a local file system to Knock.
 ```
 USAGE
   $ knock workflow push [WORKFLOWKEY] [--service-token <value>] [--environment <value>] [--branch <value>]
-    [--workflows-dir <value> --all] [-m <value> --commit] [--force]
+    [--workflows-dir <value> --all] [-m <value> --commit] [--allow-empty ] [--force]
 
 FLAGS
   -m, --commit-message=<value>  Use the given value as the commit message
       --all                     Whether to push all workflows from the target directory.
+      --allow-empty             Create an empty commit for an already-published resource (analogous to git commit
+                                --allow-empty).
       --branch=<value>          The slug of the branch to use.
       --commit                  Push and commit the workflow(s) at the same time
       --environment=<value>     [default: development] The environment to push the workflow to. Defaults to development.
@@ -1706,7 +1722,7 @@ FLAGS
       --workflows-dir=<value>   The target directory path to find all workflows to push.
 ```
 
-_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/push.ts)_
+_See code: [src/commands/workflow/push.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/push.ts)_
 
 ## `knock workflow run WORKFLOWKEY`
 
@@ -1731,7 +1747,7 @@ FLAGS
   --tenant=<value>         A tenant id for the workflow run.
 ```
 
-_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/run.ts)_
+_See code: [src/commands/workflow/run.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/run.ts)_
 
 ## `knock workflow validate [WORKFLOWKEY]`
 
@@ -1750,5 +1766,5 @@ FLAGS
   --workflows-dir=<value>  The target directory path to find all workflows to validate.
 ```
 
-_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.0/src/commands/workflow/validate.ts)_
+_See code: [src/commands/workflow/validate.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/workflow/validate.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Knock CLI",
   "author": "@knocklabs",
   "bin": {


### PR DESCRIPTION
## Summary
Release version bump to v1.2.1.

Includes:
- Add `--allow-empty` support for empty commits (#833)

## Test plan
- [ ] Merge once approved
- [ ] Run `/release cut knock-cli -v 1.2.1` in Slack


Made with [Cursor](https://cursor.com)