### PR TITLE
feat: add branch rebase command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g @knocklabs/cli
 $ knock COMMAND
 running command...
 $ knock (--version)
-@knocklabs/cli/1.2.1 darwin-arm64 node-v24.13.0
+@knocklabs/cli/1.2.1 linux-x64 node-v22.14.0
 $ knock --help [COMMAND]
 USAGE
   $ knock COMMAND
@@ -40,6 +40,7 @@ USAGE
 * [`knock branch exit`](#knock-branch-exit)
 * [`knock branch list`](#knock-branch-list)
 * [`knock branch merge SLUG`](#knock-branch-merge-slug)
+* [`knock branch rebase SLUG`](#knock-branch-rebase-slug)
 * [`knock branch switch SLUG`](#knock-branch-switch-slug)
 * [`knock channel list`](#knock-channel-list)
 * [`knock commit`](#knock-commit)
@@ -372,6 +373,27 @@ FLAGS
 ```
 
 _See code: [src/commands/branch/merge.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/merge.ts)_
+
+## `knock branch rebase SLUG`
+
+Rebases a branch onto the development environment, bringing in changes from main while preserving branch commits.
+
+```
+USAGE
+  $ knock branch rebase SLUG [--json] [--service-token <value>] [--force]
+
+ARGUMENTS
+  SLUG  The slug of the branch to rebase
+
+FLAGS
+  --force                  Remove the confirmation prompt.
+  --service-token=<value>  The service token to authenticate with.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+```
+
+_See code: [src/commands/branch/rebase.ts](https://github.com/knocklabs/knock-cli/blob/v1.2.1/src/commands/branch/rebase.ts)_
 
 ## `knock branch switch SLUG`
 
@@ -744,7 +766,7 @@ DESCRIPTION
   Display help for knock.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.49/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.53/src/commands/help.ts)_
 
 ## `knock init`
 

--- a/src/commands/branch/rebase.ts
+++ b/src/commands/branch/rebase.ts
@@ -1,0 +1,52 @@
+import type { Branch } from "@knocklabs/mgmt/resources/branches";
+import { Flags } from "@oclif/core";
+
+import BaseCommand from "@/lib/base-command";
+import { CustomArgs } from "@/lib/helpers/arg";
+import { KnockEnv } from "@/lib/helpers/const";
+import { withSpinner } from "@/lib/helpers/request";
+import { promptToConfirm } from "@/lib/helpers/ux";
+
+export default class BranchRebase extends BaseCommand<typeof BranchRebase> {
+  static summary =
+    "Rebases a branch onto the development environment, bringing in changes from main while preserving branch commits.";
+
+  static enableJsonFlag = true;
+
+  static args = {
+    slug: CustomArgs.slug({
+      required: true,
+      description: "The slug of the branch to rebase",
+    }),
+  };
+
+  static flags = {
+    force: Flags.boolean({
+      summary: "Remove the confirmation prompt.",
+    }),
+  };
+
+  async run(): Promise<Branch | void> {
+    const { args, flags } = this.props;
+
+    const prompt = `Rebase branch \`${args.slug}\` with main? This updates your branch with the latest changes from main while preserving your branch's commits.`;
+    const input = flags.force || (await promptToConfirm(prompt));
+    if (!input) return;
+
+    const resp = await withSpinner<Branch>(
+      () => this.apiV1.rebaseBranch(args.slug, KnockEnv.Development),
+      { action: "‣ Rebasing branch" },
+    );
+
+    const data = resp.data;
+
+    if (flags.json) return data;
+
+    this.render(data);
+  }
+
+  async render(data: Branch): Promise<void> {
+    this.log(`‣ Successfully rebased branch \`${data.slug}\``);
+    this.log(`  Updated at: ${data.updated_at}`);
+  }
+}

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -660,6 +660,17 @@ export default class ApiV1 {
     return environments;
   }
 
+  // By resources: Branches
+
+  async rebaseBranch(
+    branchSlug: string,
+    environment: string,
+  ): Promise<AxiosResponse<Branch>> {
+    const params = { environment };
+
+    return this.put(`/branches/${branchSlug}/rebase`, {}, { params });
+  }
+
   // By methods:
 
   async get(

--- a/test/commands/branch/rebase.test.ts
+++ b/test/commands/branch/rebase.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "@oclif/test";
+import enquirer from "enquirer";
+import * as sinon from "sinon";
+
+import { factory } from "@/../test/support";
+import KnockApiV1 from "@/lib/api-v1";
+import { KnockEnv } from "@/lib/helpers/const";
+
+const TEST_SLUG = "test-branch";
+
+describe("commands/branch/rebase", () => {
+  const branchData = factory.branch({ slug: TEST_SLUG });
+
+  describe("given confirmation accepted", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(factory.resp({ data: branchData })),
+      )
+      .stub(enquirer.prototype, "prompt", (stub) =>
+        stub.resolves({ input: "y" }),
+      )
+      .stdout()
+      .command(["branch rebase", TEST_SLUG])
+      .it(
+        "calls apiV1.rebaseBranch with correct parameters and shows success message",
+        (ctx) => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.rebaseBranch as any,
+            TEST_SLUG,
+            KnockEnv.Development,
+          );
+          expect(ctx.stdout).to.contain(
+            `‣ Successfully rebased branch \`${TEST_SLUG}\``,
+          );
+          expect(ctx.stdout).to.contain(`Updated at: ${branchData.updated_at}`);
+        },
+      );
+  });
+
+  describe("given --force flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(factory.resp({ data: branchData })),
+      )
+      .stdout()
+      .command(["branch rebase", TEST_SLUG, "--force"])
+      .it(
+        "calls apiV1.rebaseBranch without prompting for confirmation",
+        (ctx) => {
+          sinon.assert.calledWith(
+            KnockApiV1.prototype.rebaseBranch as any,
+            TEST_SLUG,
+            KnockEnv.Development,
+          );
+          expect(ctx.stdout).to.contain(
+            `‣ Successfully rebased branch \`${TEST_SLUG}\``,
+          );
+        },
+      );
+  });
+
+  describe("given confirmation declined", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(factory.resp({ data: branchData })),
+      )
+      .stub(enquirer.prototype, "prompt", (stub) =>
+        stub.resolves({ input: false }),
+      )
+      .stdout()
+      .command(["branch rebase", TEST_SLUG])
+      .it(
+        "does not call apiV1.rebaseBranch and shows no success message",
+        (ctx) => {
+          sinon.assert.notCalled(KnockApiV1.prototype.rebaseBranch as any);
+          expect(ctx.stdout).to.not.contain("Successfully rebased branch");
+        },
+      );
+  });
+
+  describe("given an argument containing mixed casing and whitespace", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(factory.resp({ data: branchData })),
+      )
+      .command(["branch rebase", " Mixed Case   With Whitespace ", "--force"])
+      .it("slugifies input before calling apiV1.rebaseBranch", () => {
+        sinon.assert.calledWith(
+          KnockApiV1.prototype.rebaseBranch as any,
+          "mixed-case-with-whitespace",
+          KnockEnv.Development,
+        );
+      });
+  });
+
+  describe("given an invalid branch slug", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .command(["branch rebase", " "])
+      .catch(/Invalid slug provided/)
+      .it("throws an error");
+  });
+
+  describe("given --json flag", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(factory.resp({ data: branchData })),
+      )
+      .stdout()
+      .command(["branch rebase", TEST_SLUG, "--force", "--json"])
+      .it("returns raw JSON response", (ctx) => {
+        const output = JSON.parse(ctx.stdout);
+        expect(output).to.have.property("slug", TEST_SLUG);
+        expect(output).to.have.property("created_at", branchData.created_at);
+        expect(output).to.have.property("updated_at", branchData.updated_at);
+        expect(output).to.have.property(
+          "last_commit_at",
+          branchData.last_commit_at,
+        );
+        expect(output).to.have.property("deleted_at", branchData.deleted_at);
+      });
+  });
+
+  describe("given no service token", () => {
+    test
+      .command(["branch rebase", TEST_SLUG])
+      .exit(2)
+      .it("exits with status 2");
+  });
+
+  describe("given API error", () => {
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(
+          factory.resp({
+            status: 404,
+            data: {
+              code: "branch_not_found",
+              message: "The branch you specified was not found in this project",
+              status: 404,
+              type: "invalid_request_error",
+            },
+          }),
+        ),
+      )
+      .stub(enquirer.prototype, "prompt", (stub) =>
+        stub.resolves({ input: "y" }),
+      )
+      .command(["branch rebase", "nonexistent-branch"])
+      .catch(/The branch you specified was not found in this project/)
+      .it("throws error when API returns branch_not_found");
+
+    test
+      .env({ KNOCK_SERVICE_TOKEN: "valid-token" })
+      .stub(KnockApiV1.prototype, "rebaseBranch", (stub) =>
+        stub.resolves(
+          factory.resp({
+            status: 422,
+            data: {
+              code: "branch_rebase_blocked",
+              message:
+                'Commit or discard unpublished changes on shared resources before rebasing. Blocking resources: workflow "Shared"',
+              status: 422,
+              type: "invalid_request_error",
+            },
+          }),
+        ),
+      )
+      .stub(enquirer.prototype, "prompt", (stub) =>
+        stub.resolves({ input: "y" }),
+      )
+      .command(["branch rebase", TEST_SLUG])
+      .catch(
+        /Commit or discard unpublished changes on shared resources before rebasing/,
+      )
+      .it("throws error when API returns branch_rebase_blocked");
+  });
+});

--- a/test/lib/api-v1.test.ts
+++ b/test/lib/api-v1.test.ts
@@ -811,4 +811,28 @@ describe("lib/api-v1", () => {
       stub.restore();
     });
   });
+
+  describe("rebaseBranch", () => {
+    it("makes a PUT request to /v1/branches/:branchSlug/rebase with supported params", async () => {
+      const apiV1 = new KnockApiV1(factory.sessionContext(), dummyConfig);
+
+      const stub = sinon.stub(apiV1.client, "put").returns(
+        Promise.resolve({
+          status: 200,
+          data: factory.branch(),
+        }),
+      );
+
+      await apiV1.rebaseBranch("test-branch", "development");
+
+      sinon.assert.calledWith(
+        stub,
+        "/v1/branches/test-branch/rebase",
+        {},
+        { params: { environment: "development" } },
+      );
+
+      stub.restore();
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `knock branch rebase <slug>` to the CLI, backed by the new Management API `PUT /v1/branches/:slug/rebase` endpoint.

The command follows existing branch command conventions:
- Required slug argument with slugification
- Confirmation prompt before rebasing, with `--force` to skip
- `--json` flag returning the updated `Branch` object
- Standard API error handling, including `branch_rebase_blocked` messages

## Implementation

- Added `rebaseBranch()` to the Axios-based `ApiV1` client (no `@knocklabs/mgmt` SDK bump required yet)
- Added `src/commands/branch/rebase.ts`
- Added API client and command tests
- Regenerated README via oclif

## Usage

```bash
knock branch rebase my-feature-branch
knock branch rebase my-feature-branch --force
knock branch rebase my-feature-branch --json
```

## Test plan

- [x] `yarn run check` (lint, format, type check)
- [x] `yarn test test/lib/api-v1.test.ts test/commands/branch/rebase.test.ts`
- [x] `yarn test test/commands/branch/*.test.ts`
- [x] `./bin/dev.js branch rebase --help`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cd26e6b-ffdd-463c-bf57-f1c9e0089ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cd26e6b-ffdd-463c-bf57-f1c9e0089ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

