### PR TITLE
feat(KNO-14443): surface user_name and user_email in whoami

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,7 +1546,7 @@ _See code: [src/commands/translation/validate.ts](https://github.com/knocklabs/k
 
 ## `knock whoami`
 
-Verify the provided service token.
+Verify authentication and show the current account and user.
 
 ```
 USAGE

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -4,13 +4,21 @@ import BaseCommand from "@/lib/base-command";
 import { withSpinnerV2 } from "@/lib/helpers/request";
 import { indentString } from "@/lib/helpers/string";
 
+// user_name / user_email are returned by the API for OAuth contexts; the
+// published @knocklabs/mgmt types may lag behind until the next SDK release.
+type WhoamiResponse = AuthVerifyResponse & {
+  user_name?: string | null;
+  user_email?: string | null;
+};
+
 export default class Whoami extends BaseCommand<typeof Whoami> {
-  static summary = "Verify the provided service token.";
+  static summary =
+    "Verify authentication and show the current account and user.";
 
   static enableJsonFlag = true;
 
-  public async run(): Promise<AuthVerifyResponse | void> {
-    const resp = await withSpinnerV2<AuthVerifyResponse>(() =>
+  public async run(): Promise<WhoamiResponse | void> {
+    const resp = await withSpinnerV2<WhoamiResponse>(() =>
       this.apiV1.mgmtClient.auth.verify(),
     );
 
@@ -24,7 +32,12 @@ export default class Whoami extends BaseCommand<typeof Whoami> {
           `Account name: ${resp.account_name}`,
           `Service token name: ${resp.service_token_name}`,
         ]
-      : [`Account name: ${resp.account_name}`, `User ID: ${resp.user_id}`];
+      : [
+          `Account name: ${resp.account_name}`,
+          `User ID: ${resp.user_id}`,
+          ...(resp.user_name ? [`User name: ${resp.user_name}`] : []),
+          ...(resp.user_email ? [`User email: ${resp.user_email}`] : []),
+        ];
 
     this.log(indentString(info.join("\n"), 4));
   }

--- a/src/lib/api-v1.ts
+++ b/src/lib/api-v1.ts
@@ -705,6 +705,8 @@ export type WhoamiResp = {
   account_slug: string;
   service_token_name: string | null;
   user_id: string | null;
+  user_name?: string | null;
+  user_email?: string | null;
   account_features?: AccountFeatures;
 };
 

--- a/test/commands/whoami.test.ts
+++ b/test/commands/whoami.test.ts
@@ -18,12 +18,17 @@ describe("commands/whoami", () => {
     user_id: null,
   };
 
-  const userData: AuthVerifyResponse = {
+  const userData: AuthVerifyResponse & {
+    user_name: string;
+    user_email: string;
+  } = {
     type: "oauth_context",
     account_name: "Collab.io",
     account_slug: "collab-io",
     service_token_name: null,
     user_id: "123",
+    user_name: "Jane Doe",
+    user_email: "jane@collab.io",
   };
 
   describe("given a valid service token via flag", () => {
@@ -77,6 +82,8 @@ describe("commands/whoami", () => {
       .it("runs the command to make a whoami request", (ctx) => {
         expect(ctx.stdout).to.contain("Account name: Collab.io");
         expect(ctx.stdout).to.contain("User ID: 123");
+        expect(ctx.stdout).to.contain("User name: Jane Doe");
+        expect(ctx.stdout).to.contain("User email: jane@collab.io");
       });
 
     test
@@ -111,6 +118,8 @@ describe("commands/whoami", () => {
 
           expect(ctx.stdout).to.contain("Account name: Collab.io");
           expect(ctx.stdout).to.contain("User ID: 123");
+          expect(ctx.stdout).to.contain("User name: Jane Doe");
+          expect(ctx.stdout).to.contain("User email: jane@collab.io");
         },
       );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `knock whoami` to document and display the new `user_name` and `user_email` fields returned by the Management API for OAuth sessions (added in control#10522 / KNO-14435).

Fixes [KNO-14443](https://linear.app/knock/issue/KNO-14443/cli-update-docs-around-whoami).

## Changes

- Show `User name` and `User email` in human-readable whoami output when present
- Clarify the command summary (no longer service-token-only)
- Add optional `user_name` / `user_email` to `WhoamiResp`
- Update tests and regenerate README command docs

## Test plan

- [x] `yarn test` (full suite)
- [x] `yarn run check` (lint, format, types)
- [ ] Manually verify `knock whoami` against an OAuth session shows name/email once API fields are live
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14443](https://linear.app/knock/issue/KNO-14443/cli-update-docs-around-whoami)

<div><a href="https://cursor.com/agents/bc-31113019-2262-4e50-9134-f87a1911d13b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31113019-2262-4e50-9134-f87a1911d13b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

