### PR TITLE
fix: publish npm package with trusted publishing

### DIFF
--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -76,14 +76,17 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [publish-brew]
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
           scope: "@knocklabs"
       - run: yarn
-      - run: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Update npm for trusted publishing
+        run: npm install --global npm@latest
+      - run: npm publish --access public

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -6,7 +6,7 @@ jobs:
   validate-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Validate version match
         run: |
@@ -29,8 +29,8 @@ jobs:
     needs: [validate-release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: yarn
@@ -88,5 +88,5 @@ jobs:
           scope: "@knocklabs"
       - run: yarn
       - name: Update npm for trusted publishing
-        run: npm install --global npm@latest
+        run: npm install --global npm@11
       - run: npm publish --access public


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Migrate the npm release job from a long-lived `NPM_TOKEN` to npm trusted publishing via GitHub Actions OIDC.

- grant the publish job `id-token: write` and read-only repository contents
- update all release jobs to current checkout and setup-node actions
- install the latest npm 11 release before publishing so the CLI supports trusted publishing while retaining the package's `npm shrinkwrap` prepack lifecycle (removed in npm 12)
- publish the public scoped package with npm instead of Yarn and remove `NPM_TOKEN`

The `@knocklabs/cli` package must have this repository and `.github/workflows/on-release-created.yml` registered as a trusted publisher in npm before the next release.

### Validation
- `yarn run check`
- `actionlint .github/workflows/on-release-created.yml`
- `npx --yes npm@11 publish --dry-run --access public`

### Tasks
[KNO-14497](https://linear.app/knock/issue/KNO-14497/cli-not-publishing-to-npm-stuck-on-112-expiredbroken-npm-auth-token)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14497](https://linear.app/knock/issue/KNO-14497/cli-not-publishing-to-npm-stuck-on-112-expiredbroken-npm-auth-token)

<div><a href="https://cursor.com/agents/bc-17799787-c330-400d-b081-084fb7485754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17799787-c330-400d-b081-084fb7485754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

